### PR TITLE
70 feat adds policy driven masking

### DIFF
--- a/data/dataset/mysql_example_test_dataset.yml
+++ b/data/dataset/mysql_example_test_dataset.yml
@@ -35,6 +35,7 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
@@ -55,6 +56,7 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
@@ -159,6 +161,7 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [system.operations]
           - name: month
@@ -176,12 +179,14 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: closed
             data_categories: [system.operations]
           - name: email
             data_categories: [system.operations]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: employee_id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
@@ -200,5 +205,6 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: last_visit
             data_categories: [system.operations]

--- a/data/dataset/postgres_example_test_dataset.yml
+++ b/data/dataset/postgres_example_test_dataset.yml
@@ -35,12 +35,15 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
               primary_key: True
           - name: name
             data_categories: [user.provided.identifiable.name]
+            fidesops_meta:
+              data_type: string
 
       - name: employee
         fields:
@@ -55,12 +58,15 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
               primary_key: True
           - name: name
             data_categories: [user.provided.identifiable.name]
+            fidesops_meta:
+              data_type: string
 
       - name: login
         fields:
@@ -165,6 +171,7 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: id
             data_categories: [system.operations]
             fidesops_meta:
@@ -184,12 +191,14 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: closed
             data_categories: [system.operations]
           - name: email
             data_categories: [system.operations]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: employee_id
             data_categories: [user.derived.identifiable.unique_id]
             fidesops_meta:
@@ -210,5 +219,6 @@ dataset:
             data_categories: [user.provided.identifiable.contact.email]
             fidesops_meta:
               identity: email
+              data_type: string
           - name: last_visit
             data_categories: [system.operations]

--- a/data/dataset/postgres_example_test_dataset.yml
+++ b/data/dataset/postgres_example_test_dataset.yml
@@ -44,6 +44,7 @@ dataset:
             data_categories: [user.provided.identifiable.name]
             fidesops_meta:
               data_type: string
+              length: 40
 
       - name: employee
         fields:

--- a/docs/fidesops/docs/tutorial/annotate_datasets.md
+++ b/docs/fidesops/docs/tutorial/annotate_datasets.md
@@ -55,7 +55,7 @@ Optional `fidesops_meta` fields:
   - `float`
   - `boolean`
   - `object_id`
-- `length`: if `length` is specified, in an erasure request, Fidesops will truncate the masked value to the specified `length`. This should be used if your database column has a length restriction. E.g. if a specific row has `email` of `jerry@mail.com`, and the masked value is `23982r3n8rupq8ewurnw`, and `length` is set to `10`, then the resulting update query will use the value `23982r3n8r`.
+- `length`: if `length` is specified, in an erasure request, Fidesops will truncate the end of the masked value to the specified `length`. This should be used if your database column has a length restriction. E.g. if a specific row has `email` of `jerry@mail.com`, and the masked value is `23982r3n8rupq8ewurnw`, and `length` is set to `10`, then the resulting update query will use the value `23982r3n8r`.
 
 ## Upload this Dataset to Fidesops
 

--- a/docs/fidesops/docs/tutorial/annotate_datasets.md
+++ b/docs/fidesops/docs/tutorial/annotate_datasets.md
@@ -48,6 +48,15 @@ the user by `email`, and from there, travel through other tables linked to `user
     identity: email
 ```
 
+Optional `fidesops_meta` fields:
+- `data_type`: only required for processing erasure requests, however, whenever specified, Fidesops will attempt to coerce the field's value to the type. For erasure requests in particular, Fidesops requires `data_type` to ensure that the configured masking strategy can process the value. Supported data types:
+  - `string`
+  - `integer`
+  - `float`
+  - `boolean`
+  - `object_id`
+- `length`: if `length` is specified, in an erasure request, Fidesops will truncate the masked value to the specified `length`. This should be used if your database column has a length restriction. E.g. if a specific row has `email` of `jerry@mail.com`, and the masked value is `23982r3n8rupq8ewurnw`, and `length` is set to `10`, then the resulting update query will use the value `23982r3n8r`.
+
 ## Upload this Dataset to Fidesops
 
 For more detailed information, [see the Datasets Guide](../guides/datasets.md).

--- a/src/fidesops/graph/config.py
+++ b/src/fidesops/graph/config.py
@@ -222,6 +222,8 @@ class Field(BaseModel):
 
 @dataclass
 class MaskingOverride:
+    """Data class to store override params related to data masking"""
+
     data_type: Optional[DataType]
     length: Optional[int]
 

--- a/src/fidesops/graph/config.py
+++ b/src/fidesops/graph/config.py
@@ -78,6 +78,7 @@ Field identities:
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import List, Optional, Tuple, Set, Dict, Literal, Any
 
 from pydantic import BaseModel
@@ -217,6 +218,12 @@ class Field(BaseModel):
                 return converter.to_value(value)
 
         return value
+
+
+@dataclass
+class MaskingOverride:
+    data_type: Optional[DataType]
+    length: Optional[int]
 
 
 class Collection(BaseModel):

