### PR TITLE
Update Postman Collection / Tutorial re: Client Scopes 

### DIFF
--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9b8debaf-14e2-4bd3-b11f-0b6b39baa84c",
+		"_postman_id": "07dc6f86-ad90-48d2-958a-9bef4156d293",
 		"name": "Fidesops",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -66,7 +66,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "",
+							"raw": "[\n    \"client:create\",\n    \"client:update\",\n    \"client:read\",\n    \"client:delete\",\n    \"config:read\",\n    \"connection:read\",\n    \"connection:create_or_update\",\n    \"connection:delete\",\n    \"dataset:create_or_update\",\n    \"dataset:delete\",\n    \"dataset:read\",\n    \"encryption:exec\",\n    \"policy:create_or_update\",\n    \"policy:read\",\n    \"policy:delete\",\n    \"privacy-request:create\",\n    \"privacy-request:read\",\n    \"privacy-request:delete\",\n    \"rule:create_or_update\",\n    \"rule:read\",\n    \"rule:delete\",\n    \"scope:read\",\n    \"storage:create_or_update\",\n    \"storage:delete\",\n    \"storage:read\"\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -81,45 +81,6 @@
 							"path": [
 								"oauth",
 								"client"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Set Client Scopes",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{root_client_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "[\n    \"client:create\",\n    \"client:update\",\n    \"client:read\",\n    \"client:delete\",\n    \"config:read\",\n    \"connection:read\",\n    \"connection:create_or_update\",\n    \"connection:delete\",\n    \"dataset:create_or_update\",\n    \"dataset:delete\",\n    \"dataset:read\",\n    \"encryption:exec\",\n    \"policy:create_or_update\",\n    \"policy:read\",\n    \"policy:delete\",\n    \"privacy-request:create\",\n    \"privacy-request:read\",\n    \"privacy-request:delete\",\n    \"rule:create_or_update\",\n    \"rule:read\",\n    \"rule:delete\",\n    \"scope:read\",\n    \"storage:create_or_update\",\n    \"storage:delete\",\n    \"storage:read\"\n]",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{host}}/oauth/client/{{client_id}}/scope",
-							"host": [
-								"{{host}}"
-							],
-							"path": [
-								"oauth",
-								"client",
-								"{{client_id}}",
-								"scope"
 							]
 						}
 					},
@@ -565,7 +526,7 @@
 					"response": []
 				},
 				{
-					"name": "Create Privacy Requests",
+					"name": "Create Access Privacy Requests",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -606,7 +567,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "These API calls step you through how to set up all the resources in Fidesops to execute access privacy requests in your system."
 		},
 		{
 			"name": "Calls to create an Erasure Request (Assume Basic Configs already set up from Access Request section)",
@@ -727,7 +689,7 @@
 					"response": []
 				},
 				{
-					"name": "Create RTF Privacy Request",
+					"name": "Create Erasure Privacy Request",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -762,7 +724,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "These API calls step you through how to set up all the resources in Fidesops to execute erasure privacy requests in your system.\n\nIt assumes you've already run through the API requests in the \"Access\" section so database connections, storage, and annotated datasets are already configured."
 		},
 		{
 			"name": "Other Useful API calls",
@@ -848,6 +811,45 @@
 						},
 						"method": "GET",
 						"header": [],
+						"url": {
+							"raw": "{{host}}/oauth/client/{{client_id}}/scope",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"oauth",
+								"client",
+								"{{client_id}}",
+								"scope"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set Client Scopes",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{root_client_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "[\n    \"client:create\",\n    \"client:update\",\n    \"client:read\",\n    \"client:delete\",\n    \"config:read\",\n    \"connection:read\",\n    \"connection:create_or_update\",\n    \"connection:delete\",\n    \"dataset:create_or_update\",\n    \"dataset:delete\",\n    \"dataset:read\",\n    \"encryption:exec\",\n    \"policy:create_or_update\",\n    \"policy:read\",\n    \"policy:delete\",\n    \"privacy-request:create\",\n    \"privacy-request:read\",\n    \"privacy-request:delete\",\n    \"rule:create_or_update\",\n    \"rule:read\",\n    \"rule:delete\",\n    \"scope:read\",\n    \"storage:create_or_update\",\n    \"storage:delete\",\n    \"storage:read\"\n]",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{host}}/oauth/client/{{client_id}}/scope",
 							"host": [
@@ -1244,7 +1246,9 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": null
+						"url": {
+							"raw": ""
+						}
 					},
 					"response": []
 				},

