### PR TITLE
Restore hot reloading of web server [#17]

### DIFF
--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -37,7 +37,9 @@ def start_webserver() -> None:
     initiate_scheduled_request_intake()
 
     logger.info("Starting web server...")
-    uvicorn.run(app, host="0.0.0.0", port=8080, log_config=None)
+    uvicorn.run(
+        "src.fidesops.main:app", host="0.0.0.0", port=8080, log_config=None, reload=True
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Purpose
Fix hot reloading of web server for dev happiness :)

# Changes

- Use uvicorn's `reload=True` argument and pass in [app import string](https://www.uvicorn.org/deployment/#running-programmatically) instead of the application itself when calling `uvicorn.run`

# Ticket
Closes #17 