--- a/src/fidesops/graph/data_type.py
+++ b/src/fidesops/graph/data_type.py
@@ -26,7 +26,7 @@ class DataTypeConverter(ABC, Generic[T]):
     def truncate(self, length: int, val: T) -> T:
         """Truncates value to given length"""
         print(
-            f"Length truncation is only supported for string and int data types. Using original masked value instead for update query."
+            "Length truncation is only supported for string data types. Using original masked value instead for update query."
         )
         return val
 
@@ -61,10 +61,6 @@ class IntTypeConverter(DataTypeConverter[int]):
     def empty_value(self) -> int:
         """Empty int value"""
         return 0
-
-    def truncate(self, length: int, val: int) -> int:
-        """Truncates value to given length"""
-        return int(str(val)[:length])
 
 
 class FloatTypeConverter(DataTypeConverter[float]):

--- a/src/fidesops/graph/data_type.py
+++ b/src/fidesops/graph/data_type.py
@@ -25,8 +25,8 @@ class DataTypeConverter(ABC, Generic[T]):
 
     def truncate(self, length: int, val: T) -> T:
         """Truncates value to given length"""
-        logger.warning(
-            f"Length truncation not supported for {T} data_type. Using original masked value instead for update query."
+        print(
+            f"Length truncation is only supported for string and int data types. Using original masked value instead for update query."
         )
         return val
 

--- a/src/fidesops/graph/data_type.py
+++ b/src/fidesops/graph/data_type.py
@@ -23,9 +23,12 @@ class DataTypeConverter(ABC, Generic[T]):
     def empty_value(self) -> T:
         """A value that represents `empty` in whatever way makes sense for type T"""
 
-    @abstractmethod
     def truncate(self, length: int, val: T) -> T:
         """Truncates value to given length"""
+        logger.warning(
+            f"Length truncation not supported for {T} data_type. Using original masked value instead for update query."
+        )
+        return val
 
 
 class StringTypeConverter(DataTypeConverter[str]):
@@ -79,13 +82,6 @@ class FloatTypeConverter(DataTypeConverter[float]):
         """Empty float value"""
         return 0.0
 
-    def truncate(self, length: int, val: float) -> float:
-        """Truncates value to given length"""
-        logger.warning(
-            "Length truncation not supported for float data_type. Using original masked value instead for update query."
-        )
-        return val
-
 
 class BooleanTypeConverter(DataTypeConverter[bool]):
     """Boolean data type converter recognizing the strings True/False, 1,0, and booleans."""
@@ -104,13 +100,6 @@ class BooleanTypeConverter(DataTypeConverter[bool]):
     def empty_value(self) -> bool:
         """Empty boolean value"""
         return False
-
-    def truncate(self, length: int, val: bool) -> bool:
-        """Truncates value to given length"""
-        logger.warning(
-            "Length truncation not supported for bool data_type. Using original masked value instead for update query."
-        )
-        return val
 
 
 class ObjectIdTypeConverter(DataTypeConverter[ObjectId]):
@@ -132,13 +121,6 @@ class ObjectIdTypeConverter(DataTypeConverter[ObjectId]):
     def empty_value(self) -> ObjectId:
         """Empty objectId value"""
         return ObjectId("000000000000000000000000")
-
-    def truncate(self, length: int, val: ObjectId) -> ObjectId:
-        """Truncates value to given length"""
-        logger.warning(
-            "Length truncation not supported for ObjectId data_type. Using original masked value instead for update query."
-        )
-        return val
 
 
 class DataType(Enum):

--- a/src/fidesops/graph/data_type.py
+++ b/src/fidesops/graph/data_type.py
@@ -1,3 +1,4 @@
+import logging
 from abc import abstractmethod, ABC
 from typing import Generic, Optional, Any, TypeVar
 from enum import Enum
@@ -5,6 +6,7 @@ from enum import Enum
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 
+logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
@@ -21,6 +23,10 @@ class DataTypeConverter(ABC, Generic[T]):
     def empty_value(self) -> T:
         """A value that represents `empty` in whatever way makes sense for type T"""
 
+    @abstractmethod
+    def truncate(self, length: int, val: T) -> T:
+        """Truncates value to given length"""
+
 
 class StringTypeConverter(DataTypeConverter[str]):
     """String data type converter. This type just uses str() type conversion."""
@@ -32,6 +38,10 @@ class StringTypeConverter(DataTypeConverter[str]):
     def empty_value(self) -> str:
         """Empty string value"""
         return ""
+
+    def truncate(self, length: int, val: str) -> str:
+        """Truncates value to given length"""
+        return val[:length]
 
 
 class IntTypeConverter(DataTypeConverter[int]):
@@ -49,6 +59,10 @@ class IntTypeConverter(DataTypeConverter[int]):
         """Empty int value"""
         return 0
 
+    def truncate(self, length: int, val: int) -> int:
+        """Truncates value to given length"""
+        return int(str(val)[:length])
+
 
 class FloatTypeConverter(DataTypeConverter[float]):
     """Float data type converter. This type just uses built-in float() type conversion."""
@@ -64,6 +78,13 @@ class FloatTypeConverter(DataTypeConverter[float]):
     def empty_value(self) -> float:
         """Empty float value"""
         return 0.0
+
+    def truncate(self, length: int, val: float) -> float:
+        """Truncates value to given length"""
+        logger.warning(
+            "Length truncation not supported for float data_type. Using original masked value instead for update query."
+        )
+        return val
 
 
 class BooleanTypeConverter(DataTypeConverter[bool]):
@@ -83,6 +104,13 @@ class BooleanTypeConverter(DataTypeConverter[bool]):
     def empty_value(self) -> bool:
         """Empty boolean value"""
         return False
+
+    def truncate(self, length: int, val: bool) -> bool:
+        """Truncates value to given length"""
+        logger.warning(
+            "Length truncation not supported for bool data_type. Using original masked value instead for update query."
+        )
+        return val
 
 
 class ObjectIdTypeConverter(DataTypeConverter[ObjectId]):
@@ -104,6 +132,13 @@ class ObjectIdTypeConverter(DataTypeConverter[ObjectId]):
     def empty_value(self) -> ObjectId:
         """Empty objectId value"""
         return ObjectId("000000000000000000000000")
+
+    def truncate(self, length: int, val: ObjectId) -> ObjectId:
+        """Truncates value to given length"""
+        logger.warning(
+            "Length truncation not supported for ObjectId data_type. Using original masked value instead for update query."
+        )
+        return val
 
 
 class DataType(Enum):

--- a/src/fidesops/graph/data_type.py
+++ b/src/fidesops/graph/data_type.py
@@ -25,8 +25,8 @@ class DataTypeConverter(ABC, Generic[T]):
 
     def truncate(self, length: int, val: T) -> T:
         """Truncates value to given length"""
-        print(
-            "Length truncation is only supported for string data types. Using original masked value instead for update query."
+        logger.warning(
+            f"{self.__class__.__name__} does not support length truncation. Using original masked value instead for update query."
         )
         return val
 

--- a/src/fidesops/models/policy.py
+++ b/src/fidesops/models/policy.py
@@ -40,6 +40,12 @@ from fidesops.service.masking.strategy.masking_strategy_factory import (
     SupportedMaskingStrategies,
 )
 from fidesops.service.masking.strategy.masking_strategy_nullify import NULL_REWRITE
+from fidesops.service.masking.strategy.masking_strategy_random_string_rewrite import (
+    RANDOM_STRING_REWRITE,
+)
+from fidesops.service.masking.strategy.masking_strategy_string_rewrite import (
+    STRING_REWRITE,
+)
 
 
 class ActionType(EnumType):
@@ -102,14 +108,15 @@ def _validate_rule(
             "Erasure Rules must have masking strategies."
         )
 
-    # Temporary, remove when we have the pieces in place to support more than null masking.
+    # Temporary, remove when we have the pieces in place to support more than these masking strategies.
     if (
         action_type == ActionType.erasure.value
         and masking_strategy
-        and masking_strategy.get("strategy") != NULL_REWRITE
+        and masking_strategy.get("strategy")
+        not in [NULL_REWRITE, STRING_REWRITE, RANDOM_STRING_REWRITE]
     ):
         raise common_exceptions.RuleValidationError(
-            "Only the Null Masking Strategy (null_rewrite) is supported at this time."
+            "Only the following masking strategies are supported at this time:  null_rewrite, string_rewrite, random_string_rewrite"
         )
 
     if action_type == ActionType.access.value and storage_destination_id is None:

--- a/src/fidesops/service/connectors/query_config.py
+++ b/src/fidesops/service/connectors/query_config.py
@@ -1,13 +1,15 @@
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections import namedtuple
 from typing import Dict, Any, List, Set, Optional, Generic, TypeVar, Tuple
 
 from sqlalchemy import text
 from sqlalchemy.sql.elements import TextClause
 
 from fidesops.common_exceptions import FidesopsException
-from fidesops.graph.config import ROOT_COLLECTION_ADDRESS, CollectionAddress, Field
+from fidesops.graph.config import ROOT_COLLECTION_ADDRESS, CollectionAddress, Field, MaskingOverride
+from fidesops.graph.data_type import DataType, DataTypeConverter
 from fidesops.graph.traversal import TraversalNode, Row
 from fidesops.models.policy import Policy, ActionType, Rule
 from fidesops.schemas.policy import PolicyMaskingSpec
@@ -136,18 +138,26 @@ class QueryConfig(Generic[T], ABC):
             )
 
             for field_name in field_names:
-                data_type: Optional[str] = [field.data_type for field in self.primary_key_fields if field.name == field_name][0]
-                if strategy_config["strategy"] is not SupportedMaskingStrategies.null_rewrite.value:
-                    if not data_type:
+                masking_override: MaskingOverride(Optional[DataType], Optional[int]) = [MaskingOverride(field.data_type, field.length) for field in self.primary_key_fields if field.name == field_name][0]
+                not_null_masking = strategy_config["strategy"] is not SupportedMaskingStrategies.null_rewrite.name
+                if not_null_masking:
+                    if not masking_override.data_type:
                         logger.warning(
-                            f"Unable to generate a query for {self.node.address} due to: data_type required on fields for the {strategy_config['strategy']} masking strategy"
+                            f"Unable to generate a query for field {field_name} due to: data_type required on fields for the {strategy_config['strategy']} masking strategy"
                             )
-                    if not strategy.data_type_supported(data_type=data_type):
+                    if not strategy.data_type_supported(data_type=masking_override.data_type.name):
                         logger.warning(
-                            f"Unable to generate a query for {self.node.address} due to: data_type of {data_type} is not supported for the {strategy_config['strategy']} masking strategy"
+                            f"Unable to generate a query for field {field_name} due to: data_type of {masking_override.data_type} is not supported for the {strategy_config['strategy']} masking strategy"
                         )
-                val = row[field_name]
-                value_map[field_name] = strategy.mask(str(val))
+                val: Any = row[field_name]
+                masked_val = strategy.mask(val)
+                logger.info(f"Generated the following masked val for field {field_name}: {masked_val}")
+                if masking_override.length and not_null_masking:
+                    logger.warning(f"Because a length has been specified for field {field_name}, we will truncate length of masked value to match, regardless of masking strategy")
+                    #  for strategies other than null masking we assume that masked data type is the same as specified data type
+                    data_type_convertor: DataTypeConverter = masking_override.data_type.value
+                    masked_val = data_type_convertor.truncate(masking_override.length, masked_val)
+                value_map[field_name] = masked_val
         return value_map
 
     @abstractmethod

--- a/src/fidesops/service/connectors/query_config.py
+++ b/src/fidesops/service/connectors/query_config.py
@@ -20,7 +20,6 @@ from fidesops.service.masking.strategy.masking_strategy_nullify import NULL_REWR
 from fidesops.util.querytoken import QueryToken
 from fidesops.service.masking.strategy.masking_strategy_factory import (
     get_strategy,
-    SupportedMaskingStrategies,
 )
 from fidesops.util.collection_util import append, filter_nonempty_values
 
@@ -151,9 +150,7 @@ class QueryConfig(Generic[T], ABC):
                     for field in self.node.node.collection.fields
                     if field.name == field_name
                 ][0]
