### PR TITLE
Add Connection and Storage Secrets Schemas to API Documentation [SOL-269]

### DIFF
--- a/src/fidesops/models/storage.py
+++ b/src/fidesops/models/storage.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict
 
 from pydantic import ValidationError
 from sqlalchemy import (
@@ -27,13 +26,14 @@ from fidesops.schemas.storage.storage import (
 
 from fidesops.core.config import config
 from fidesops.db.base_class import JSONTypeOverride
+from fidesops.schemas.storage.storage_secrets_docs_only import possible_storage_secrets
 
 logger = logging.getLogger(__name__)
 
 
 def get_schema_for_secrets(
     storage_type: StorageType,
-    secrets: Dict[str, str],
+    secrets: possible_storage_secrets,
 ) -> SUPPORTED_STORAGE_SECRETS:
     """
     Returns the secrets that pertain to `storage_type` represented as a Pydantic schema
@@ -86,7 +86,7 @@ class StorageConfig(Base):
         self,
         *,
         db: Session,
-        storage_secrets: Dict[str, str],
+        storage_secrets: possible_storage_secrets,
     ) -> None:
         """Creates or updates secrets associated with a config id"""
 

--- a/src/fidesops/schemas/base_class.py
+++ b/src/fidesops/schemas/base_class.py
@@ -2,8 +2,6 @@ from typing import List, Any
 
 from pydantic import BaseModel
 
-from fidesops.common_exceptions import ValidationError
-
 
 class FidesopsSchema(BaseModel):
     """

--- a/src/fidesops/schemas/base_class.py
+++ b/src/fidesops/schemas/base_class.py
@@ -22,11 +22,11 @@ class FidesopsSchema(BaseModel):
 BaseSchema = FidesopsSchema
 
 
-class DocsOnlySchema(BaseModel):
+class NoValidationSchema(BaseModel):
     """A schema to be used for API documentation only, when validation is handled later in the request process,
     but we still want valid request schemas to show up in the docs."""
 
     @classmethod
-    def validate(cls: "DocsOnlySchema", value: Any) -> Any:
+    def validate(cls: "NoValidationSchema", value: Any) -> Any:
         """Returns value exactly as it was passed in, when validation is going to be handled later."""
         return value

--- a/src/fidesops/schemas/base_class.py
+++ b/src/fidesops/schemas/base_class.py
@@ -1,6 +1,8 @@
-from typing import List
+from typing import List, Any
 
 from pydantic import BaseModel
+
+from fidesops.common_exceptions import ValidationError
 
 
 class FidesopsSchema(BaseModel):
@@ -20,3 +22,13 @@ class FidesopsSchema(BaseModel):
 
 
 BaseSchema = FidesopsSchema
+
+
+class DocsOnlySchema(BaseModel):
+    """A schema to be used for API documentation only, when validation is handled later in the request process,
+    but we still want valid request schemas to show up in the docs."""
+
+    @classmethod
+    def validate(cls: "DocsOnlySchema", value: Any) -> Any:
+        """Returns value exactly as it was passed in, when validation is going to be handled later."""
+        return value

--- a/src/fidesops/schemas/connection_configuration/__init__.py
+++ b/src/fidesops/schemas/connection_configuration/__init__.py
@@ -1,16 +1,19 @@
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from fidesops.schemas.connection_configuration.connection_secrets_mongodb import (
     MongoDBSchema,
+    MongoDBDocsSchema,
 )
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
 from fidesops.schemas.connection_configuration.connection_secrets_mysql import (
     MySQLSchema,
+    MySQLDocsSchema,
 )
 from fidesops.schemas.connection_configuration.connection_secrets_postgres import (
     PostgreSQLSchema,
+    PostgreSQLDocsSchema,
 )
 from fidesops.models.connectionconfig import ConnectionType
 from fidesops.schemas.connection_configuration.connections_secrets_https import (
@@ -40,3 +43,8 @@ def get_connection_secrets_validator(
         raise NotImplementedError(
             f"Add {connection_type} to the 'secrets_validators' mapping."
         )
+
+
+connection_secrets_schemas = Union[
+    MongoDBDocsSchema, PostgreSQLDocsSchema, MySQLDocsSchema
+]

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mongodb.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mongodb.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.base_class import NoValidationSchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -18,5 +18,5 @@ class MongoDBSchema(ConnectionConfigSecretsSchema):
     _required_components: List[str] = ["host"]
 
 
-class MongoDBDocsSchema(MongoDBSchema, DocsOnlySchema):
+class MongoDBDocsSchema(MongoDBSchema, NoValidationSchema):
     """Mongo DB Secrets Schema for API docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mongodb.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mongodb.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
 
+from fidesops.schemas.base_class import DocsOnlySchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -15,3 +16,7 @@ class MongoDBSchema(ConnectionConfigSecretsSchema):
     defaultauthdb: Optional[str] = None
 
     _required_components: List[str] = ["host"]
+
+
+class MongoDBDocsSchema(MongoDBSchema, DocsOnlySchema):
+    """Mongo DB Secrets Schema for API docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mysql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mysql.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
 
+from fidesops.schemas.base_class import DocsOnlySchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -17,3 +18,7 @@ class MySQLSchema(ConnectionConfigSecretsSchema):
     port: Optional[int] = None
 
     _required_components: List[str] = ["host"]
+
+
+class MySQLDocsSchema(MySQLSchema, DocsOnlySchema):
+    """MySQL Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mysql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mysql.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.base_class import NoValidationSchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -20,5 +20,5 @@ class MySQLSchema(ConnectionConfigSecretsSchema):
     _required_components: List[str] = ["host"]
 
 
-class MySQLDocsSchema(MySQLSchema, DocsOnlySchema):
+class MySQLDocsSchema(MySQLSchema, NoValidationSchema):
     """MySQL Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_postgres.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_postgres.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
 
+from fidesops.schemas.base_class import DocsOnlySchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -17,3 +18,7 @@ class PostgreSQLSchema(ConnectionConfigSecretsSchema):
     port: Optional[int] = None
 
     _required_components: List[str] = ["host"]
+
+
+class PostgreSQLDocsSchema(PostgreSQLSchema, DocsOnlySchema):
+    """Postgres Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_postgres.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_postgres.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.base_class import NoValidationSchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -20,5 +20,5 @@ class PostgreSQLSchema(ConnectionConfigSecretsSchema):
     _required_components: List[str] = ["host"]
 
 
-class PostgreSQLDocsSchema(PostgreSQLSchema, DocsOnlySchema):
+class PostgreSQLDocsSchema(PostgreSQLSchema, NoValidationSchema):
     """Postgres Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connections_secrets_https.py
+++ b/src/fidesops/schemas/connection_configuration/connections_secrets_https.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from fidesops.schemas.base_class import DocsOnlySchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -12,3 +13,7 @@ class HttpsSchema(ConnectionConfigSecretsSchema):
     authorization: str
 
     _required_components: List[str] = ["url", "authorization"]
+
+
+class HttpsDocsSchema(HttpsSchema, DocsOnlySchema):
+    """HTTPS Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connections_secrets_https.py
+++ b/src/fidesops/schemas/connection_configuration/connections_secrets_https.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.base_class import NoValidationSchema
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
@@ -15,5 +15,5 @@ class HttpsSchema(ConnectionConfigSecretsSchema):
     _required_components: List[str] = ["url", "authorization"]
 
 
-class HttpsDocsSchema(HttpsSchema, DocsOnlySchema):
+class HttpsDocsSchema(HttpsSchema, NoValidationSchema):
     """HTTPS Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/storage/storage.py
+++ b/src/fidesops/schemas/storage/storage.py
@@ -18,7 +18,6 @@ from pydantic.main import BaseModel
 
 from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/fidesops/schemas/storage/storage_secrets_docs_only.py
+++ b/src/fidesops/schemas/storage/storage_secrets_docs_only.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.base_class import NoValidationSchema
 from fidesops.schemas.storage.storage import (
     StorageSecretsLocal,
     StorageSecretsS3,
@@ -8,11 +8,11 @@ from fidesops.schemas.storage.storage import (
 )
 
 
-class StorageSecretsS3Docs(StorageSecretsS3, DocsOnlySchema):
+class StorageSecretsS3Docs(StorageSecretsS3, NoValidationSchema):
     """The secrets required to connect to S3, for documentation"""
 
 
-class StorageSecretsOnetrustDocs(StorageSecretsOnetrust, DocsOnlySchema):
+class StorageSecretsOnetrustDocs(StorageSecretsOnetrust, NoValidationSchema):
     """The secrets required to send results to Onetrust, for documentation"""
 
 

--- a/src/fidesops/schemas/storage/storage_secrets_docs_only.py
+++ b/src/fidesops/schemas/storage/storage_secrets_docs_only.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+from fidesops.schemas.base_class import DocsOnlySchema
+from fidesops.schemas.storage.storage import (
+    StorageSecretsLocal,
+    StorageSecretsS3,
+    StorageSecretsOnetrust,
+)
+
+
+class StorageSecretsS3Docs(StorageSecretsS3, DocsOnlySchema):
+    """The secrets required to connect to S3, for documentation"""
+
+
+class StorageSecretsOnetrustDocs(StorageSecretsOnetrust, DocsOnlySchema):
+    """The secrets required to send results to Onetrust, for documentation"""
+
+
+possible_storage_secrets = Union[StorageSecretsS3Docs, StorageSecretsOnetrustDocs]

--- a/src/fidesops/service/connectors/mongodb_connector.py
+++ b/src/fidesops/service/connectors/mongodb_connector.py
@@ -45,7 +45,10 @@ class MongoDBConnector(BaseConnector):
         """Returns a client for a MongoDB instance"""
         config = MongoDBSchema(**self.configuration.secrets or {})
         uri = config.url if config.url else self.build_uri()
-        return MongoClient(uri, serverSelectionTimeoutMS=5000)
+        try:
+            return MongoClient(uri, serverSelectionTimeoutMS=5000)
+        except ValueError:
+            raise ConnectionException("Value Error connecting to MongoDB.")
 
     def query_config(self, node: TraversalNode) -> QueryConfig[Any]:
         """Query wrapper corresponding to the input traversal_node."""

--- a/tests/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_config_endpoints.py
@@ -437,6 +437,7 @@ class TestPutConnectionConfigSecrets:
         resp = api_client.put(
             f"{V1_URL_PREFIX}{CONNECTIONS}/this-is-not-a-known-key/secret",
             headers=auth_header,
+            json={}
         )
         assert resp.status_code == 404
 


### PR DESCRIPTION
# Purpose
The schemas for the secrets to connect to a database or create a storage location are not yet included in our docs.  These schemas have been more difficult to specify, as there are multiple possible schemas for both of these endpoints, and we can't specify which schema is the relevant one upfront. There are also overlaps in the possible fields between schemas, making it difficult for fastapi to automatically select the correct one - we need to wait until we load the connection config or storage config in the view to be sure we have the correct schema. However, we still want the possible schemas documented.

# Changes

- Create a new `DocsOnlySchema` to use when we still want a schema to show up in the docs, but we don't want it validated yet - the validation will happen later once we've determined the correct schema to use, of the multiple possibilities. This schema validation just passes the incoming request body through as-is, h/t @seanpreston for the idea.
- Get rid of needing to access the raw fast api request in connection secrets since we're passing through the unvalidated secrets
-  Catch a possible 500 error when validating mongo secrets, discovered while testing

## Docs!

![Screen Shot 2021-11-03 at 6 02 55 PM](https://user-images.githubusercontent.com/9755598/140229840-65b01747-f174-4825-9122-3ec62ea132a3.png)
![Screen Shot 2021-11-03 at 6 02 31 PM](https://user-images.githubusercontent.com/9755598/140229858-1d17804d-bddc-4e31-8d95-22ece676c07c.png)


# Ticket
https://ethyca.atlassian.net/browse/SOL-269 (old, internal ticket) 