### PR TITLE
closes #36- masks params provided in % str formatter in logs, unless set otherwise

### DIFF
--- a/docs/fidesops/docs/development/overview.md
+++ b/docs/fidesops/docs/development/overview.md
@@ -30,6 +30,7 @@ commands to give you different functionality.
   - `ipython` - open a Python shell
 - `make pytest` - runs all unit tests except those that talk to integration databases
 - `make pytest-integration-access` - runs access integration tests
+- `make pytest-integration-erasure` - runs erasure integration tests
 - `make reset-db` - tears down the Fideops postgres db, then recreates and re-runs migrations.
 - `make quickstart` - runs a quick, five second quickstart that talks to the Fidesops API to execute privacy requests
 - `make check-migrations` - verifies there are no un-run migrations 

--- a/docs/fidesops/docs/tutorial/outline.md
+++ b/docs/fidesops/docs/tutorial/outline.md
@@ -16,7 +16,6 @@ import yaml
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 # For tutorial simplicity. In prod, this should go in an ENV file or similar.
 FIDESOPS_URL = "http://localhost:8000"

--- a/src/fidesops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_endpoints.py
@@ -192,7 +192,9 @@ def connection_status(
     try:
         connector.test_connection()
     except ConnectionException as exc:
-        logger.warning("Connection test failed on %s: %s", NotPii(connection_config.key), str(exc))
+        logger.warning(
+            "Connection test failed on %s: %s", NotPii(connection_config.key), str(exc)
+        )
         connection_config.update_test_status(succeeded=False, db=db)
         return TestStatusMessage(
             msg=msg,

--- a/src/fidesops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_endpoints.py
@@ -32,6 +32,7 @@ from fidesops.api.v1.scope_registry import (
     CONNECTION_DELETE,
     CONNECTION_CREATE_OR_UPDATE,
 )
+from fidesops.util.logger import NotPii
 from fidesops.util.oauth_util import verify_oauth_client
 from fidesops.api import deps
 from fidesops.models.connectionconfig import ConnectionConfig
@@ -191,7 +192,7 @@ def connection_status(
     try:
         connector.test_connection()
     except ConnectionException as exc:
-        logger.warning(f"Connection test failed on {connection_config.key}: {str(exc)}")
+        logger.warning("Connection test failed on %s: %s", NotPii(connection_config.key), str(exc))
         connection_config.update_test_status(succeeded=False, db=db)
         return TestStatusMessage(
             msg=msg,

--- a/src/fidesops/api/v1/endpoints/policy_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/policy_endpoints.py
@@ -120,7 +120,7 @@ def create_or_update_policies(
                 },
             )
         except KeyOrNameAlreadyExists as exc:
-            logger.warning(f"Create/update failed for policy: {exc}")
+            logger.warning("Create/update failed for policy: %s", exc)
             failure = {
                 "message": exc.args[0],
                 "data": policy_data,
@@ -128,7 +128,7 @@ def create_or_update_policies(
             failed.append(BulkUpdateFailed(**failure))
             continue
         except PolicyValidationError as exc:
-            logger.warning(f"Create/update failed for policy: {exc}")
+            logger.warning("Create/update failed for policy: %s", exc)
             failure = {
                 "message": "This record could not be added because the data provided was invalid.",
                 "data": policy_data,

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -137,14 +137,14 @@ def create_privacy_request(
                 privacy_request=privacy_request,
             ).run()
         except common_exceptions.RedisConnectionError as exc:
-            logger.error(exc)
+            logger.error("RedisConnectionError: %s", exc)
             # Thrown when cache.ping() fails on cache connection retrieval
             raise HTTPException(
                 status_code=HTTP_424_FAILED_DEPENDENCY,
                 detail=exc.args[0],
             )
         except Exception as exc:
-            logger.error(exc)
+            logger.error("Exception: %s", exc)
             failure = {
                 "message": "This record could not be added",
                 "data": kwargs,

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -17,6 +17,7 @@ from pydantic import (
 from pydantic.env_settings import SettingsSourceCallable
 
 from fidesops.common_exceptions import MissingConfig
+from fidesops.util.logger import NotPii
 
 logger = logging.getLogger(__name__)
 
@@ -201,9 +202,9 @@ def load_file(file_name: str) -> str:
     for dir_str in directories:
         possible_location = os.path.join(dir_str, file_name)
         if possible_location and os.path.isfile(possible_location):
-            logger.info("Loading file %s from %s", file_name, dir_str)
+            logger.info("Loading file %s from %s", NotPii(file_name), NotPii(dir_str))
             return possible_location
-        logger.debug("%s not found at %s", file_name, dir_str)
+        logger.debug("%s not found at %s", NotPii(file_name), NotPii(dir_str))
     raise FileNotFoundError
 
 
@@ -229,7 +230,7 @@ def get_config() -> FidesopsConfig:
     try:
         return FidesopsConfig.parse_obj(load_toml("fidesops.toml"))
     except (FileNotFoundError, ValidationError) as e:
-        logger.warning("fidesops.toml could not be loaded: %s", e)
+        logger.warning("fidesops.toml could not be loaded: %s", NotPii(e))
         # If no path is specified Pydantic will attempt to read settings from
         # the environment. Default values will still be used if the matching
         # environment variable is not set.

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -237,7 +237,7 @@ def get_config() -> FidesopsConfig:
         try:
             return FidesopsConfig()
         except ValidationError as exc:
-            logger.error(exc)
+            logger.error("ValidationError: %s", exc)
             # If FidesopsConfig is missing any required values Pydantic will throw
             # an ImportError. This means the config has not been correctly specified
             # so we can throw the missing config error.

--- a/src/fidesops/db/session.py
+++ b/src/fidesops/db/session.py
@@ -48,7 +48,7 @@ class ExtendedSession(Session):
         try:
             return super().commit()
         except Exception as exc:
-            logger.error(exc)
+            logger.error("Exception: %s", exc)
             # Rollback the current transaction after each failed commit
             self.rollback()
             raise

--- a/src/fidesops/graph/graph.py
+++ b/src/fidesops/graph/graph.py
@@ -15,7 +15,6 @@ from fidesops.graph.config import (
     Field,
 )
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/fidesops/graph/traversal.py
+++ b/src/fidesops/graph/traversal.py
@@ -14,10 +14,10 @@ from fidesops.graph.config import (
     ROOT_COLLECTION_ADDRESS,
 )
 from fidesops.graph.graph import Node, Edge, DatasetGraph
+from fidesops.util.logger import NotPii
 from fidesops.util.queue import Queue
 from fidesops.util.collection_util import append
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -174,7 +174,7 @@ class Traversal:
         and raises an error on any traversal failure conditions."""
         self.traverse(
             {self.root_node.address: [self.seed_data]},
-            lambda n, m: logger.info("Traverse %s", n.address),
+            lambda n, m: logger.info("Traverse %s", NotPii(n.address)),
         )
 
     def traversal_map(

--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -8,8 +8,10 @@ from fidesops.api.v1.urn_registry import V1_URL_PREFIX
 from fidesops.db.database import init_db
 from fidesops.core.config import config
 from fidesops.tasks.scheduled.tasks import initiate_scheduled_request_intake
+from fidesops.util.logger import get_fides_log_record_factory
 
 logging.basicConfig(level=logging.INFO)
+logging.setLogRecordFactory(get_fides_log_record_factory())
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="fidesops", openapi_url=f"{V1_URL_PREFIX}/openapi.json")

--- a/src/fidesops/models/datasetconfig.py
+++ b/src/fidesops/models/datasetconfig.py
@@ -21,6 +21,7 @@ from fidesops.graph.config import (
 )
 from fidesops.models.connectionconfig import ConnectionConfig
 from fidesops.schemas.dataset import FidesopsDataset, FidesopsDatasetField
+from fidesops.util.logger import NotPii
 
 logger = logging.getLogger(__name__)
 
@@ -144,9 +145,9 @@ def convert_dataset_to_graph(dataset: FidesopsDataset, connection_key: str) -> D
         ]
         logger.debug(
             "Parsing dataset %s: parsed collection %s with %s fields",
-            dataset_name,
-            collection.name,
-            len(graph_fields),
+            NotPii(dataset_name),
+            NotPii(collection.name),
+            NotPii(len(graph_fields)),
         )
         collection_after: Set[CollectionAddress] = set()
         if collection.fidesops_meta and collection.fidesops_meta.after:
@@ -160,8 +161,8 @@ def convert_dataset_to_graph(dataset: FidesopsDataset, connection_key: str) -> D
         graph_collections.append(graph_collection)
     logger.debug(
         "Finished parsing dataset %s with %s collections",
-        dataset_name,
-        len(graph_collections),
+        NotPii(dataset_name),
+        NotPii(len(graph_collections)),
     )
 
     return Dataset(

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -1,5 +1,4 @@
 # pylint: disable=R0401
-import logging
 from typing import Any, Dict
 
 from enum import Enum as EnumType
@@ -25,8 +24,6 @@ from fidesops.util.cache import (
     get_identity_cache_key,
     FidesopsRedis,
 )
-
-logging.basicConfig(level=logging.INFO)
 
 
 class PrivacyRequestStatus(EnumType):

--- a/src/fidesops/models/storage.py
+++ b/src/fidesops/models/storage.py
@@ -103,7 +103,7 @@ class StorageConfig(Base):
             KeyError,
             ValidationError,
         ) as exc:
-            logger.error(exc)
+            logger.error("Error: %s", exc)
             # We don't want to handle these explicitly here, only in the API view
             raise
 

--- a/src/fidesops/service/connectors/base_connector.py
+++ b/src/fidesops/service/connectors/base_connector.py
@@ -7,7 +7,6 @@ from fidesops.models.connectionconfig import ConnectionConfig
 from fidesops.models.policy import Policy
 from fidesops.service.connectors.query_config import QueryConfig
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -52,13 +51,7 @@ class BaseConnector(ABC):
         each input key that may be queried on."""
 
     @abstractmethod
-    def mask_data(
-        self,
-        node: TraversalNode,
-        policy: Policy,
-        rows: List[Row],
-        log_queries_with_data: bool = False,
-    ) -> int:
+    def mask_data(self, node: TraversalNode, policy: Policy, rows: List[Row]) -> int:
         """Execute a masking request. Return the number of rows that have been updated"""
 
     def dry_run_query(self, node: TraversalNode) -> str:

--- a/src/fidesops/service/connectors/mongodb_connector.py
+++ b/src/fidesops/service/connectors/mongodb_connector.py
@@ -14,8 +14,8 @@ from fidesops.service.connectors.base_connector import (
     BaseConnector,
 )
 from fidesops.service.connectors.query_config import QueryConfig, MongoQueryConfig
+from fidesops.util.logger import NotPii
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -100,13 +100,7 @@ class MongoDBConnector(BaseConnector):
         logger.info(f"Found {len(rows)} on {node.address}")
         return rows
 
-    def mask_data(
-        self,
-        node: TraversalNode,
-        policy: Policy,
-        rows: List[Row],
-        log_queries_with_data: bool = True,
-    ) -> int:
+    def mask_data(self, node: TraversalNode, policy: Policy, rows: List[Row]) -> int:
         # pylint: disable=too-many-locals
         """Execute a masking request"""
         query_config = self.query_config(node)
@@ -121,10 +115,11 @@ class MongoDBConnector(BaseConnector):
                 collection = db[collection_name]
                 update_result = collection.update_one(query, update, upsert=False)
                 update_ct += update_result.modified_count
-
-                if log_queries_with_data:
-                    logger.info(
-                        f"db.{collection_name}.update_one({query}, {update}, upsert=False)"
-                    )
+                logger.info(
+                    "db.%s.update_one(%s, %s, upsert=False)",
+                    NotPii(collection_name),
+                    query,
+                    update,
+                )
 
         return update_ct

--- a/src/fidesops/service/connectors/query_config.py
+++ b/src/fidesops/service/connectors/query_config.py
@@ -12,7 +12,6 @@ from fidesops.models.policy import Policy, ActionType, Rule
 from fidesops.service.masking.strategy.masking_strategy_factory import get_strategy
 from fidesops.util.collection_util import append
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
 

--- a/src/fidesops/service/connectors/sql_connector.py
+++ b/src/fidesops/service/connectors/sql_connector.py
@@ -18,7 +18,6 @@ from fidesops.service.connectors.base_connector import (
 )
 from fidesops.service.connectors.query_config import SQLQueryConfig
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -82,13 +81,7 @@ class SQLConnector(BaseConnector):
             results = connection.execute(stmt)
             return SQLConnector.cursor_result_to_rows(results)
 
-    def mask_data(
-        self,
-        node: TraversalNode,
-        policy: Policy,
-        rows: List[Row],
-        log_queries_with_data: bool = True,
-    ) -> int:
+    def mask_data(self, node: TraversalNode, policy: Policy, rows: List[Row]) -> int:
         """Execute a masking request. Returns the number of records masked"""
         query_config = self.query_config(node)
         update_ct = 0

--- a/src/fidesops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/service/privacy_request/request_runner_service.py
@@ -18,8 +18,6 @@ from fidesops.task.graph_task import (
 )
 from fidesops.util.cache import FidesopsRedis
 
-logging.basicConfig(level=logging.INFO)
-
 
 class PrivacyRequestRunner:
     """The class responsible for dispatching PrivacyRequests into the execution layer"""

--- a/src/fidesops/task/graph_task.py
+++ b/src/fidesops/task/graph_task.py
@@ -249,7 +249,7 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
             return 0
 
         output = self.connector.mask_data(
-            self.traversal_node, self.resources.policy, retrieved_data, True
+            self.traversal_node, self.resources.policy, retrieved_data
         )
         self.log_end(ActionType.erasure)
         return output

--- a/src/fidesops/task/graph_task.py
+++ b/src/fidesops/task/graph_task.py
@@ -24,8 +24,8 @@ from fidesops.models.privacy_request import PrivacyRequest, ExecutionLogStatus
 from fidesops.service.connectors import BaseConnector
 from fidesops.task.task_resources import TaskResources
 from fidesops.util.collection_util import partition, append
+from fidesops.util.logger import NotPii
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 dask.config.set(scheduler="processes")
@@ -142,9 +142,9 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
         if not len(data) == len(self.input_keys):
             logger.warning(
                 "%s expected %s input keys, received %s",
-                self,
-                len(self.input_keys),
-                len(data),
+                NotPii(self),
+                NotPii(len(self.input_keys)),
+                NotPii(len(data)),
             )
 
         output: Dict[str, List[Any]] = {}

--- a/src/fidesops/task/task_resources.py
+++ b/src/fidesops/task/task_resources.py
@@ -18,7 +18,6 @@ from fidesops.service.connectors import (
 )
 from fidesops.util.cache import get_cache
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Union, Optional
 
 MASKED = "MASKED"
 
@@ -23,14 +23,16 @@ def get_fides_log_record_factory() -> Any:
         func: str = None,
         sinfo: str = None,
     ) -> logging.LogRecord:
-        masked_args: tuple[Any, ...] = tuple(_mask_pii_for_logs(arg) for arg in args)
+        env_log_pii: bool = os.getenv("LOG_PII") == "True"
+        if not env_log_pii:
+            args: tuple[Any, ...] = tuple(_mask_pii_for_logs(arg) for arg in args)
         return logging.LogRecord(
             name=name,
             level=level,
             pathname=fn,
             lineno=lno,
             msg=msg,
-            args=masked_args,
+            args=args,
             exc_info=exc_info,
             func=func,
             sinfo=sinfo,
@@ -44,8 +46,6 @@ def _mask_pii_for_logs(pii_text: Any) -> Any:
     :param pii_text: param that contains possible pii
     :return: depending on ENV config, returns masked pii param
     """
-    if os.getenv("LOG_PII") == "True":
-        return pii_text
     if isinstance(pii_text, NotPii):
         return pii_text
     return MASKED

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,0 +1,51 @@
+import logging
+import os
+from typing import Any, Mapping, Union
+
+MASKED = "MASKED"
+
+
+class NotPii(str):
+    """whitelist non pii data"""
+
+
+def get_fides_log_record_factory() -> Any:
+    """intercepts default LogRecord for custom handling of params"""
+
+    def factory(  # pylint: disable=R0913
+        name: str,
+        level: int,
+        fn: str,
+        lno: int,
+        msg: str,
+        args: Union[tuple[Any, ...], Mapping[str, Any]],
+        exc_info: Any,
+        func: str = None,
+        sinfo: str = None,
+    ) -> logging.LogRecord:
+        masked_args: tuple[Any, ...] = tuple(_mask_pii_for_logs(arg) for arg in args)
+        return logging.LogRecord(
+            name=name,
+            level=level,
+            pathname=fn,
+            lineno=lno,
+            msg=msg,
+            args=masked_args,
+            exc_info=exc_info,
+            func=func,
+            sinfo=sinfo,
+        )
+
+    return factory
+
+
+def _mask_pii_for_logs(pii_text: Any) -> Any:
+    """
+    :param pii_text: param that contains possible pii
+    :return: depending on ENV config, returns masked pii param
+    """
+    if os.getenv("LOG_PII") == "True":
+        return pii_text
+    if isinstance(pii_text, NotPii):
+        return pii_text
+    return MASKED

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Mapping, Union, Optional
+from typing import Any, Mapping, Union
 
 MASKED = "MASKED"
 
@@ -24,15 +24,16 @@ def get_fides_log_record_factory() -> Any:
         sinfo: str = None,
     ) -> logging.LogRecord:
         env_log_pii: bool = os.getenv("LOG_PII") == "True"
+        new_args = args
         if not env_log_pii:
-            args: tuple[Any, ...] = tuple(_mask_pii_for_logs(arg) for arg in args)
+            new_args = tuple(_mask_pii_for_logs(arg) for arg in args)
         return logging.LogRecord(
             name=name,
             level=level,
             pathname=fn,
             lineno=lno,
             msg=msg,
-            args=args,
+            args=new_args,
             exc_info=exc_info,
             func=func,
             sinfo=sinfo,

--- a/tests/integration_tests/test_sql_task.py
+++ b/tests/integration_tests/test_sql_task.py
@@ -30,7 +30,6 @@ from ..graph.graph_test_util import (
 from ..task.traversal_data import integration_db_graph, integration_db_dataset
 
 dask.config.set(scheduler="processes")
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 sample_postgres_configuration_policy = erasure_policy(
     "system.operations",

--- a/tests/util/test_logger.py
+++ b/tests/util/test_logger.py
@@ -1,5 +1,3 @@
-import os
-
 from fidesops.util import logger
 from fidesops.util.logger import NotPii, MASKED
 
@@ -8,14 +6,6 @@ def test_logger_masks_pii() -> None:
     some_data = "some_data"
     result = logger._mask_pii_for_logs(some_data)
     assert result == MASKED
-
-
-def test_logger_does_not_mask_pii_env() -> None:
-    os.environ["LOG_PII"] = "True"
-    some_data = "some_data"
-    result = logger._mask_pii_for_logs(some_data)
-    assert result == some_data
-    os.environ["LOG_PII"] = "False"
 
 
 def test_logger_does_not_mask_whitelist() -> None:

--- a/tests/util/test_logger.py
+++ b/tests/util/test_logger.py
@@ -1,0 +1,24 @@
+import os
+
+from fidesops.util import logger
+from fidesops.util.logger import NotPii, MASKED
+
+
+def test_logger_masks_pii() -> None:
+    some_data = "some_data"
+    result = logger._mask_pii_for_logs(some_data)
+    assert result == MASKED
+
+
+def test_logger_does_not_mask_pii_env() -> None:
+    os.environ["LOG_PII"] = "True"
+    some_data = "some_data"
+    result = logger._mask_pii_for_logs(some_data)
+    assert result == some_data
+    os.environ["LOG_PII"] = "False"
+
+
+def test_logger_does_not_mask_whitelist() -> None:
+    some_data = NotPii("some_data")
+    result = logger._mask_pii_for_logs(some_data)
+    assert result == some_data


### PR DESCRIPTION
# Purpose
Allows logging pii to be configurable via env variable

# Changes
- Removes superfluous `logging.basicConfig()` statements, since it only needs to be set at root logger level (`src/fidesops/main.py`). More details here- https://docs.python.org/3/library/logging.html#logging.basicConfig
- Adds custom log factory that masks pii values by default (see https://docs.python.org/3/library/logging.html#logging.LogRecord.getMessage), unless one of the following is true:
1. `LOG_PII` env var is set to `True`
2. The arg is explicitly white-labeled as `NotPii`
- Adds tests for custom log factory ^

# Ticket
https://github.com/ethyca/fidesops/issues/36