### PR TITLE
Catch Errors when validating Dataset that references another Dataset

### DIFF
--- a/src/fidesops/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/dataset_endpoints.py
@@ -8,6 +8,7 @@ from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
 from pydantic import conlist
 from sqlalchemy.orm import Session
+from fidesops.common_exceptions import ValidationError
 
 from fidesops.common_exceptions import TraversalError
 from starlette.status import HTTP_404_NOT_FOUND
@@ -88,7 +89,7 @@ def validate_dataset(
         graph = DatasetGraph(convert_dataset_to_graph(dataset, connection_config.key))
         unique_identities = set(graph.identity_keys.values())
         Traversal(graph, {k: None for k in unique_identities})
-    except TraversalError as err:
+    except (TraversalError, ValidationError) as err:
         logger.warning(
             f"Traversal validation failed for dataset '{dataset.fides_key}': {err}"
         )

--- a/tests/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/api/v1/endpoints/test_dataset_endpoints.py
@@ -225,13 +225,36 @@ class TestValidateDataset:
         response_body = json.loads(response.text)
         assert response_body["dataset"]
         assert response_body["traversal_details"]
-        assert response_body["traversal_details"]["is_traversable"] == False
+        assert response_body["traversal_details"]["is_traversable"] is False
         assert (
             "Some nodes were not reachable" in response_body["traversal_details"]["msg"]
         )
         assert (
             "postgres_example_test_dataset:address"
             in response_body["traversal_details"]["msg"]
+        )
+
+    def test_validate_dataset_that_references_another_dataset(
+        self,
+        example_datasets: List,
+        validate_dataset_url,
+        api_client: TestClient,
+        generate_auth_header,
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        dataset = example_datasets[1]
+
+        response = api_client.put(
+            validate_dataset_url, headers=auth_header, json=dataset
+        )
+        assert response.status_code == 200
+        response_body = json.loads(response.text)
+        assert response_body["dataset"]
+        assert response_body["traversal_details"]
+        assert response_body["traversal_details"]["is_traversable"] is False
+        assert (
+            "Referred to object postgres_example_test_dataset:customer:id does not exist"
+            == response_body["traversal_details"]["msg"]
         )
 
     def test_put_validate_dataset(
@@ -250,7 +273,7 @@ class TestValidateDataset:
         assert response_body["dataset"]
         assert response_body["dataset"]["fides_key"] == "postgres_example_test_dataset"
         assert response_body["traversal_details"]
-        assert response_body["traversal_details"]["is_traversable"] == True
+        assert response_body["traversal_details"]["is_traversable"] is True
         assert response_body["traversal_details"]["msg"] is None
 
 

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -429,7 +429,7 @@ class TestCreatePrivacyRequest:
                 assert row[3] is None
                 assert row[4] is None
 
-        assert card_found == True
+        assert card_found is True
 
 
 class TestGetPrivacyRequests:

--- a/tests/graph/test_edge.py
+++ b/tests/graph/test_edge.py
@@ -31,7 +31,7 @@ def test_split_by_address() -> None:
         FieldAddress("a", "b", "c"),
     )
 
-    assert b_edge.split_by_address(CollectionAddress("x", "y")) == None
+    assert b_edge.split_by_address(CollectionAddress("x", "y")) is None
 
 
 def test_spans() -> None:

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -48,7 +48,7 @@ def test_node_eq() -> None:
 def test_node_contains() -> None:
     node = graph.nodes[CollectionAddress("s1", "t1")]
     assert node.contains_field(lambda f: f.name == "f3")
-    assert node.contains_field(lambda f: f.name == "f4") == False
+    assert node.contains_field(lambda f: f.name == "f4") is False
     assert node.contains_field(lambda f: f.primary_key)
 
 

--- a/tests/models/test_datasetconfig.py
+++ b/tests/models/test_datasetconfig.py
@@ -104,17 +104,17 @@ def test_convert_dataset_to_graph(example_datasets):
     # check that primary key member has been set
     assert (
         field([graph], ("postgres_example_test_dataset", "address", "id")).primary_key
-        == True
+        is True
     )
     assert (
         field([graph], ("postgres_example_test_dataset", "customer", "id")).primary_key
-        == True
+        is True
     )
     assert (
         field([graph], ("postgres_example_test_dataset", "employee", "id")).primary_key
-        == True
+        is True
     )
     assert (
         field([graph], ("postgres_example_test_dataset", "visit", "email")).primary_key
-        == False
+        is False
     )

--- a/tests/util/test_cache.py
+++ b/tests/util/test_cache.py
@@ -50,7 +50,7 @@ def test_encode_decode() -> None:
             random.random(), random.randint(0, 1000), faker.name()
         )
         assert FidesopsRedis.decode_obj(FidesopsRedis.encode_obj(test_obj)) == test_obj
-    assert FidesopsRedis.decode_obj(None) == None
+    assert FidesopsRedis.decode_obj(None) is None
 
 
 def test_scan(cache: FidesopsRedis) -> List:

--- a/tests/util/test_queue.py
+++ b/tests/util/test_queue.py
@@ -7,7 +7,7 @@ def test_queue() -> None:
     assert queue.pop_first_match(lambda x: x.startswith("B")) == "B"
     assert queue.pop_first_match(lambda x: x.startswith("B")) == "B1"
     assert queue.pop_first_match(lambda x: x.startswith("B")) is None
-    assert queue.is_empty() == False
+    assert queue.is_empty() is False
     assert queue.data == ["C"]
     queue.push_if_new("C")
     assert queue.data == ["C"]


### PR DESCRIPTION
# Purpose

Currently, a PUT request to `/connection/<connection_key>/validate_datset` with a request body that has a field referencing another dataset will throw a 500 error due to an uncaught validation error. 

# Changes
-  Catch validation errors when validating datasets and return a useful error message to the user. 

# Ticket
[Unticketed]