-                not_null_masking: bool = (
-                     strategy_config.get("strategy") != NULL_REWRITE
-                )
+                not_null_masking: bool = strategy_config.get("strategy") != NULL_REWRITE
                 if not_null_masking:
                     if not masking_override.data_type:
                         logger.warning(

--- a/src/fidesops/service/masking/strategy/masking_strategy.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy.py
@@ -32,7 +32,6 @@ class MaskingStrategy(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_supported_data_types() -> List[DataType]:
-        """Returns the supported data types for the given strategy"""
+    def data_type_supported(data_type: str) -> bool:
+        """Returns the whether the data type is supported for the given strategy"""
         pass
-        # fixme: add supported data types for each masking strategy

--- a/src/fidesops/service/masking/strategy/masking_strategy.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy.py
@@ -32,6 +32,6 @@ class MaskingStrategy(ABC):
 
     @staticmethod
     @abstractmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Returns the whether the data type is supported for the given strategy"""
         pass

--- a/src/fidesops/service/masking/strategy/masking_strategy.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy.py
@@ -1,7 +1,8 @@
 # MR Note - It would be nice to enforce this at compile time
 from abc import abstractmethod, ABC
-from typing import Optional
+from typing import Optional, List
 
+from fidesops.graph.data_type import DataType
 from fidesops.schemas.masking.masking_configuration import MaskingConfiguration
 from fidesops.schemas.masking.masking_strategy_description import (
     MaskingStrategyDescription,
@@ -28,3 +29,10 @@ class MaskingStrategy(ABC):
         """Returns the description used for documentation. In particular, used by the
         documentation endpoint in masking_endpoints.list_masking_strategies"""
         pass
+
+    @staticmethod
+    @abstractmethod
+    def get_supported_data_types() -> List[DataType]:
+        """Returns the supported data types for the given strategy"""
+        pass
+        # fixme: add supported data types for each masking strategy

--- a/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -14,6 +14,7 @@ from fidesops.util.encryption.aes_gcm_encryption_scheme import encrypt
 
 
 AES_ENCRYPT = "aes_encrypt"
+SUPPORTED_DATA_TYPES = ["string"]
 
 
 class AesEncryptionMaskingStrategy(MaskingStrategy):
@@ -54,3 +55,8 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
                 ),
             ],
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -14,7 +14,6 @@ from fidesops.util.encryption.aes_gcm_encryption_scheme import encrypt
 
 
 AES_ENCRYPT = "aes_encrypt"
-SUPPORTED_DATA_TYPES = {"string"}
 
 
 class AesEncryptionMaskingStrategy(MaskingStrategy):
@@ -59,4 +58,5 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
     @staticmethod
     def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
-        return data_type in SUPPORTED_DATA_TYPES
+        supported_data_types = {"string"}
+        return data_type in supported_data_types

--- a/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -57,6 +57,6 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -14,7 +14,7 @@ from fidesops.util.encryption.aes_gcm_encryption_scheme import encrypt
 
 
 AES_ENCRYPT = "aes_encrypt"
-SUPPORTED_DATA_TYPES = ["string"]
+SUPPORTED_DATA_TYPES = {"string"}
 
 
 class AesEncryptionMaskingStrategy(MaskingStrategy):

--- a/src/fidesops/service/masking/strategy/masking_strategy_factory.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_factory.py
@@ -23,7 +23,7 @@ from fidesops.common_exceptions import (
     NoSuchStrategyException,
 )
 
-from fidesops.schemas.masking.masking_configuration import FormatPreservationConfig
+from fidesops.schemas.masking.masking_configuration import FormatPreservationConfig, MaskingConfiguration
 
 
 class SupportedMaskingStrategies(Enum):
@@ -57,7 +57,7 @@ def get_strategy(
         )
     strategy = SupportedMaskingStrategies[strategy_name].value
     try:
-        strategy_config = strategy.get_configuration_model()(**configuration)
+        strategy_config: MaskingConfiguration = strategy.get_configuration_model()(**configuration)
         return strategy(configuration=strategy_config)
     except ValidationError as e:
         raise FidesopsValidationError(message=str(e))

--- a/src/fidesops/service/masking/strategy/masking_strategy_factory.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_factory.py
@@ -23,7 +23,10 @@ from fidesops.common_exceptions import (
     NoSuchStrategyException,
 )
 
-from fidesops.schemas.masking.masking_configuration import FormatPreservationConfig, MaskingConfiguration
+from fidesops.schemas.masking.masking_configuration import (
+    FormatPreservationConfig,
+    MaskingConfiguration,
+)
 
 
 class SupportedMaskingStrategies(Enum):
@@ -54,7 +57,9 @@ def get_strategy(
         )
     strategy = SupportedMaskingStrategies[strategy_name].value
     try:
-        strategy_config: MaskingConfiguration = strategy.get_configuration_model()(**configuration)
+        strategy_config: MaskingConfiguration = strategy.get_configuration_model()(
+            **configuration
+        )
         return strategy(configuration=strategy_config)
     except ValidationError as e:
         raise FidesopsValidationError(message=str(e))

--- a/src/fidesops/service/masking/strategy/masking_strategy_factory.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_factory.py
@@ -32,10 +32,7 @@ class SupportedMaskingStrategies(Enum):
     """
 
     string_rewrite = StringRewriteMaskingStrategy
-    hash = HashMaskingStrategy
     random_string_rewrite = RandomStringRewriteMaskingStrategy
-    aes_encrypt = AesEncryptionMaskingStrategy
-    hmac = HmacMaskingStrategy
     null_rewrite = NullMaskingStrategy
 
 

--- a/src/fidesops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hash.py
@@ -15,7 +15,6 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HASH = "hash"
-SUPPORTED_DATA_TYPES = {"string"}
 
 
 class HashMaskingStrategy(MaskingStrategy):
@@ -71,7 +70,8 @@ class HashMaskingStrategy(MaskingStrategy):
     @staticmethod
     def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
-        return data_type in SUPPORTED_DATA_TYPES
+        supported_data_types = {"string"}
+        return data_type in supported_data_types
 
     # Helpers
 

--- a/src/fidesops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hash.py
@@ -15,7 +15,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HASH = "hash"
-SUPPORTED_DATA_TYPES = ["string"]
+SUPPORTED_DATA_TYPES = {"string"}
 
 
 class HashMaskingStrategy(MaskingStrategy):

--- a/src/fidesops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hash.py
@@ -15,6 +15,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HASH = "hash"
+SUPPORTED_DATA_TYPES = ["string"]
 
 
 class HashMaskingStrategy(MaskingStrategy):
@@ -66,6 +67,11 @@ class HashMaskingStrategy(MaskingStrategy):
                 ),
             ],
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return data_type in SUPPORTED_DATA_TYPES
 
     # Helpers
 

