### PR TITLE
log fix

### DIFF
--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -51,6 +51,6 @@ def _mask_pii_for_logs(parameter: Any) -> Any:
     Don't mask numeric values as this can throw errors in consumers
     format strings.
     """
-    if isinstance(parameter,(NotPii,Number)):
+    if isinstance(parameter, (NotPii, Number)):
         return parameter
     return MASKED

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -51,6 +51,6 @@ def _mask_pii_for_logs(parameter: Any) -> Any:
     Don't mask numeric values as this can throw errors in consumers
     format strings.
     """
-    if isinstance(parameter, NotPii) or isinstance(parameter, Number):
+    if isinstance(parameter,(NotPii,Number)):
         return parameter
     return MASKED

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import Any, Mapping, Union
+from numbers import Number
 
 MASKED = "MASKED"
 
@@ -42,11 +43,14 @@ def get_fides_log_record_factory() -> Any:
     return factory
 
 
-def _mask_pii_for_logs(pii_text: Any) -> Any:
+def _mask_pii_for_logs(parameter: Any) -> Any:
     """
-    :param pii_text: param that contains possible pii
-    :return: depending on ENV config, returns masked pii param
+    :param parameter: param that contains possible pii
+    :return: depending on ENV config, returns masked pii param.
+
+    Don't mask numeric values as this can throw errors in consumers
+    format strings.
     """
-    if isinstance(pii_text, NotPii):
-        return pii_text
+    if isinstance(parameter, NotPii) or isinstance(parameter, Number):
+        return parameter
     return MASKED

--- a/tests/api/v1/endpoints/test_encryption_endpoints.py
+++ b/tests/api/v1/endpoints/test_encryption_endpoints.py
@@ -152,7 +152,11 @@ class TestAESDecrypt:
         orig_data = "test_data"
         encrypted_data = encrypt(orig_data, key.encode(config.security.ENCODING), nonce)
 
-        request = {"value": encrypted_data, "key": key, "nonce": bytes_to_b64_str(nonce)}
+        request = {
+            "value": encrypted_data,
+            "key": key,
+            "nonce": bytes_to_b64_str(nonce),
+        }
 
         response = api_client.put(
             url,

--- a/tests/service/storage_uploader_service_test.py
+++ b/tests/service/storage_uploader_service_test.py
@@ -31,7 +31,10 @@ from fidesops.tasks.storage import (
     encrypt_access_request_results,
 )
 from fidesops.common_exceptions import StorageUploadError
-from fidesops.util.encryption.aes_gcm_encryption_scheme import decrypt, decrypt_combined_nonce_and_message
+from fidesops.util.encryption.aes_gcm_encryption_scheme import (
+    decrypt,
+    decrypt_combined_nonce_and_message,
+)
 
 
 @mock.patch("fidesops.service.storage.storage_uploader_service.upload_to_s3")
@@ -387,7 +390,9 @@ class TestWriteToInMemoryBuffer:
         assert isinstance(buff, BytesIO)
         encrypted = buff.read()
         data = encrypted.decode(config.security.ENCODING)
-        decrypted = decrypt_combined_nonce_and_message(data, self.key.encode(config.security.ENCODING))
+        decrypted = decrypt_combined_nonce_and_message(
+            data, self.key.encode(config.security.ENCODING)
+        )
         assert json.loads(decrypted) == original_data
 
     def test_encrypted_csv(self, data, privacy_request_with_encryption_keys):
@@ -401,7 +406,9 @@ class TestWriteToInMemoryBuffer:
         with zipfile.open("mongo:address.csv", "r") as address_csv:
             data = address_csv.read().decode(config.security.ENCODING)
 
-            decrypted = decrypt_combined_nonce_and_message(data, self.key.encode(config.security.ENCODING))
+            decrypted = decrypt_combined_nonce_and_message(
+                data, self.key.encode(config.security.ENCODING)
+            )
 
             binary_stream = BytesIO(decrypted.encode(config.security.ENCODING))
             df = pd.read_csv(binary_stream, encoding=config.security.ENCODING)
@@ -435,7 +442,9 @@ class TestEncryptResultsPackage:
         privacy_request.cache_encryption("abvnfhrke8398398")
         data = "test data"
         ret = encrypt_access_request_results(data, request_id=privacy_request.id)
-        decrypted = decrypt_combined_nonce_and_message(ret, key.encode(config.security.ENCODING))
+        decrypted = decrypt_combined_nonce_and_message(
+            ret, key.encode(config.security.ENCODING)
+        )
         assert data == decrypted
 
 


### PR DESCRIPTION
# Purpose
Fixes errors raised in uvicorn (and any consumed library) that uses our logger when our masking logger improperly converts values to strings.

# Changes
- logger does not mask any numeric types. 

# Ticket
Closes #88 