### PR TITLE
Set AUTOCOMMIT on the DB engine [unticketed]

### DIFF
--- a/src/fidesops/db/session.py
+++ b/src/fidesops/db/session.py
@@ -14,7 +14,10 @@ from fidesops.core.config import config
 logger = logging.getLogger(__name__)
 
 
-def get_db_engine(database_uri: Optional[str] = None) -> Engine:
+def get_db_engine(
+    database_uri: Optional[str] = None,
+    isolation_level: Optional[str] = "AUTOCOMMIT",
+) -> Engine:
     """
     Return a database engine. If the TESTING environment var is set the
     database engine returned will be connected to the test DB.
@@ -27,7 +30,11 @@ def get_db_engine(database_uri: Optional[str] = None) -> Engine:
         else:
             database_uri = config.database.SQLALCHEMY_DATABASE_URI
 
-    return create_engine(database_uri, pool_pre_ping=True)
+    return create_engine(
+        database_uri,
+        pool_pre_ping=True,
+        isolation_level=isolation_level,
+    )
 
 
 def get_db_session(engine: Optional[Engine] = None) -> sessionmaker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,14 +88,14 @@ def api_client() -> Generator:
 @pytest.fixture(scope="function")
 def oauth_client(db: Session) -> Generator:
     """Return a client for authentication purposes"""
-    client = ClientDetail(
-        hashed_secret="thisisatest",
-        salt="thisisstillatest",
-        scopes=SCOPE_REGISTRY,
+    client = ClientDetail.create(
+        db=db,
+        data={
+            "hashed_secret": "thisisatest",
+            "salt": "thisisstillatest",
+            "scopes": SCOPE_REGISTRY,
+        },
     )
-    db.add(client)
-    db.commit()
-    db.refresh(client)
     yield client
     client.delete(db)
 


### PR DESCRIPTION
# Purpose

This PR is an exploration into setting `AUTOCOMMIT` to our DB sessions, to help make execution of the identity graph async. As discussed with @stevenbenjamin this morning, the alternative is to set `autocommit=True` at the session level in SQLAlchemy, and remove the `.commit()` references in our code. This could be more prudent as it's using SQLAlchemy's supported bindings, instead of going straight to DBAPI.

# Changes

-
# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo)
- [ ] Good unit test/integration test coverage

# Ticket

Fixes #
 