--- a/src/fidesops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hash.py
@@ -69,7 +69,7 @@ class HashMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return data_type in SUPPORTED_DATA_TYPES
 

--- a/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
@@ -95,7 +95,7 @@ class HmacMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return data_type in SUPPORTED_DATA_TYPES
 

--- a/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
@@ -16,7 +16,6 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HMAC = "hmac"
-SUPPORTED_DATA_TYPES = {"string"}
 
 
 class HmacMaskingStrategy(MaskingStrategy):
@@ -97,7 +96,8 @@ class HmacMaskingStrategy(MaskingStrategy):
     @staticmethod
     def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
-        return data_type in SUPPORTED_DATA_TYPES
+        supported_data_types = {"string"}
+        return data_type in supported_data_types
 
 
 def _hmac(value: str, hmac_key: str, salt: str, hashing_alg: Callable) -> str:

--- a/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
@@ -16,7 +16,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HMAC = "hmac"
-SUPPORTED_DATA_TYPES = ["string"]
+SUPPORTED_DATA_TYPES = {"string"}
 
 
 class HmacMaskingStrategy(MaskingStrategy):

--- a/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_hmac.py
@@ -16,6 +16,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 HMAC = "hmac"
+SUPPORTED_DATA_TYPES = ["string"]
 
 
 class HmacMaskingStrategy(MaskingStrategy):
