### PR TITLE
Fix Dockerfile importlib.metadata.PackageNotFoundError: fidesops [#23]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN pip install -r requirements.txt
 RUN pip install -r dev-requirements.txt
 
 # Copy in the application files and install it locally
-COPY . /fidesops
-WORKDIR /fidesops
+COPY . /fidesops_install
+WORKDIR /fidesops_install
 RUN pip install -e .
+
+WORKDIR /fidesops
 
 CMD [ "fidesops", "webserver" ]


### PR DESCRIPTION
# Purpose
Fix `fidesops` not getting installed with `make server`:
```
fidesops    | Traceback (most recent call last):
fidesops    |   File "/usr/local/bin/fidesops", line 33, in <module>
fidesops    |     sys.exit(load_entry_point('fidesops', 'console_scripts', 'fidesops')())
fidesops    |   File "/usr/local/bin/fidesops", line 22, in importlib_load_entry_point
fidesops    |     for entry_point in distribution(dist_name).entry_points
fidesops    |   File "/usr/local/lib/python3.9/importlib/metadata.py", line 524, in distribution
fidesops    |     return Distribution.from_name(distribution_name)
fidesops    |   File "/usr/local/lib/python3.9/importlib/metadata.py", line 187, in from_name
fidesops    |     raise PackageNotFoundError(name)
fidesops    | importlib.metadata.PackageNotFoundError: fidesops
```
The culprit appears to be the bind mount in `docker-compose.yml`:
```yaml
    fidesops:
      ...
      volumes:
        - type: bind
          source: ./
          target: /fidesops
          read_only: False
```

# Changes

Set the working directory to `fidesops` _after_ it installed.  It seems like `docker-compose` is bind mounting a local directory to `/fidesops` which is useful for reloading, but then we can't find the package source when we're trying to install.

# Ticket
Fixes #23