### PR TITLE
Remove SAR references in favor of Access Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,5 @@ docker-stack.yml
 
 envfiles/
 
-# SAR package local upload destination, generated at runtime
+# Access request package local upload destination, generated at runtime
 fides_uploads

--- a/docs/fidesops/docs/guides/storage.md
+++ b/docs/fidesops/docs/guides/storage.md
@@ -12,9 +12,9 @@ Take me directly to [api docs](http://0.0.0.0:8080/docs#/Storage) (you'll need t
 
 ## Overview
 
-SAR requests will produce a data package upon completion. This data will need to be uploaded to a storage destination (e.g. an S3 bucket). 
+Access requests requests will produce a data package upon completion. This data will need to be uploaded to a storage destination (e.g. an S3 bucket). 
 
-Fidesops never stores privacy request results locally, so you’ll need to configure at least one storage destination if you wish to process SAR requests.
+Fidesops never stores privacy request results locally, so you’ll need to configure at least one storage destination if you wish to process Access requests.
 
 Storage destinations are configured on Rules. 
 
@@ -26,9 +26,9 @@ Each unique destination is configured using a "StorageConfig", which you can cre
 
 To configure a StorageConfig, you'll first need to choose a storage destination type. Fidesops currently supports the following types:
 
-- **S3** - S3 upload is straightforward, in which files are uploaded in an S3 bucket of your choosing upon completion of SAR requests. Use S3 if you simply need a place to store those files.
+- **S3** - S3 upload is straightforward, in which files are uploaded in an S3 bucket of your choosing upon completion of Access requests. Use S3 if you simply need a place to store those files.
 - **OneTrust** - A OneTrust storage destination should be configured if you wish to use Fidesops to process requests from an existing OneTrust integration. Read more about how our OneTrust integration works [here](./onetrust.md)
-- **local** - This saves upload packages locally, generating a `fides_uploads` directory at the root of this project. This destination type should be used only for testing purposes, never to process real-world SAR requests.
+- **local** - This saves upload packages locally, generating a `fides_uploads` directory at the root of this project. This destination type should be used only for testing purposes, never to process real-world Access requests.
 
 ## Configuration
 
@@ -71,7 +71,7 @@ Additional params needed for S3:
 
 Additional params needed for OneTrust:
 
-- `service_name`: Name of your service / company. This informs OneTrust from where the data obtained from a given SAR request originated. 
+- `service_name`: Name of your service / company. This informs OneTrust from where the data obtained from a given Access request originated. 
 - `onetrust_polling_hr`: Hour, in UTC timezone, at which to poll OneTrust for new requests. Accepts an int from 0-23, where 0 is midnight. E.g. `7` is 7am UTC.
 - `onetrust_polling_day_of_week`: Day on which to poll OneTrust for new requests. Accepts an int from 0-6 where 0 is Sunday. E.g. `1` is Monday.
 

--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -1218,7 +1218,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n  {\n    \"name\": \"My SAR Upload Bucket\",\n    \"key\": \"{{S3_BUCKET_KEY}}\",\n    \"type\": \"s3\",\n    \"format\": \"csv\",\n    \"details\": {\n      \"bucket\": \"test_bucket\",\n      \"object_name\": \"test_name\"\n    }\n  }\n]",
+							"raw": "[\n  {\n    \"name\": \"My Access Request Upload Bucket\",\n    \"key\": \"{{S3_BUCKET_KEY}}\",\n    \"type\": \"s3\",\n    \"format\": \"csv\",\n    \"details\": {\n      \"bucket\": \"test_bucket\",\n      \"object_name\": \"test_name\"\n    }\n  }\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1501,7 +1501,7 @@
 		},
 		{
 			"key": "S3_BUCKET_KEY",
-			"value": "my-sar-upload-bucket"
+			"value": "my-access-request-upload-bucket"
 		},
 		{
 			"key": "separate_policy_key",

--- a/src/fidesops/api/v1/endpoints/storage_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/storage_endpoints.py
@@ -69,7 +69,7 @@ def upload_data(
     storage_key: str = Body(...),
 ) -> DataUpload:
     """
-    Uploads data from a SAR to specified storage destination.
+    Uploads data from an access request to specified storage destination.
     Returns location of data.
     """
     logger.info(f"Finding privacy request with id '{request_id}'")

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -178,12 +178,12 @@ class PrivacyRequestRunner:
         Dispatch a privacy_request into the execution layer by:
             1. Generate a graph from all the currently configured datasets
             2. Take the provided identity data
-            3. Start the SAR execution
-            4. When finished, upload the results to the configured storage destination
+            3. Start the access request / erasure request execution
+            4. When finished, upload the results to the configured storage destination if applicable
         """
         from fidesops.task.graph_task import (
             filter_data_categories,
-            run_sar,
+            run_access_request,
             run_erasure,
         )
 
@@ -205,7 +205,7 @@ class PrivacyRequestRunner:
             )
 
         try:
-            access_result = run_sar(
+            access_result = run_access_request(
                 privacy_request=self.privacy_request,
                 policy=policy,
                 graph=dataset_graph,
@@ -214,7 +214,7 @@ class PrivacyRequestRunner:
             )
             if not access_result:
                 logging.info(
-                    f"No results returned for sar request {self.privacy_request.id}"
+                    f"No results returned for access request {self.privacy_request.id}"
                 )
 
             # Once the access request is complete, process the data uploads
@@ -233,7 +233,7 @@ class PrivacyRequestRunner:
                     access_result, target_categories, dataset_graph
                 )
                 logging.info(
-                    f"Starting sar upload for rule {rule.key} for privacy request {self.privacy_request.id}"
+                    f"Starting access request upload for rule {rule.key} for privacy request {self.privacy_request.id}"
                 )
                 try:
                     upload(
@@ -256,7 +256,7 @@ class PrivacyRequestRunner:
                     graph=dataset_graph,
                     connection_configs=connection_configs,
                     identity=identity_data,
-                    sar_data=access_result,
+                    access_request_data=access_result,
                 )
 
         except BaseException as exc:

--- a/src/fidesops/tasks/storage.py
+++ b/src/fidesops/tasks/storage.py
@@ -54,7 +54,7 @@ def upload_to_s3(
     file_key: str,
     resp_format: str,
 ) -> str:
-    """Uploads arbitrary data to s3 returned from a SAR request"""
+    """Uploads arbitrary data to s3 returned from an access request"""
     logger.info(f"Starting S3 Upload of {file_key}")
     try:
         my_session = get_s3_session(
@@ -85,7 +85,7 @@ def upload_to_onetrust(
     storage_secrets: Dict[StorageSecrets, Any],
     ref_id: str,
 ) -> str:
-    """Uploads arbitrary data to onetrust returned from a SAR request"""
+    """Uploads arbitrary data to onetrust returned from an access request"""
     logger.info(f"Starting OneTrust Upload for ref_id {ref_id}")
 
     onetrust_hostname = storage_secrets[StorageSecrets.ONETRUST_HOSTNAME.value]

--- a/tests/api/v1/endpoints/test_policy_endpoints.py
+++ b/tests/api/v1/endpoints/test_policy_endpoints.py
@@ -64,7 +64,7 @@ class TestGetPolicies:
         assert len(policy_data["rules"]) == 1
 
         rule = policy_data["rules"][0]
-        assert rule["key"] == "sar-rule"
+        assert rule["key"] == "access-request-rule"
         assert rule["action_type"] == "access"
         assert rule["storage_destination"]["type"] == "s3"
 
@@ -116,7 +116,7 @@ class TestGetPolicyDetail:
         assert len(data["rules"]) == 1
 
         rule = data["rules"][0]
-        assert rule["key"] == "sar-rule"
+        assert rule["key"] == "access-request-rule"
         assert rule["action_type"] == "access"
         assert rule["storage_destination"]["type"] == "s3"
 
@@ -148,7 +148,7 @@ class TestGetPolicyDetail:
         assert len(policy_data["rules"]) == 1
 
         rule = policy_data["rules"][0]
-        assert rule["key"] == "sar-rule"
+        assert rule["key"] == "access-request-rule"
         assert rule["action_type"] == "access"
         assert rule["storage_destination"]["type"] == "s3"
 
@@ -496,8 +496,8 @@ class TestCreateRules:
         another_policy = Policy.create(
             db=db,
             data={
-                "name": "Second SAR policy",
-                "key": "second-sar-policy",
+                "name": "Second Access Request policy",
+                "key": "second-access-request-policy",
                 "client_id": oauth_client.id,
             },
         )

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -56,10 +56,10 @@ class TestCreatePrivacyRequest:
         resp = api_client.post(url, json={}, headers=auth_header)
         assert resp.status_code == 403
 
-    @mock.patch("fidesops.task.graph_task.run_sar")
+    @mock.patch("fidesops.task.graph_task.run_access_request")
     def test_create_privacy_request(
         self,
-        run_sar_mock,
+        run_access_request_mock,
         url,
         db,
         api_client: TestClient,
@@ -80,9 +80,9 @@ class TestCreatePrivacyRequest:
         assert len(response_data) == 1
         pr = PrivacyRequest.get(db=db, id=response_data[0]["id"])
         pr.delete(db=db)
-        assert run_sar_mock.called
+        assert run_access_request_mock.called
 
-    @mock.patch("fidesops.task.graph_task.run_sar")
+    @mock.patch("fidesops.task.graph_task.run_access_request")
     def test_create_privacy_request_limit_exceeded(
         self,
         _,
@@ -137,10 +137,10 @@ class TestCreatePrivacyRequest:
         pr = PrivacyRequest.get(db=db, id=response_data[0]["id"])
         pr.delete(db=db)
 
-    @mock.patch("fidesops.task.graph_task.run_sar")
+    @mock.patch("fidesops.task.graph_task.run_access_request")
     def test_create_privacy_request_with_external_id(
         self,
-        run_sar_mock,
+        run_access_request_mock,
         url,
         db,
         api_client: TestClient,
@@ -167,12 +167,12 @@ class TestCreatePrivacyRequest:
         pr = PrivacyRequest.get(db=db, id=response_data[0]["id"])
         assert pr.external_id == external_id
         pr.delete(db=db)
-        assert run_sar_mock.called
+        assert run_access_request_mock.called
 
-    @mock.patch("fidesops.task.graph_task.run_sar")
+    @mock.patch("fidesops.task.graph_task.run_access_request")
     def test_create_privacy_request_caches_identity(
         self,
-        run_sar_mock,
+        run_access_request_mock,
         url,
         db,
         api_client: TestClient,
@@ -200,7 +200,7 @@ class TestCreatePrivacyRequest:
         )
         assert cache.get(key) == list(identity.values())[0]
         pr.delete(db=db)
-        assert run_sar_mock.called
+        assert run_access_request_mock.called
 
     def test_create_privacy_request_no_identities(
         self,
@@ -254,7 +254,7 @@ class TestCreatePrivacyRequest:
             assert results[key] is not None
             assert results[key] != {}
 
-        result_key_prefix = f"EN_{pr.id}__SAR__postgres_example_test_dataset:"
+        result_key_prefix = f"EN_{pr.id}__access_request__postgres_example_test_dataset:"
         customer_key = result_key_prefix + "customer"
         assert results[customer_key][0]["email"] == customer_email
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -257,22 +257,22 @@ def policy(
     oauth_client: ClientDetail,
     storage_config: StorageConfig,
 ) -> Generator:
-    sar_policy = Policy.create(
+    access_request_policy = Policy.create(
         db=db,
         data={
-            "name": "example sar policy",
-            "key": "example-sar-policy",
+            "name": "example access request policy",
+            "key": "example-access-request-policy",
             "client_id": oauth_client.id,
         },
     )
 
-    sar_rule = Rule.create(
+    access_request_rule = Rule.create(
         db=db,
         data={
             "action_type": ActionType.access.value,
             "client_id": oauth_client.id,
-            "name": "SAR Rule",
-            "policy_id": sar_policy.id,
+            "name": "Access Request Rule",
+            "policy_id": access_request_policy.id,
             "storage_destination_id": storage_config.id,
         },
     )
@@ -282,20 +282,20 @@ def policy(
         data={
             "client_id": oauth_client.id,
             "data_category": DataCategory("user.provided.identifiable").value,
-            "rule_id": sar_rule.id,
+            "rule_id": access_request_rule.id,
         },
     )
-    yield sar_policy
+    yield access_request_policy
     try:
         rule_target.delete(db)
     except ObjectDeletedError:
         pass
     try:
-        sar_rule.delete(db)
+        access_request_rule.delete(db)
     except ObjectDeletedError:
         pass
     try:
-        sar_policy.delete(db)
+        access_request_policy.delete(db)
     except ObjectDeletedError:
         pass
 

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -67,7 +67,7 @@ def test_retry_decorator():
     config.execution.TASK_RETRY_DELAY = 0.1
     config.execution.TASK_RETRY_BACKOFF = 0.01
 
-    class TestRetrySar:
+    class TestRetryDecorator:
         def __init__(self):
             self.traversal_node = payment_card_node
             self.call_count = 0
@@ -89,7 +89,7 @@ def test_retry_decorator():
             self.call_count += 1
             input_data["nonexistant_value"]
 
-    test_obj = TestRetrySar()
+    test_obj = TestRetryDecorator()
     test_obj.test_function()
     assert test_obj.call_count == 6  # called once, with 5 retries
     assert test_obj.end_called_with[0] == ActionType.access

--- a/tests/integration_tests/test_mongo_task.py
+++ b/tests/integration_tests/test_mongo_task.py
@@ -66,7 +66,7 @@ def test_combined_erasure_task(
     field([mongo_dataset], ("mongo_test", "address", "zip")).data_categories = ["C"]
     graph = DatasetGraph(mongo_dataset, postgres_dataset)
 
-    sar_data = graph_task.run_sar(
+    access_request_data = graph_task.run_access_request(
         privacy_request,
         policy,
         graph,
@@ -74,8 +74,7 @@ def test_combined_erasure_task(
         {"email": seed_email},
     )
 
-    print("SAR DATA:")
-    for k, v in sar_data.items():
+    for k, v in access_request_data.items():
         print(k)
         for row in v:
             print(f"\t{row}")
@@ -85,7 +84,7 @@ def test_combined_erasure_task(
         graph,
         [integration_mongodb_config, integration_postgres_config],
         {"email": seed_email},
-        sar_data,
+        access_request_data,
     )
     print("-----")
     for k, v in x.items():
@@ -117,7 +116,7 @@ def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config):
     field([dataset], ("mongo_test", "address", "zip")).data_categories = ["C"]
     field([dataset], ("mongo_test", "customer", "name")).data_categories = ["A"]
 
-    sar_data = graph_task.run_sar(
+    access_request_data = graph_task.run_access_request(
         privacy_request,
         policy,
         graph,
@@ -130,7 +129,7 @@ def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config):
         graph,
         [integration_mongodb_config],
         {"email": seed_email},
-        sar_data,
+        access_request_data,
     )
 
     assert v == {
@@ -145,7 +144,7 @@ def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config):
 def test_dask_mongo_task(integration_mongodb_config: ConnectionConfig) -> None:
     privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
 
-    v = graph_task.run_sar(
+    v = graph_task.run_access_request(
         privacy_request,
         policy,
         integration_db_graph("mongo_test", integration_mongodb_config.key),
@@ -193,7 +192,7 @@ def test_filter_on_data_categories_mongo(
     )
     dataset_graph = DatasetGraph(*[graph, mongo_graph])
 
-    sar_results = graph_task.run_sar(
+    access_request_results = graph_task.run_access_request(
         privacy_request,
         policy,
         dataset_graph,
@@ -206,7 +205,7 @@ def test_filter_on_data_categories_mongo(
         "user.provided.identifiable.date_of_birth",
     }
     filtered_results = filter_data_categories(
-        sar_results, target_categories, dataset_graph
+        access_request_results, target_categories, dataset_graph
     )
 
     # Mongo results obtained via customer_id field from postgres_example_test_dataset.customer.id

--- a/tests/models/test_policy.py
+++ b/tests/models/test_policy.py
@@ -299,8 +299,8 @@ def test_validate_policy(
     erasure_policy = Policy.create(
         db=db,
         data={
-            "name": "example sar policy",
-            "key": "example-sar-policy",
+            "name": "example erasure policy",
+            "key": "example-erasure-policy",
             "client_id": oauth_client.id,
         },
     )

--- a/tests/models/test_privacy_request.py
+++ b/tests/models/test_privacy_request.py
@@ -4,7 +4,6 @@ from unittest import mock
 from unittest.mock import Mock
 from uuid import uuid4
 
-import pytest
 from sqlalchemy.orm import Session
 
 from fidesops.models.policy import Policy
@@ -14,7 +13,6 @@ from fidesops.models.privacy_request import (
     PrivacyRequestStatus,
 )
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
-from fidesops.task.graph_task import run_sar
 from fidesops.util.cache import FidesopsRedis, get_identity_cache_key
 
 
@@ -136,11 +134,11 @@ def test_delete_privacy_request_removes_cached_data(
     assert cache.get(key) is None
 
 
-@mock.patch("fidesops.task.graph_task.run_sar")
+@mock.patch("fidesops.task.graph_task.run_access_request")
 @mock.patch("fidesops.models.privacy_request.upload")
 def test_policy_upload_called(
     upload_mock: Mock,
-    run_sar_mock: Mock,
+    run_access_request_mock: Mock,
     db: Session,
     privacy_request: PrivacyRequest,
     privacy_request_runner: PrivacyRequestRunner,
@@ -148,7 +146,7 @@ def test_policy_upload_called(
     privacy_request_runner.run()
     assert privacy_request.finished_processing_at is not None
     assert upload_mock.called
-    assert run_sar_mock.called
+    assert run_access_request_mock.called
 
 
 def test_start_processing_sets_started_processing_at(


### PR DESCRIPTION
# Purpose

Everywhere we use "SAR", we should use "Access Request" instead, so it's non-region specific but rather action-specific.

# Changes

- Updates docs, variable names, mocks, and cache keys. 

# Ticket
https://ethyca.atlassian.net/browse/SOL-253