@@ -92,6 +93,11 @@ class HmacMaskingStrategy(MaskingStrategy):
         return _hmac(
             value=value, hmac_key=hmac_key, salt=salt, hashing_alg=hashlib.sha512
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return data_type in SUPPORTED_DATA_TYPES
 
 
 def _hmac(value: str, hmac_key: str, salt: str, hashing_alg: Callable) -> str:

--- a/src/fidesops/service/masking/strategy/masking_strategy_nullify.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_nullify.py
@@ -40,6 +40,6 @@ class NullMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return True

--- a/src/fidesops/service/masking/strategy/masking_strategy_nullify.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_nullify.py
@@ -38,3 +38,8 @@ class NullMaskingStrategy(MaskingStrategy):
             description="Masks the input value with a null value",
             configurations=[],
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return True

--- a/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
@@ -15,7 +15,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 RANDOM_STRING_REWRITE = "random_string_rewrite"
-SUPPORTED_DATA_TYPES = ["string"]
+SUPPORTED_DATA_TYPES = {"string"}
 
 
 class RandomStringRewriteMaskingStrategy(MaskingStrategy):

--- a/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
@@ -58,6 +58,6 @@ class RandomStringRewriteMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
@@ -15,6 +15,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 RANDOM_STRING_REWRITE = "random_string_rewrite"
+SUPPORTED_DATA_TYPES = ["string"]
 
 
 class RandomStringRewriteMaskingStrategy(MaskingStrategy):
@@ -55,3 +56,8 @@ class RandomStringRewriteMaskingStrategy(MaskingStrategy):
                 )
             ],
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_random_string_rewrite.py
@@ -15,7 +15,6 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 RANDOM_STRING_REWRITE = "random_string_rewrite"
-SUPPORTED_DATA_TYPES = {"string"}
 
 
 class RandomStringRewriteMaskingStrategy(MaskingStrategy):
