### PR TITLE
Require ConnectionConfig Write Access to Mask Data [#40]

### DIFF
--- a/src/fidesops/task/graph_task.py
+++ b/src/fidesops/task/graph_task.py
@@ -18,7 +18,7 @@ from fidesops.graph.config import (
 )
 from fidesops.graph.graph import Edge, DatasetGraph
 from fidesops.graph.traversal import TraversalNode, Row, Traversal
-from fidesops.models.connectionconfig import ConnectionConfig
+from fidesops.models.connectionconfig import ConnectionConfig, AccessLevel
 from fidesops.models.policy import ActionType, Policy
 from fidesops.models.privacy_request import PrivacyRequest, ExecutionLogStatus
 from fidesops.service.connectors import BaseConnector
@@ -122,6 +122,11 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
     def generate_dry_run_query(self) -> str:
         """Type-specific query generated for this traversal_node."""
         return self.connector.dry_run_query(self.traversal_node)
+
+    def can_write_data(self) -> bool:
+        """Checks if the relevant ConnectionConfig has been granted "write" access to its data"""
+        connection_config = self.connector.configuration
+        return connection_config.access == AccessLevel.write
 
     def to_dask_input_data(self, *data: List[Row]) -> Dict[str, List[Any]]:
         """Each dict in the input list represents the output of a dependent task.
@@ -230,6 +235,16 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
                 None,
                 ActionType.erasure,
                 ExecutionLogStatus.complete,
+            )
+            return 0
+
+        if not self.can_write_data():
+            self.update_status(
+                f"No values were erased since this connection {self.connector.configuration.key} has not been "
+                f"given write access",
+                None,
+                ActionType.erasure,
+                ExecutionLogStatus.error,
             )
             return 0
 

--- a/src/fidesops/task/graph_task.py
+++ b/src/fidesops/task/graph_task.py
@@ -125,7 +125,7 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
 
     def can_write_data(self) -> bool:
         """Checks if the relevant ConnectionConfig has been granted "write" access to its data"""
-        connection_config = self.connector.configuration
+        connection_config: ConnectionConfig = self.connector.configuration
         return connection_config.access == AccessLevel.write
 
     def to_dask_input_data(self, *data: List[Row]) -> Dict[str, List[Any]]:

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -368,6 +368,7 @@ class TestCreatePrivacyRequest:
         stmt = select(
             column("id"),
             column("email"),
+            column("name"),
         ).select_from(table("customer"))
         res = integration_db.execute(stmt).all()
 
@@ -379,6 +380,7 @@ class TestCreatePrivacyRequest:
                 # ("user.provided.identifiable.contact.email") has been erased by the parent
                 # category ("user.provided.identifiable.contact")
                 assert row[1] is None
+                assert row[2] is not None
             else:
                 # There are two rows other rows, and they should not have been erased
                 assert row[1] in ["customer-1@example.com", "jane@example.com"]
@@ -455,8 +457,8 @@ class TestCreatePrivacyRequest:
         generate_auth_header,
         erasure_policy,
     ):
-        customer_email = "customer-1@example.com"
-        customer_id = 1
+        customer_email = "customer-2@example.com"
+        customer_id = 2
         data = [
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -13,7 +13,9 @@ from fastapi_pagination import Params
 import pytest
 from starlette.testclient import TestClient
 
-from fidesops.api.v1.endpoints.privacy_request_endpoints import EMBEDDED_EXECUTION_LOG_LIMIT
+from fidesops.api.v1.endpoints.privacy_request_endpoints import (
+    EMBEDDED_EXECUTION_LOG_LIMIT,
+)
 from fidesops.api.v1.urn_registry import (
     PRIVACY_REQUESTS,
     V1_URL_PREFIX,
@@ -29,7 +31,11 @@ from fidesops.db.session import (
     get_db_session,
 )
 from fidesops.models.client import ClientDetail
-from fidesops.models.privacy_request import PrivacyRequest, ExecutionLog, ExecutionLogStatus
+from fidesops.models.privacy_request import (
+    PrivacyRequest,
+    ExecutionLog,
+    ExecutionLogStatus,
+)
 from fidesops.models.policy import DataCategory, ActionType
 from fidesops.schemas.dataset import DryRunDatasetResponse
 from fidesops.util.cache import get_identity_cache_key
@@ -228,7 +234,7 @@ class TestCreatePrivacyRequest:
     @pytest.mark.integration
     def test_create_and_process_access_request(
         self,
-        postgres_example_test_dataset_config,
+        postgres_example_test_dataset_config_read_access,
         url,
         db,
         api_client: TestClient,
@@ -255,7 +261,9 @@ class TestCreatePrivacyRequest:
             assert results[key] is not None
             assert results[key] != {}
 
-        result_key_prefix = f"EN_{pr.id}__access_request__postgres_example_test_dataset:"
+        result_key_prefix = (
+            f"EN_{pr.id}__access_request__postgres_example_test_dataset:"
+        )
         customer_key = result_key_prefix + "customer"
         assert results[customer_key][0]["email"] == customer_email
 
@@ -436,6 +444,62 @@ class TestCreatePrivacyRequest:
                 assert row[4] is None
 
         assert card_found is True
+
+    @pytest.mark.integration_erasure
+    def test_create_and_process_erasure_request_read_access(
+        self,
+        postgres_example_test_dataset_config_read_access,
+        url,
+        db,
+        api_client: TestClient,
+        generate_auth_header,
+        erasure_policy,
+    ):
+        customer_email = "customer-1@example.com"
+        customer_id = 1
+        data = [
+            {
+                "requested_at": "2021-08-30T16:09:37.359Z",
+                "policy_key": erasure_policy.key,
+                "identities": [{"email": customer_email}],
+            }
+        ]
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
+        resp = api_client.post(url, json=data, headers=auth_header)
+
+        assert resp.status_code == 200
+        response_data = resp.json()["succeeded"]
+        assert len(response_data) == 1
+        pr = PrivacyRequest.get(db=db, id=response_data[0]["id"])
+        errored_execution_logs = pr.execution_logs.filter_by(status="error")
+        assert errored_execution_logs.count() == 9
+        assert (
+            errored_execution_logs[0].message
+            == "No values were erased since this connection "
+            "my-postgres-db-1-read-config has not been given write access"
+        )
+        pr.delete(db=db)
+
+        example_postgres_uri = (
+            "postgresql://postgres:postgres@postgres_example/postgres_example"
+        )
+        engine = get_db_engine(database_uri=example_postgres_uri)
+        SessionLocal = get_db_session(engine=engine)
+        integration_db = SessionLocal()
+        stmt = select(
+            column("id"),
+            column("name"),
+        ).select_from(table("customer"))
+        res = integration_db.execute(stmt).all()
+
+        customer_found = False
+        for row in res:
+            if customer_id in row:
+                customer_found = True
+                # Check that the `name` field is NOT `None`. We couldn't erase, because the ConnectionConfig only had
+                # "read" access
+                assert row[1] is not None
+        assert customer_found
 
 
 class TestGetPrivacyRequests:
@@ -750,12 +814,12 @@ class TestGetPrivacyRequests:
         assert resp == expected_resp
 
     def test_verbose_privacy_request_embed_limit(
-            self,
-            db,
-            api_client: TestClient,
-            generate_auth_header,
-            privacy_request: PrivacyRequest,
-            url,
+        self,
+        db,
+        api_client: TestClient,
+        generate_auth_header,
+        privacy_request: PrivacyRequest,
+        url,
     ):
         for i in range(0, EMBEDDED_EXECUTION_LOG_LIMIT + 10):
             ExecutionLog.create(
@@ -775,8 +839,13 @@ class TestGetPrivacyRequests:
         assert 200 == response.status_code
 
         resp = response.json()
-        assert len(resp["items"][0]["results"]["my-postgres-db"]) == EMBEDDED_EXECUTION_LOG_LIMIT
-        db.query(ExecutionLog).filter(ExecutionLog.privacy_request_id==privacy_request.id).delete()
+        assert (
+            len(resp["items"][0]["results"]["my-postgres-db"])
+            == EMBEDDED_EXECUTION_LOG_LIMIT
+        )
+        db.query(ExecutionLog).filter(
+            ExecutionLog.privacy_request_id == privacy_request.id
+        ).delete()
 
 
 class TestGetExecutionLogs:

--- a/tests/integration_fixtures.py
+++ b/tests/integration_fixtures.py
@@ -114,7 +114,7 @@ def integration_postgres_config() -> ConnectionConfig:
         name="postgres_test",
         key="postgres_example",
         connection_type=ConnectionType.postgres,
-        access=AccessLevel.read,
+        access=AccessLevel.write,
         secrets={
             "host": postgres_conf["SERVER"],
             "port": postgres_conf["PORT"],
@@ -167,7 +167,7 @@ def integration_mongodb_config(set_os_env: None) -> ConnectionConfig:
     return ConnectionConfig(
         key="mongo_example",
         connection_type=ConnectionType.mongodb,
-        access=AccessLevel.read,
+        access=AccessLevel.write,
         secrets={
             "host": mongo_conf["SERVER"],
             "defaultauthdb": mongo_conf["DB"],


### PR DESCRIPTION
# Purpose

Currently the query builder will still try to generate erasure statements for database tables that the configured connection has no write access to. If no write access is granted, Fidesops should not generate these statements or try to execute them.

# Changes

- Add a check in `GraphTask. erasure_request` that verifies that the related `ConnectionConfig` for the particular TraversalNode has `write_access` or it skips building and executing an update statement. 
- Fixes some of our integration erasure unit tests that were using connection configs with read access

# Ticket
Resolves https://github.com/ethyca/fidesops/issues/40