### PR TITLE
Fix Hot Reloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,4 @@ COPY . /fidesops
 WORKDIR /fidesops
 RUN pip install -e .
 
-WORKDIR /fidesops
-
 CMD [ "fidesops", "webserver" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN pip install -r requirements.txt
 RUN pip install -r dev-requirements.txt
 
 # Copy in the application files and install it locally
-COPY . /fidesops_install
-WORKDIR /fidesops_install
+COPY . /fidesops
+WORKDIR /fidesops
 RUN pip install -e .
 
 WORKDIR /fidesops

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         source: ./
         target: /fidesops
         read_only: False
+      - /fidesops/src/fidesops.egg-info
 
   db:
     image: postgres:12


### PR DESCRIPTION
# Purpose

Fix hot reloading again, while making sure the solution doesn't cause `importlib.metadata.PackageNotFoundError: fidesops`.  A fix to one can break the other and vice versa.

While we improved hot reloading recently, https://github.com/ethyca/fidesops/pull/18, a separate fix to build the python package for fidesops on a fresh install https://github.com/ethyca/fidesops/pull/48 broke hot reloading again (it looks like watchgod is working, but it's deceptive, the actual file changes aren't reloaded). 


# Changes

- Whitelist the `.egg-info` directory to keep the copy of fidesops on the host machine from overriding it, so when we do `make server` we can find the fidesops package.
- Revert Dockerfile to make the WORKDIR be '/fidesops` before building the python package for fidesops, which we seem to need for reloading.

# To test
- On a fresh install of fidesops, make sure that package is installed when you do `pip list`
- On a completely fresh install run `make server` and make sure 1) fidesops gets installed properly and 2) hit an API endpoint, make a change to that endpoint and hit the endpoint again and make sure the actual file changes were reloaded and are reflected in the response

## Notes
These resources were super useful:
- https://jbhannah.net/articles/python-docker-disappearing-egg-info (for understanding what is happening)
- https://stackoverflow.com/questions/47914261/docker-volume-bind-breaks-python-script-cli-entry-point (for pointing me towards a fix)

# Ticket
[unticketed]
