### PR TITLE
Fix link in PR template to docs about how to update ER diagram [Unticketed]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 -
 # Checklist
 
-- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](../docs/fidesops/docs/development/update_erd_diagram.md)
+- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
 - [ ] Good unit test/integration test coverage
 
 # Ticket


### PR DESCRIPTION
# Purpose

The database diagram link in this PR template is bad, see checklist below.

# Changes

Switches to direct link from relative link

# Checklist

- [X] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](../docs/fidesops/docs/development/update_erd_diagram.md)
- [X] Good unit test/integration test coverage

# Ticket

[Unticketed] 