@@ -60,4 +59,5 @@ class RandomStringRewriteMaskingStrategy(MaskingStrategy):
     @staticmethod
     def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
-        return data_type in SUPPORTED_DATA_TYPES
+        supported_data_types = {"string"}
+        return data_type in supported_data_types

--- a/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
@@ -33,6 +33,7 @@ class StringRewriteMaskingStrategy(MaskingStrategy):
         if self.format_preservation is not None:
             formatter = FormatPreservation(self.format_preservation)
             return formatter.format(self.rewrite_value)
+        # fixme: how to handle length if different than rewrite_value?
         return self.rewrite_value
 
     @staticmethod

--- a/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
@@ -13,7 +13,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 STRING_REWRITE = "string_rewrite"
-SUPPORTED_DATA_TYPES = ["string"]
+SUPPORTED_DATA_TYPES = {"string"}
 
 
 class StringRewriteMaskingStrategy(MaskingStrategy):

--- a/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
@@ -57,6 +57,6 @@ class StringRewriteMaskingStrategy(MaskingStrategy):
         )
 
     @staticmethod
-    def data_type_supported(data_type: str) -> bool:
+    def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
         return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
@@ -13,6 +13,7 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 STRING_REWRITE = "string_rewrite"
+SUPPORTED_DATA_TYPES = ["string"]
 
 
 class StringRewriteMaskingStrategy(MaskingStrategy):
@@ -54,3 +55,8 @@ class StringRewriteMaskingStrategy(MaskingStrategy):
                 )
             ],
         )
+
+    @staticmethod
+    def data_type_supported(data_type: str) -> bool:
+        """Determines whether or not the given data type is supported by this masking strategy"""
+        return data_type in SUPPORTED_DATA_TYPES

--- a/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
+++ b/src/fidesops/service/masking/strategy/masking_strategy_string_rewrite.py
@@ -13,7 +13,6 @@ from fidesops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 
 STRING_REWRITE = "string_rewrite"
-SUPPORTED_DATA_TYPES = {"string"}
 
 
 class StringRewriteMaskingStrategy(MaskingStrategy):
@@ -59,4 +58,5 @@ class StringRewriteMaskingStrategy(MaskingStrategy):
     @staticmethod
     def data_type_supported(data_type: Optional[str]) -> bool:
         """Determines whether or not the given data type is supported by this masking strategy"""
-        return data_type in SUPPORTED_DATA_TYPES
+        supported_data_types = {"string"}
+        return data_type in supported_data_types

--- a/tests/api/v1/endpoints/test_masking_endpoints.py
+++ b/tests/api/v1/endpoints/test_masking_endpoints.py
@@ -73,13 +73,7 @@ class TestMaskValues:
         response = api_client.put(
             f"{V1_URL_PREFIX}{MASKING}?value={value}", json=masking_strategy
         )
-        assert 200 == response.status_code
-        json_response = json.loads(response.text)
-        assert value == json_response["plain"]
-        assert (
-            "bf4f5048cc2daf518311f55154dd68c372cf41304e3c439cba62e99fde57333c"
-            == json_response["masked_value"]
-        )
+        assert 404 == response.status_code
 
     def test_mask_value_hash(self, api_client: TestClient):
         value = "867-5309"
