### PR TITLE
Upgrade Dask to 2021.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pydash==5.0.2
 boto3~=1.18.14
 cryptography~=3.4.8
 fastapi-pagination[sqlalchemy]~= 0.8.3
-dask==2021.9.0
+dask==2021.10.0
 requests~=2.25.0
 pymongo==3.12.0
 pandas==1.3.3


### PR DESCRIPTION
# Purpose
Dask 2021.9.0 and earlier has a critical security vulnerability in the usage of `dask.distributed`; see #32 for details

# Changes

- Upgrades to latest `dask`

# Ticket
Fixes #32