### PR TITLE
Send Privacy Request Identities as a Dictionary [#118]

### DIFF
--- a/docs/fidesops/docs/guides/policy_webhooks.md
+++ b/docs/fidesops/docs/guides/policy_webhooks.md
@@ -19,9 +19,9 @@ A Policy Webhook is an HTTPS Callback that you've defined on a Policy to call an
 REST API endpoint *before* or *after* a PrivacyRequest executes.
 
 You can define as many webhooks as you'd like.  Webhooks can be `one_way`, 
-where we will just ping your API and move on, or `two_way`, where we will wait for a response. Any `derived_identities`
+where we will just ping your API and move on, or `two_way`, where we will wait for a response. Any new fields in `derived_identity`
 returned from a `two_way` webhook will be saved and can be used to locate other user information.  For example, a webhook
-might take a known `email` `identity` and use that to find a `phone_number` `identity`.
+might take a known `email` `identity` and use that to find a `phone_number` `derived_identity`.
 
 Another use case for a Policy Webhook might be to log a user out of your mobile app after you've cleared
 their data from your system.  In this case, you'd create a `Policy` and a `ConnectionConfig` to describe the URL to hit
@@ -177,7 +177,7 @@ POST <user-defined URL>
   "privacy_request_id": "pri_029832ba-3b84-40f7-8946-82aec6f95448",
   "direction": "one_way | two_way",
   "callback_type": "pre | post",
-  "identities": {
+  "identity": {
     "email": "customer-1@example.com",
     "phone_number": "555-5555"
   }
@@ -209,7 +209,7 @@ We don't expect a response from `one-way` webhooks, but `two-way` webhooks shoul
 
 ```json
 {
-  "derived_identities": {
+  "derived_identity": {
     "email": "customer-1@gmail.com",
     "phone_number": "555-5555"
   },
@@ -217,7 +217,7 @@ We don't expect a response from `one-way` webhooks, but `two-way` webhooks shoul
 }
 ```
 
-Derived identities are optional: a returned email or phone number will replace currently known emails or phone numbers.
+Derived identity is optional: a returned email or phone number will replace currently known emails or phone numbers.
 
 ## Resuming PrivacyRequest Execution
 
@@ -228,7 +228,7 @@ given to you in the original request header with the `reply-to-token` auth token
 
 ```json
 {
-  "derived_identities": {
+  "derived_identity": {
     "email": "customer-1@gmail.com",
     "phone_number": "555-5555"
   }

--- a/docs/fidesops/docs/guides/privacy_requests.md
+++ b/docs/fidesops/docs/guides/privacy_requests.md
@@ -31,10 +31,10 @@ Privacy Requests can be executed by submitting them to Fidesops via the Privacy 
     "external_id": "a-user-defined-id",
     "requested_at": "2021-10-31T16:00:00.000Z",
     "policy_key": "a-demo-policy",
-    "identities": [{
+    "identities": {
       "email": "identity@example.com",
       "phone_number: "+1 (123) 456 7891"
-    }],
+    },
   }
 ]
 ```
@@ -76,7 +76,7 @@ POST /privacy-request
 [
     {
         "requested_at": "2021-08-30T16:09:37.359Z",
-        "identities": [{"email": "customer-1@example.com"}],
+        "identities": {"email": "customer-1@example.com"},
         "policy_key": "my_access_policy",
         "encryption_key": "test--encryption"
     }

--- a/docs/fidesops/docs/guides/privacy_requests.md
+++ b/docs/fidesops/docs/guides/privacy_requests.md
@@ -31,7 +31,7 @@ Privacy Requests can be executed by submitting them to Fidesops via the Privacy 
     "external_id": "a-user-defined-id",
     "requested_at": "2021-10-31T16:00:00.000Z",
     "policy_key": "a-demo-policy",
-    "identities": {
+    "identity": {
       "email": "identity@example.com",
       "phone_number: "+1 (123) 456 7891"
     },
@@ -76,7 +76,7 @@ POST /privacy-request
 [
     {
         "requested_at": "2021-08-30T16:09:37.359Z",
-        "identities": {"email": "customer-1@example.com"},
+        "identity": {"email": "customer-1@example.com"},
         "policy_key": "my_access_policy",
         "encryption_key": "test--encryption"
     }

--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -548,7 +548,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": [{\"email\": \"customer-1@example.com\"}],\n        \"policy_key\": \"{{policy_key}}\"\n    }\n]",
+							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": {\"email\": \"customer-1@example.com\"},\n        \"policy_key\": \"{{policy_key}}\"\n    }\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -705,7 +705,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": [{\"email\": \"customer-2@example.com\"}],\n        \"policy_key\": \"{{separate_policy_key}}\"\n    }\n]",
+							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": {\"email\": \"customer-2@example.com\"},\n        \"policy_key\": \"{{separate_policy_key}}\"\n    }\n]",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -548,7 +548,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": {\"email\": \"customer-1@example.com\"},\n        \"policy_key\": \"{{policy_key}}\"\n    }\n]",
+							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identity\": {\"email\": \"customer-1@example.com\"},\n        \"policy_key\": \"{{policy_key}}\"\n    }\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -705,7 +705,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identities\": {\"email\": \"customer-2@example.com\"},\n        \"policy_key\": \"{{separate_policy_key}}\"\n    }\n]",
+							"raw": "[\n    {\n        \"requested_at\": \"2021-08-30T16:09:37.359Z\",\n        \"identity\": {\"email\": \"customer-2@example.com\"},\n        \"policy_key\": \"{{separate_policy_key}}\"\n    }\n]",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/fidesops/docs/tutorial/execute_privacy_request.md
+++ b/docs/fidesops/docs/tutorial/execute_privacy_request.md
@@ -17,7 +17,7 @@ To summarize so far, we have:
     5) Defined Policies describing what data we're looking for and what to do with that data.
 
 For our last step, we'll write a method that will let us create a Privacy Request.  We need to specify the
-Policy we want applied to that Privacy Request, as well as the starting Identities of the user we'll need
+Policy we want applied to that Privacy Request, as well as the starting identity of the user we'll need
 to locate the remaining user information:
 
 ### Define helper method
@@ -33,7 +33,7 @@ def create_privacy_request(email, policy_key, access_token):
         {
             "requested_at": datetime(2021, 1, 1).isoformat(),
             "policy_key": policy_key,
-            "identities": {"email": email},
+            "identity": {"email": email},
         },
     ]
     response = requests.post(

--- a/docs/fidesops/docs/tutorial/execute_privacy_request.md
+++ b/docs/fidesops/docs/tutorial/execute_privacy_request.md
@@ -33,7 +33,7 @@ def create_privacy_request(email, policy_key, access_token):
         {
             "requested_at": datetime(2021, 1, 1).isoformat(),
             "policy_key": policy_key,
-            "identities": [{"email": email}],
+            "identities": {"email": email},
         },
     ]
     response = requests.post(

--- a/quickstart.py
+++ b/quickstart.py
@@ -423,7 +423,7 @@ def create_privacy_request(user_email: str, policy_key: str):
         {
             "requested_at": str(datetime.utcnow()),
             "policy_key": policy_key,
-            "identities": [{"email": user_email}],
+            "identities": {"email": user_email},
         },
     ]
     response = requests.post(

--- a/quickstart.py
+++ b/quickstart.py
@@ -423,7 +423,7 @@ def create_privacy_request(user_email: str, policy_key: str):
         {
             "requested_at": str(datetime.utcnow()),
             "policy_key": policy_key,
-            "identities": {"email": user_email},
+            "identity": {"email": user_email},
         },
     ]
     response = requests.post(

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -107,7 +107,7 @@ def create_privacy_request(
 
     optional_fields = ["external_id", "started_processing_at", "finished_processing_at"]
     for privacy_request_data in data:
-        if len(privacy_request_data.identities) == 0:
+        if not any(privacy_request_data.identities.dict().values()):
             logger.warning(
                 "Create failed for privacy request with no identities provided"
             )
@@ -152,9 +152,8 @@ def create_privacy_request(
 
             # Store identity in the cache
             logger.info(f"Caching identities for privacy request {privacy_request.id}")
-            for identity in privacy_request_data.identities:
-                privacy_request.cache_identity(identity)
-                privacy_request.cache_encryption(privacy_request_data.encryption_key)
+            privacy_request.cache_identity(privacy_request_data.identities)
+            privacy_request.cache_encryption(privacy_request_data.encryption_key)
 
             PrivacyRequestRunner(
                 cache=cache,

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -107,9 +107,9 @@ def create_privacy_request(
 
     optional_fields = ["external_id", "started_processing_at", "finished_processing_at"]
     for privacy_request_data in data:
-        if not any(privacy_request_data.identities.dict().values()):
+        if not any(privacy_request_data.identity.dict().values()):
             logger.warning(
-                "Create failed for privacy request with no identities provided"
+                "Create failed for privacy request with no identity provided"
             )
             failure = {
                 "message": "You must provide at least one identity to process",
@@ -151,8 +151,8 @@ def create_privacy_request(
             privacy_request = PrivacyRequest.create(db=db, data=kwargs)
 
             # Store identity in the cache
-            logger.info(f"Caching identities for privacy request {privacy_request.id}")
-            privacy_request.cache_identity(privacy_request_data.identities)
+            logger.info(f"Caching identity for privacy request {privacy_request.id}")
+            privacy_request.cache_identity(privacy_request_data.identity)
             privacy_request.cache_encryption(privacy_request_data.encryption_key)
 
             PrivacyRequestRunner(
@@ -402,6 +402,6 @@ def resume_privacy_request(
 ) -> None:
     """Resume running a privacy request after it was paused by a Pre-Execution webhook"""
     privacy_request = get_privacy_request_or_error(db, privacy_request_id)
-    privacy_request.cache_identity(webhook_callback.derived_identities)
+    privacy_request.cache_identity(webhook_callback.derived_identity)
 
     # TODO resume running privacy request from specific webhook

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -173,7 +173,7 @@ class PrivacyRequest(Base):
             privacy_request_id=self.id,
             direction=webhook.direction.value,
             callback_type=webhook.prefix,
-            identities=self.get_cached_identity_data(),
+            identity=self.get_cached_identity_data(),
         )
 
         headers = {}
@@ -197,13 +197,13 @@ class PrivacyRequest(Base):
         response_body = SecondPartyResponseFormat(**response)
 
         # Cache any new identities
-        if response_body.derived_identities and any(
-            [response_body.derived_identities.dict().values()]
+        if response_body.derived_identity and any(
+            [response_body.derived_identity.dict().values()]
         ):
             logger.info(
                 f"Updating known identities on privacy request {self.id} from webhook {webhook.key}."
             )
-            self.cache_identity(response_body.derived_identities)
+            self.cache_identity(response_body.derived_identity)
 
         # Pause execution if instructed
         if response_body.halt and is_pre_webhook:

--- a/src/fidesops/schemas/external_https.py
+++ b/src/fidesops/schemas/external_https.py
@@ -20,7 +20,7 @@ class SecondPartyRequestFormat(BaseModel):
     privacy_request_id: str
     direction: WebhookDirection
     callback_type: CallbackType
-    identities: PrivacyRequestIdentity
+    identity: PrivacyRequestIdentity
 
     class Config:
         """Using enum values"""
@@ -34,7 +34,7 @@ class SecondPartyResponseFormat(BaseModel):
     Responses are only expected (and considered) for two_way webhooks.
     """
 
-    derived_identities: Optional[PrivacyRequestIdentity] = None
+    derived_identity: Optional[PrivacyRequestIdentity] = None
     halt: bool
 
     class Config:
@@ -46,7 +46,7 @@ class SecondPartyResponseFormat(BaseModel):
 class PrivacyRequestResumeFormat(BaseModel):
     """Expected request body to resume a privacy request after it was paused by a webhook"""
 
-    derived_identities: Optional[PrivacyRequestIdentity] = {}
+    derived_identity: Optional[PrivacyRequestIdentity] = {}
 
     class Config:
         """Using enum values"""

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -22,7 +22,7 @@ class PrivacyRequestCreate(BaseSchema):
     started_processing_at: Optional[datetime]
     finished_processing_at: Optional[datetime]
     requested_at: datetime
-    identities: List[PrivacyRequestIdentity]
+    identities: PrivacyRequestIdentity
     policy_key: FidesOpsKey
     encryption_key: Optional[str] = None
 

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -22,7 +22,7 @@ class PrivacyRequestCreate(BaseSchema):
     started_processing_at: Optional[datetime]
     finished_processing_at: Optional[datetime]
     requested_at: datetime
-    identities: PrivacyRequestIdentity
+    identity: PrivacyRequestIdentity
     policy_key: FidesOpsKey
     encryption_key: Optional[str] = None
 

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -75,7 +75,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": {"email": "test@example.com"},
+                "identity": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -105,7 +105,7 @@ class TestCreatePrivacyRequest:
                 {
                     "requested_at": "2021-08-30T16:09:37.359Z",
                     "policy_key": policy.key,
-                    "identities": {"email": "ftest{i}@example.com"},
+                    "identity": {"email": "ftest{i}@example.com"},
                 },
             )
 
@@ -134,7 +134,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": {"email": "test@example.com"},
+                "identity": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -164,7 +164,7 @@ class TestCreatePrivacyRequest:
                 "external_id": external_id,
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": {"email": "test@example.com"},
+                "identity": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -198,7 +198,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": identity,
+                "identity": identity,
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -222,7 +222,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": {"email": "test@example.com"},
+                "identity": {"email": "test@example.com"},
                 "encryption_key": "test",
             }
         ]
@@ -249,7 +249,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": identity,
+                "identity": identity,
                 "encryption_key": "test--encryption",
             }
         ]
@@ -279,7 +279,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": {},
+                "identity": {},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -891,7 +891,7 @@ class TestResumePrivacyRequest:
             webhook=policy_pre_execution_webhooks[0]
         )
         response = api_client.post(
-            url, headers=auth_header, json={"derived_identities": {}}
+            url, headers=auth_header, json={"derived_identity": {}}
         )
         assert response.status_code == 200
         # TODO add to test after more of this is connected

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -75,7 +75,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [{"email": "test@example.com"}],
+                "identities": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -105,7 +105,7 @@ class TestCreatePrivacyRequest:
                 {
                     "requested_at": "2021-08-30T16:09:37.359Z",
                     "policy_key": policy.key,
-                    "identities": [{"email": "ftest{i}@example.com"}],
+                    "identities": {"email": "ftest{i}@example.com"},
                 },
             )
 
@@ -134,7 +134,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [{"email": "test@example.com"}],
+                "identities": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -164,7 +164,7 @@ class TestCreatePrivacyRequest:
                 "external_id": external_id,
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [{"email": "test@example.com"}],
+                "identities": {"email": "test@example.com"},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -198,7 +198,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [identity],
+                "identities": identity,
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])
@@ -222,7 +222,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": ["test@example.com"],
+                "identities": {"email": "test@example.com"},
                 "encryption_key": "test",
             }
         ]
@@ -249,7 +249,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [identity],
+                "identities": identity,
                 "encryption_key": "test--encryption",
             }
         ]
@@ -279,7 +279,7 @@ class TestCreatePrivacyRequest:
             {
                 "requested_at": "2021-08-30T16:09:37.359Z",
                 "policy_key": policy.key,
-                "identities": [],
+                "identities": {},
             }
         ]
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CREATE])

--- a/tests/models/test_privacy_request.py
+++ b/tests/models/test_privacy_request.py
@@ -157,7 +157,7 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
+                    "identity": identity.dict(),
                 },
                 status_code=500,
             )
@@ -184,7 +184,7 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
+                    "identity": identity.dict(),
                 },
                 status_code=500,
             )
@@ -210,7 +210,7 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
+                    "identity": identity.dict(),
                     "halt": False,
                 },
                 status_code=200,
@@ -238,7 +238,7 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
+                    "identity": identity.dict(),
                     "halt": True,
                 },
                 status_code=200,
@@ -248,7 +248,7 @@ class TestPrivacyRequestTriggerWebhooks:
                 privacy_request.trigger_policy_webhook(webhook)
 
 
-    def test_trigger_two_way_policy_webhook_add_derived_identities(
+    def test_trigger_two_way_policy_webhook_add_derived_identity(
         self,
         db,
         https_connection_config,
@@ -267,8 +267,8 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
-                    "derived_identities": {"phone_number": "555-555-5555"},
+                    "identity": identity.dict(),
+                    "derived_identity": {"phone_number": "555-555-5555"},
                     "halt": False,
                 },
                 status_code=200,
@@ -301,7 +301,7 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
+                    "identity": identity.dict(),
                 },
                 status_code=200,
             )
@@ -316,8 +316,8 @@ class TestPrivacyRequestTriggerWebhooks:
                     "privacy_request_id": privacy_request.id,
                     "direction": webhook.direction.value,
                     "callback_type": webhook.prefix,
-                    "identities": identity.dict(),
-                    "derived_identities": {"unsupported_identity": "1200 Fides Road"},
+                    "identity": identity.dict(),
+                    "derived_identity": {"unsupported_identity": "1200 Fides Road"},
                     "halt": True,
                 },
                 status_code=200,

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -72,7 +72,6 @@ def get_privacy_request_results(
         "requested_at": pydash.get(privacy_request_data, "requested_at"),
         "policy_id": policy.id,
         "status": "pending",
-        # "client_id": client.id,
     }
     optional_fields = ["started_processing_at", "finished_processing_at"]
     for field in optional_fields:
@@ -83,12 +82,9 @@ def get_privacy_request_results(
         except AttributeError:
             pass
     privacy_request = PrivacyRequest.create(db=db, data=kwargs)
-
-    print(json.dumps(privacy_request_data, indent=2))
-    for identity in privacy_request_data["identities"]:
-        privacy_request.cache_identity(identity)
-        if "encryption_key" in privacy_request_data:
-            privacy_request.cache_encryption(privacy_request_data["encryption_key"])
+    privacy_request.cache_identity(privacy_request_data["identities"])
+    if "encryption_key" in privacy_request_data:
+        privacy_request.cache_encryption(privacy_request_data["encryption_key"])
 
     wait_for(
         PrivacyRequestRunner(

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -82,7 +82,7 @@ def get_privacy_request_results(
         except AttributeError:
             pass
     privacy_request = PrivacyRequest.create(db=db, data=kwargs)
-    privacy_request.cache_identity(privacy_request_data["identities"])
+    privacy_request.cache_identity(privacy_request_data["identity"])
     if "encryption_key" in privacy_request_data:
         privacy_request.cache_encryption(privacy_request_data["encryption_key"])
 
@@ -109,7 +109,7 @@ def test_create_and_process_access_request(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, policy, cache, data)
@@ -150,7 +150,7 @@ def test_create_and_process_erasure_request_specific_category(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -195,7 +195,7 @@ def test_create_and_process_erasure_request_generic_category(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": {"email": email},
+        "identity": {"email": email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -246,7 +246,7 @@ def test_create_and_process_erasure_request_with_table_joins(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -289,7 +289,7 @@ def test_create_and_process_erasure_request_read_access(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -371,7 +371,7 @@ def test_create_and_process_access_request_snowflake(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
     pr = get_privacy_request_results(db, policy, cache, data)
     results = pr.get_results()
@@ -400,7 +400,7 @@ def test_create_and_process_erasure_request_snowflake(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": {"email": customer_email},
+        "identity": {"email": customer_email},
     }
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
     pr.delete(db=db)

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -113,7 +113,7 @@ def test_create_and_process_access_request(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, policy, cache, data)
@@ -154,7 +154,7 @@ def test_create_and_process_erasure_request_specific_category(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -199,7 +199,7 @@ def test_create_and_process_erasure_request_generic_category(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": [{"email": email}],
+        "identities": {"email": email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -250,7 +250,7 @@ def test_create_and_process_erasure_request_with_table_joins(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -293,7 +293,7 @@ def test_create_and_process_erasure_request_read_access(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
 
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
@@ -375,7 +375,7 @@ def test_create_and_process_access_request_snowflake(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
     pr = get_privacy_request_results(db, policy, cache, data)
     results = pr.get_results()
@@ -404,7 +404,7 @@ def test_create_and_process_erasure_request_snowflake(
     data = {
         "requested_at": "2021-08-30T16:09:37.359Z",
         "policy_key": erasure_policy.key,
-        "identities": [{"email": customer_email}],
+        "identities": {"email": customer_email},
     }
     pr = get_privacy_request_results(db, erasure_policy, cache, data)
     pr.delete(db=db)


### PR DESCRIPTION
# Purpose

Bugfix - privacy requests take in a list of identities currently, but this is unintentional. Later items in the list would override earlier items in the list.  If you want to use multiple emails for example, they should be submitted as separate privacy requests.

# Changes
- Send identities in the privacy request as a dictionary instead of a list of dictionaries.
- Update guides, postman request, tutorial, and quickstart
- Adjust key to "identity", and related keys for updating webhooks, set key to "derived_identity" rather than "identities" and "derived_identities"

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage

# Ticket

Fixes #118 
 