@@ -91,13 +85,7 @@ class TestMaskValues:
         response = api_client.put(
             f"{V1_URL_PREFIX}{MASKING}?value={value}", json=masking_strategy
         )
-        assert 200 == response.status_code
-        json_response = json.loads(response.text)
-        assert value == json_response["plain"]
-        assert (
-            "c67e2f74843b247b72aae44b6d28bc63ead8bc1f125a4074be2c49941772c142"
-            == json_response["masked_value"]
-        )
+        assert 404 == response.status_code
 
     def test_mask_value_aes_encrypt(self, api_client: TestClient):
         value = "last name"
@@ -112,10 +100,7 @@ class TestMaskValues:
         response = api_client.put(
             f"{V1_URL_PREFIX}{MASKING}?value={value}", json=masking_strategy
         )
-        assert 200 == response.status_code
-        json_response = json.loads(response.text)
-        assert value == json_response["plain"]
-        assert "nG0BmcgF2VTqn36mNxdW/uMixR/Zz002EA==" == json_response["masked_value"]
+        assert 404 == response.status_code
 
     def test_mask_value_no_such_strategy(self, api_client: TestClient):
         value = "check"
@@ -158,11 +143,7 @@ class TestMaskValues:
         response = api_client.put(
             f"{V1_URL_PREFIX}{MASKING}?value={value}", json=masking_strategy
         )
-        assert 400 == response.status_code
-        assert (
-            "Encryption key must be 16 bytes long"
-            == json.loads(response.text)["detail"]
-        )
+        assert 404 == response.status_code
 
     def test_masking_value_null(self, api_client: TestClient):
         value = "my_email"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -312,6 +312,59 @@ def erasure_policy(
 
 
 @pytest.fixture(scope="function")
+def erasure_policy_string_rewrite_long(
+        db: Session,
+        oauth_client: ClientDetail,
+) -> Generator:
+    erasure_policy = Policy.create(
+        db=db,
+        data={
+            "name": "example erasure policy string rewrite",
+            "key": "example_erasure_policy_string_rewrite",
+            "client_id": oauth_client.id,
+        },
+    )
+
+    erasure_rule = Rule.create(
+        db=db,
+        data={
+            "action_type": ActionType.erasure.value,
+            "client_id": oauth_client.id,
+            "name": "Erasure Rule",
+            "policy_id": erasure_policy.id,
+            "masking_strategy": {
+                "strategy": STRING_REWRITE,
+                "configuration": {
+                    "rewrite_value": "some rewrite value that is very long and goes on and on"
+                },
+            },
+        },
+    )
+
+    rule_target = RuleTarget.create(
+        db=db,
+        data={
+            "client_id": oauth_client.id,
+            "data_category": DataCategory("user.provided.identifiable.name").value,
+            "rule_id": erasure_rule.id,
+        },
+    )
+    yield erasure_policy
+    try:
+        rule_target.delete(db)
+    except ObjectDeletedError:
+        pass
+    try:
+        erasure_rule.delete(db)
+    except ObjectDeletedError:
+        pass
+    try:
+        erasure_policy.delete(db)
+    except ObjectDeletedError:
+        pass
+
+
+@pytest.fixture(scope="function")
 def erasure_policy_two_rules(
     db: Session, oauth_client: ClientDetail, erasure_policy: Policy
 ) -> Generator:

--- a/tests/service/connectors/test_queryconfig.py
+++ b/tests/service/connectors/test_queryconfig.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import Dict, Any, Set
 
+from fidesops.common_exceptions import NoSuchStrategyException
 from fidesops.graph.config import CollectionAddress
 from fidesops.graph.graph import DatasetGraph
 from fidesops.graph.traversal import Traversal, TraversalNode
@@ -209,18 +210,9 @@ class TestSQLQueryConfig:
             "configuration": {"algorithm": "SHA-512"},
         }
 