--- a/docs/fidesops/docs/tutorial/annotate_datasets.md
+++ b/docs/fidesops/docs/tutorial/annotate_datasets.md
@@ -9,7 +9,7 @@ For more detailed information, [see the Datasets Guide](../guides/datasets.md).
 Next, fidesops needs to know how to traverse through our Flask App's database tables. 
 We should upload a YAML file that describes our Flask App's database in a language that Fides understands.
 
-See `fides_resources/flaskr_postgres_dataset.yml` where we've already annotated the tables and fields in our Postgres
+See `fidesdemo/fides_resources/flaskr_postgres_dataset.yml` where we've already annotated the tables and fields in our Postgres
 database with the relevant Data Categories.  We just need a few more annotations:
 
 Add a `fidesops_meta` attribute to `flaskr_postgres_dataset.collections.seller_id`.  Fidesops will be able to take the users `id `

--- a/docs/fidesops/docs/tutorial/oauth_client.md
+++ b/docs/fidesops/docs/tutorial/oauth_client.md
@@ -8,7 +8,7 @@ For more detailed information, [see the Oauth Guide](../guides/oauth.md).
 
 Our first step is to create an Oauth Client that we can use to authenticate all of our requests.
 
-Add a method to our Python script that will call create a token given a `client_id` and a `client_secret`:
+Add a method to our Python script that will call the fidesops API to create a token given a `client_id` and a `client_secret`:
 
 
 ### Define helper methods
@@ -74,18 +74,10 @@ def create_oauth_client(access_token):
         "dataset:delete",
     ]
     response = requests.post(
-        f"{FIDESOPS_URL}/api/v1/oauth/client", headers=oauth_headers(access_token)
+        f"{FIDESOPS_URL}/api/v1/oauth/client", headers=oauth_headers(access_token), json=scopes_data
     )
     logger.info(f"Creating Oauth Client. Status {response.status_code}")
-
-    oauth_client = response.json()
-    response = requests.put(
-        f"{FIDESOPS_URL}/api/v1/oauth/client/{oauth_client['client_id']}/scope",
-        headers=oauth_headers(access_token),
-        json=scopes_data,
-    )
-    logger.info(f"Adding scopes to oauth client. Status {response.status_code}")
-    return oauth_client
+    return response.json()
 
 ```
 

--- a/docs/fidesops/docs/tutorial/outline.md
+++ b/docs/fidesops/docs/tutorial/outline.md
@@ -7,6 +7,8 @@ library to call the `Fidesops` API to build our required configuration.
 As we go through each step in the tutorial, you'll add a couple of helper methods that are wrappers to API calls, and
 then add calls to these functions at the bottom to be executed when we run this script.
 
+Create the file `fidesdemo/flaskr/fidesops.py` and add the following imports, environment variables,
+and outline the methods we'll be creating together: 
 ```python
 import logging
 import requests

--- a/docs/fidesops/docs/tutorial/postgres_connection.md
+++ b/docs/fidesops/docs/tutorial/postgres_connection.md
@@ -8,7 +8,7 @@ For more detailed information, [see the Database Connectors Guide](../guides/dat
 
 Next, we need to create a ConnectionConfig so fidesops can connect to our Flask App's  database.
 
-Let's add a method that hits the PUT `connection` endpoint, and creates a ConnectionConfig for a `postgres` database.
+Let's add a method that hits the PUT `connection` endpoint, and creates a ConnectionConfig for a `postgres` database:
 
 ### Define helper methods
 
@@ -36,7 +36,7 @@ def create_postgres_connection(key, access_token):
 
 ```
 
-Secrets, like a username and password that are needed to access the Flask App's database, are added separately:
+Secrets, like a username and password that are needed to access the Flask App's databases, are added separately:
 
 ```python
 def configure_postgres_connection(


### PR DESCRIPTION
# Purpose

When an Oauth Client is created in Fidesops, its scopes can be set in the same request; we no longer need a followup request to set those scopes separately.  This has been updated in oauth docs, but update other documentation to reflect.

# Changes
-  Update postman collection to create client/set scopes in a single request
- Update tutorial to create client/set scopes in a single method. I didn't realize we had this capability so I split into two requests originally.

# Ticket
[not ticketed]