### PR TITLE
Avoid Creating DB Connection to Embed Execution Logs [SOL-232]

### DIFF
--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Set
 
 from enum import Enum as EnumType
-
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy import (
     Column,
@@ -155,6 +154,16 @@ class PrivacyRequest(Base):
         from fidesops.service.request_intake.onetrust_service import transition_status
 
         transition_status(OneTrustSubtaskStatus.FAILED, self.onetrust_context)
+
+    # passive_deletes="all" prevents execution logs from having their privacy_request_id set to null when
+    # a privacy_request is deleted.  We want to retain for record-keeping.
+    execution_logs = relationship(
+        "ExecutionLog",
+        backref="privacy_request",
+        lazy="dynamic",
+        passive_deletes="all",
+        primaryjoin="foreign(ExecutionLog.privacy_request_id)==PrivacyRequest.id",
+    )
 
 
 class PrivacyRequestRunner:
@@ -317,4 +326,3 @@ class ExecutionLog(Base):
         nullable=False,
         index=True,
     )
-    # privacy_request = relationship("PrivacyRequest", foreign_keys=[privacy_request_id], primaryjoin='ExecutionLog.privacy_request_id==PrivacyRequest.id', backref=backref("execution_logs", lazy="dynamic"))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -408,7 +408,7 @@ def postgres_execution_log(
             "collection_name": "user",
             "fields_affected": [
                 {
-                    "path": "user.email",
+                    "path": "my-postgres-db:user:email",
                     "field_name": "email",
                     "data_categories": ["user.provided.identifiable.contact.email"],
                 }
@@ -433,12 +433,12 @@ def second_postgres_execution_log(
             "collection_name": "address",
             "fields_affected": [
                 {
-                    "path": "address.street",
+                    "path": "my-postgres-db:address:street",
                     "field_name": "street",
                     "data_categories": ["user.provided.identifiable.contact.street"],
                 },
                 {
-                    "path": "address.city",
+                    "path": "my-postgres-db:address:city",
                     "field_name": "city",
                     "data_categories": ["user.provided.identifiable.contact.city"],
                 },
@@ -462,7 +462,7 @@ def mongo_execution_log(db: Session, privacy_request: PrivacyRequest) -> Executi
             "collection_name": "orders",
             "fields_affected": [
                 {
-                    "path": "orders.name",
+                    "path": "my-mongo-db:orders:name",
                     "field_name": "name",
                     "data_categories": ["user.provided.identifiable.contact.name"],
                 }


### PR DESCRIPTION
# Purpose

Get rid of having to create another db connection when we embed execution logs in the privacy request response.


# Changes
- Define a `privacy_request.execution_logs` relationship using a [custom foreign condition](https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#creating-custom-foreign-conditions) since there are intentionally no foreign keys on execution log 
- Earlier attempts defined this relationship on the child (execution_log) instead of the parent (privacyrequest), but this needs to be on the parent so we can specify the cascade delete behavior 
  -  From [SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/orm/cascades.html#using-foreign-key-on-delete-cascade-with-orm-relationships) 
  > At the ORM level, this direction is reversed. SQLAlchemy handles the deletion of “child” objects relative to a “parent” from the “parent” side, which means that delete and delete-orphan cascade are configured on the one-to-many side.
  - Here we do *not* nullify the `executionlog.privacy_request_id` when a privacy_request is deleted, for record keeping

    - Note that no delete privacy request endpoint exists yet
- Additionally, in tests, update the path on the ExecutionLog fixture to reflect how they are currently being built.

# Ticket
https://ethyca.atlassian.net/browse/SOL-232 (old, internal ticket)