-        text_clause = config.generate_update_stmt(row, erasure_policy)
-        assert (
-            text_clause.text
-            == "UPDATE customer SET email = :email,name = :name WHERE  id = :id"
-        )
-        assert text_clause._bindparams["name"].key == "name"
-        assert text_clause._bindparams["name"].value == HashMaskingStrategy(
-            HashMaskingConfiguration(algorithm="SHA-512")
-        ).mask("John Customer")
-        assert text_clause._bindparams["email"].value == HashMaskingStrategy(
-            HashMaskingConfiguration(algorithm="SHA-512")
-        ).mask("customer-1@example.com")
+        with pytest.raises(NoSuchStrategyException):
+            config.generate_update_stmt(row, erasure_policy)
+
 
     def test_generate_update_stmts_from_multiple_rules(
         self, erasure_policy_two_rules, example_datasets, integration_postgres_config
@@ -345,9 +337,5 @@ class TestMongoQueryConfig:
         target = rule_two.targets[0]
         target.data_category = DataCategory("user.provided.identifiable.gender").value
 
-        mongo_statement = config.generate_update_stmt(row, erasure_policy_two_rules)
-        assert mongo_statement[0] == {"_id": 1}
-        assert len(mongo_statement[1]["$set"]["gender"]) == 30
-        assert mongo_statement[1]["$set"]["birthday"] == HashMaskingStrategy(
-            HashMaskingConfiguration(algorithm="SHA-512")
-        ).mask("1988-01-10")
+        with pytest.raises(NoSuchStrategyException):
+            config.generate_update_stmt(row, erasure_policy_two_rules)

--- a/tests/service/masking/strategy/test_masking_strategy_factory.py
+++ b/tests/service/masking/strategy/test_masking_strategy_factory.py
@@ -14,8 +14,8 @@ from fidesops.service.masking.strategy.masking_strategy_string_rewrite import (
 
 
 def test_get_strategy_hash():
-    strategy = get_strategy("hash", {})
-    assert isinstance(strategy, HashMaskingStrategy)
+    with pytest.raises(NoSuchStrategyException):
+        get_strategy("hash", {})
 
 
 def test_get_strategy_rewrite():
@@ -26,8 +26,8 @@ def test_get_strategy_rewrite():
 
 def test_get_strategy_aes_encrypt():
     config = {"mode": "GCM", "key": "keycard", "nonce": "none"}
-    strategy = get_strategy("aes_encrypt", config)
-    assert isinstance(strategy, AesEncryptionMaskingStrategy)
+    with pytest.raises(NoSuchStrategyException):
+        get_strategy("aes_encrypt", config)
 
 
 def test_get_strategy_invalid():

--- a/tests/service/masking/test_masking_processor.py
+++ b/tests/service/masking/test_masking_processor.py
@@ -34,26 +34,20 @@ def string_rewrite_strategy() -> PolicyMaskingSpec:
     )
 
 
-def test_mask_one_strategy(hash_strategy: PolicyMaskingSpec):
+def test_mask_hash_strategy(hash_strategy: PolicyMaskingSpec):
     policy_masking_spec = [hash_strategy]
     value = "22475"
-    expected_masked_value = "7d6f1a312135fe11d1c47bc2a44413c4449b434ea0ce30ea3e438de557579a340548af12863c1e966547669e8b7cfc844e6c18aabae6c97c9eb1f0d388158bf5"
-
-    masked_value = mask(value, policy_masking_spec)
-
-    assert masked_value == expected_masked_value
+    with pytest.raises(NoSuchStrategyException):
+        mask(value, policy_masking_spec)
 
 
-def test_mask_one_strategy_format_preservation(
+def test_mask_hash_strategy_format_preservation(
     hash_strategy_format_preservation: PolicyMaskingSpec,
 ):
     policy_masking_spec = [hash_strategy_format_preservation]
     value = "meow@meow.com"
-    expected_masked_value = "774a23fae48c0c950258fe40e5e08cc867440dfa8086e93efe6414e3df9ec334af3cd34ba90df9e95b1d8e370c1677c071eb34dd1c90293b7aaae4c261e5bda9@masked.com"
-
-    masked_value = mask(value, policy_masking_spec)
-
-    assert masked_value == expected_masked_value
+    with pytest.raises(NoSuchStrategyException):
+        mask(value, policy_masking_spec)
 
 
 def test_mask_multi_strategies(
@@ -62,11 +56,8 @@ def test_mask_multi_strategies(
     policy_masking_spec = [string_rewrite_strategy, hash_strategy]
     value = "22475"
 
-    expected_masked_value = "832ac8125bbda9887b394fd8f23157804d45ee6c2b8dc7c51fe6d6eef0a93fe1b7c98e2b96ac453f432f2e3ac651fa914ff0bb52a75687f748e0c9b9209f4a64"
-
-    masked_value = mask(value, policy_masking_spec)
-
-    assert masked_value == expected_masked_value
+    with pytest.raises(NoSuchStrategyException):
+        mask(value, policy_masking_spec)
 
 
 def test_mask_no_strategies():
@@ -88,8 +79,6 @@ def test_mask_invalid_strategy():
 def test_mask_no_input(hash_strategy: PolicyMaskingSpec):
     policy_masking_spec = [hash_strategy]
     value = None
-    expected_masked_value = None
 
-    masked_value = mask(value, policy_masking_spec)
-
-    assert masked_value == expected_masked_value
+    with pytest.raises(NoSuchStrategyException):
+        mask(value, policy_masking_spec)


### PR DESCRIPTION
# Purpose
- Adds handling for new `length` and `data_type` params on `Field`
- Restricts supported masking strategies to the following:
[ ] HMAC
[ ] Hash
[ ] AES Encryption
[ x ] Null
[ x ] Random string rewrite
[ x ] Default string rewrite


# Changes
- Adds supported `data_type`s to each masking strategy
- Requires a `data_type` on `Field` for masking strategies that are not `null_rewrite`
- Adds methods to each `DataTypeConverter` to truncate val to specified `length` if provided (we only truncate `integer` and `string` data types) 

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo)
- [x] Good unit test/integration test coverage

# Ticket

Fixes #70
 
