### PR TITLE
Target Specific Tests in Docker 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,14 @@ When you run `make server` or `make server-shell`, the database will be spun up 
 Tests are run using `pytest`. Some commands you may need are listed below. The full documentation can be found at: https://docs.pytest.org/en/6.2.x/. There is some additional Pytest config in the `pyproject.toml` file at the root of the repo. Running `make pytest` will automatically migrate the database for you to the latest version by running `alembic upgrade head` before the `pytest` command itself.
 
 - Run all tests: `make pytest`
-- Run all tests in a directory: `make path=path/to/dir/ pytest`
-- Run all tests in a file: `make path=path/to/file.py pytest`
-- Run all tests within a class within a file: `make path=path/to/file.py::ClassName pytest`
-- Run a specific test within a class within a file: `make path=path/to/file.py::ClassName::method_name pytest`
-- Run a specific test within a file: `make path=path/to/file.py::method_name pytest`
+- Run all tests in a directory: `make pytestpath=path/to/dir/ pytest`
+- Run all tests in a file: `make pytestpath=path/to/file.py pytest`
+- Run all tests within a class within a file: `make pytestpath=path/to/file.py::ClassName pytest`
+- Run a specific test within a class within a file: `make pytestpath=path/to/file.py::ClassName::method_name pytest`
+- Run a specific test within a file: `make pytestpath=path/to/file.py::method_name pytest`
+- Run integration tests (access): `make pytest-integration-access`
+- Run integration tests (erasure): `make pytest-integration-erasure`
+
 
 ### How to write tests
 

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,9 @@ mypy: compose-build
 pytest: compose-build
 	@echo "Running pytest unit tests..."
 	@docker-compose run $(IMAGE_NAME) \
-		pytest -m "not integration and not integration_erasure"
+		pytest $(pytestpath) -m "not integration and not integration_erasure"
 
-# Run the pytest integration tests. Note the inclusion of the unit tests "tests/" folder in the
-# pytest target; this is to reuse the test configuration, test fixtures, etc.
+# Run the pytest integration tests.
 pytest-integration-access: compose-build
 	@echo "Building additional Docker images for integration tests..."
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml build
@@ -113,7 +112,7 @@ pytest-integration-access: compose-build
 	@echo "Running pytest integration tests..."
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml \
 		run $(IMAGE_NAME) \
-		pytest -m integration tests/
+		pytest $(pytestpath) -m integration
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml down --remove-orphans
 
 pytest-integration-erasure: compose-build
@@ -122,7 +121,7 @@ pytest-integration-erasure: compose-build
 	@echo "Running pytest integration tests..."
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml \
 		run $(IMAGE_NAME) \
-		pytest -m integration_erasure tests/
+		pytest $(pytestpath) -m "integration_erasure"
 
 ####################
 # Utils


### PR DESCRIPTION
# Purpose
Documentation suggests you can do something like `make path=path/to/dir/ pytest`, but that was removed because "path" is overloaded.   This is a really useful feature to target specific tests so I'd like to add this back, except don't use "path".

# Changes
- Target specific tests with `make pytestpath=path/to/dir/ pytest`
- Update contributing documentation
- Remove loading entire `tests` directory in integration tests which was making it impossible to target specific tests.  It was previously added to reuse the test configuration and test fixtures, but this no longer seems necessary.  My theory is that some integration tests have been added that are outside the integration_test directory.


# Ticket
[unticketed]