### PR TITLE
Fidesops 78 microsoft sql server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,15 @@ RUN apt-get update && \
     gcc
 
 # SQL Server (MS SQL)
+# https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15
+RUN apt-get install apt-transport-https
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/debian/10/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
 ENV ACCEPT_EULA=y DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y install \
-    apt-transport-https \
     unixodbc-dev \
+    msodbcsql17 \
     mssql-tools
 
 # Update pip and install requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-slim-buster
+FROM --platform=linux/amd64 python:3.9.6-slim-buster
 
 # Install auxiliary software
 RUN apt-get update && \
@@ -8,7 +8,19 @@ RUN apt-get update && \
     ipython \
     vim \
     curl \
+    g++ \
+    gnupg \
     gcc
+
+# SQL Server (MS SQL)
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/debian/10/prod.list | tee /etc/apt/sources.list.d/msprod.list
+RUN apt-get update
+ENV ACCEPT_EULA=y DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y install \
+    apt-transport-https \
+    unixodbc-dev \
+    mssql-tools
 
 # Update pip and install requirements
 COPY requirements.txt dev-requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,11 @@ RUN pip install -U pip  \
 # Copy in the application files and install it locally
 COPY . /fidesops
 WORKDIR /fidesops
-RUN pip install -e .
+ARG include_dangerous="False"
+RUN if [ "$include_dangerous" = "True" ] ; then \
+    pip install -e ".[all,mssql]" ; \
+    else \
+    pip install -e ".[all]" ; \
+    fi
 
 CMD [ "fidesops", "webserver" ]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ quickstart: compose-build
 ####################
 
 docker-build:
-	docker build --tag $(IMAGE) .
+	docker build --build-arg include_dangerous=$(include_dangerous) --tag $(IMAGE) .
 
 docker-push:
 	docker tag $(IMAGE) $(IMAGE_LATEST)
@@ -104,7 +104,7 @@ pytest: compose-build
 # Run the pytest integration tests.
 pytest-integration-access: compose-build
 	@echo "Building additional Docker images for integration tests..."
-	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml build
+	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml build --build-arg include_dangerous=$(include_dangerous)
 	@echo "Bringing up the integration environment..."
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml up -d
 	@echo "Waiting 10s for integration containers to be ready..."
@@ -117,7 +117,7 @@ pytest-integration-access: compose-build
 
 pytest-integration-erasure: compose-build
 	@echo "Building additional Docker images for integration tests..."
-	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml build
+	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml build --build-arg include_dangerous=$(include_dangerous)
 	@echo "Running pytest integration tests..."
 	@docker-compose -f docker-compose.yml -f docker-compose.integration-test.yml \
 		run $(IMAGE_NAME) \
@@ -150,7 +150,7 @@ clean:
 compose-build:
 	@echo "Tearing down the docker compose images, network, etc..."
 	@docker-compose down --remove-orphans
-	@docker-compose build
+	@docker-compose build --build-arg include_dangerous=$(include_dangerous)
 
 .PHONY: teardown
 teardown:

--- a/data/sql/mssql_example.sql
+++ b/data/sql/mssql_example.sql
@@ -1,0 +1,194 @@
+DROP TABLE IF EXISTS public.report;
+DROP TABLE IF EXISTS public.service_request;
+DROP TABLE IF EXISTS public.login;
+DROP TABLE IF EXISTS public.visit;
+DROP TABLE IF EXISTS public.order_item;
+DROP TABLE IF EXISTS public.orders;
+DROP TABLE IF EXISTS public.payment_card;
+DROP TABLE IF EXISTS public.employee;
+DROP TABLE IF EXISTS public.customer;
+DROP TABLE IF EXISTS public.address;
+DROP TABLE IF EXISTS public.product;
+DROP TABLE IF EXISTS public.composite_pk_test;
+DROP TABLE IF EXISTS public.type_link_test;
+
+
+CREATE TABLE public.product (
+    id INT PRIMARY KEY,
+    name CHARACTER VARYING(100),
+    price MONEY
+);
+
+CREATE TABLE public.address (
+    id BIGINT PRIMARY KEY,
+    house INT,
+    street CHARACTER VARYING(100),
+    city CHARACTER VARYING(100),
+    state CHARACTER VARYING(100),
+    zip CHARACTER VARYING(100)
+);
+
+CREATE TABLE public.customer (
+    id INT PRIMARY KEY,
+    email CHARACTER VARYING(100),
+    name  CHARACTER VARYING(100),
+    created TIMESTAMP,
+    address_id BIGINT
+);
+
+CREATE TABLE public.employee (
+    id INT PRIMARY KEY,
+    email CHARACTER VARYING(100),
+    name CHARACTER VARYING(100),
+    address_id BIGINT
+);
+
+CREATE TABLE public.payment_card (
+    id CHARACTER VARYING(100) PRIMARY KEY,
+    name CHARACTER VARYING(100),
+    ccn BIGINT,
+    code SMALLINT,
+    preferred BOOLEAN,
+    customer_id INT,
+    billing_address_id BIGINT
+);
+
+CREATE TABLE public.orders (
+    id CHARACTER VARYING(100) PRIMARY KEY,
+    customer_id INT,
+    shipping_address_id BIGINT,
+    payment_card_id CHARACTER VARYING(100)
+);
+
+CREATE TABLE public.order_item (
+    order_id CHARACTER VARYING(100),
+    item_no SMALLINT,
+    product_id INT,
+    quantity SMALLINT,
+    CONSTRAINT order_item_pk PRIMARY KEY (order_id, item_no)
+);
+
+CREATE TABLE public.visit (
+    email CHARACTER VARYING(100),
+    last_visit TIMESTAMP,
+    CONSTRAINT visit_pk PRIMARY KEY (email, last_visit)
+);
+
+CREATE TABLE public.login (
+    id INT PRIMARY KEY,
+    customer_id INT,
+    time TIMESTAMP
+);
+
+CREATE TABLE public.service_request (
+    id CHARACTER VARYING(100) PRIMARY KEY,
+    email CHARACTER VARYING(100),
+    alt_email CHARACTER VARYING(100),
+    opened DATE,
+    closed DATE,
+    employee_id INT
+);
+
+CREATE TABLE public.report (
+    id INT PRIMARY KEY,
+    email CHARACTER VARYING(100),
+    name CHARACTER VARYING(100),
+    year INT,
+    month INT,
+    total_visits INT
+);
+
+CREATE TABLE public.composite_pk_test (
+    id_a INT NOT NULL,
+    id_b INT NOT NULL,
+    description VARCHAR(100),
+    customer_id INT,
+    PRIMARY KEY(id_a, id_b)
+);
+
+INSERT INTO public.composite_pk_test VALUES
+    (1,10,'linked to customer 1',1),
+    (1,11,'linked to customer 2',2),
+    (2,10,'linked to customer 3',3);
+
+CREATE TABLE public.type_link_test (
+    id CHARACTER VARYING(100) PRIMARY KEY,
+    name CHARACTER VARYING(100)
+);
+
+-- Populate tables with some public data
+INSERT INTO public.product VALUES
+(1, 'Example Product 1', '$10.00'),
+(2, 'Example Product 2', '$20.00'),
+(3, 'Example Product 3', '$50.00');
+
+INSERT INTO public.address VALUES
+(1, '123', 'Example Street', 'Exampletown', 'NY', '12345'),
+(2, '4', 'Example Lane', 'Exampletown', 'NY', '12321'),
+(3, '555', 'Example Ave', 'Example City', 'NY', '12000'),
+(4, '1111', 'Example Place', 'Example Mountain', 'TX', '54321');
+
+
+INSERT INTO public.customer VALUES
+(1, 'customer-1@example.com', 'John Customer', '2020-04-01 11:47:42', 1),
+(2, 'customer-2@example.com', 'Jill Customer', '2020-04-01 11:47:42', 2),
+(3, 'jane@example.com', 'Jane Customer', '2020-04-01 11:47:42', 4);
+
+
+INSERT INTO public.employee VALUES
+(1, 'employee-1@example.com', 'Jack Employee', 3),
+(2, 'employee-2@example.com', 'Jane Employee', 3);
+
+INSERT INTO public.payment_card VALUES
+('pay_aaa-aaa', 'Example Card 1', 123456789, 321, true, 1, 1),
+('pay_bbb-bbb', 'Example Card 2', 987654321, 123, false, 2, 1),
+('pay_ccc-ccc', 'Example Card 3', 373719391, 222, false, 3, 4);
+
+
+INSERT INTO public.orders VALUES
+('ord_aaa-aaa', 1, 2, 'pay_aaa-aaa'),
+('ord_bbb-bbb', 2, 1, 'pay_bbb-bbb'),
+('ord_ccc-ccc', 1, 1, 'pay_aaa-aaa'),
+('ord_ddd-ddd', 1, 1, 'pay_bbb-bbb'),
+('ord_ddd-eee', 3, 4, 'pay-ccc-ccc');
+
+
+INSERT INTO public.order_item VALUES
+('ord_aaa-aaa', 1, 1, 1),
+('ord_bbb-bbb', 1, 1, 1),
+('ord_ccc-ccc', 1, 1, 1),
+('ord_ccc-ccc', 2, 2, 1),
+('ord_ddd-ddd', 1, 1, 1),
+('ord_eee-eee', 3, 4, 3);
+
+
+INSERT INTO public.visit VALUES
+('customer-1@example.com', '2021-01-06 01:00:00'),
+('customer-2@example.com', '2021-01-06 01:00:00');
+
+INSERT INTO public.login VALUES
+(1, 1, '2021-01-01 01:00:00'),
+(2, 1, '2021-01-02 01:00:00'),
+(3, 1, '2021-01-03 01:00:00'),
+(4, 1, '2021-01-04 01:00:00'),
+(5, 1, '2021-01-05 01:00:00'),
+(6, 1, '2021-01-06 01:00:00'),
+(7, 2, '2021-01-06 01:00:00'),
+(8, 3, '2021-01-06 01:00:00');
+
+
+INSERT INTO public.service_request VALUES
+('ser_aaa-aaa', 'customer-1@example.com', 'customer-1-alt@example.com', '2021-01-01', '2021-01-03', 1),
+('ser_bbb-bbb', 'customer-2@example.com', null, '2021-01-04', null, 1),
+('ser_ccc-ccc', 'customer-3@example.com', null, '2021-01-05', '2020-01-07', 1),
+('ser_ddd-ddd', 'customer-3@example.com', null, '2021-05-05', '2020-05-08', 2);
+
+INSERT INTO public.report VALUES
+(1, 'admin-account@example.com', 'Monthly Report', 2021, 8, 100),
+(2, 'admin-account@example.com', 'Monthly Report', 2021, 9, 100),
+(3, 'admin-account@example.com', 'Monthly Report', 2021, 10, 100),
+(4, 'admin-account@example.com', 'Monthly Report', 2021, 11, 100);
+
+INSERT INTO public.type_link_test VALUES
+('1', 'name1'),
+('2', 'name2');

--- a/data/sql/mssql_example.sql
+++ b/data/sql/mssql_example.sql
@@ -1,194 +1,84 @@
-DROP TABLE IF EXISTS public.report;
-DROP TABLE IF EXISTS public.service_request;
-DROP TABLE IF EXISTS public.login;
-DROP TABLE IF EXISTS public.visit;
-DROP TABLE IF EXISTS public.order_item;
-DROP TABLE IF EXISTS public.orders;
-DROP TABLE IF EXISTS public.payment_card;
-DROP TABLE IF EXISTS public.employee;
-DROP TABLE IF EXISTS public.customer;
-DROP TABLE IF EXISTS public.address;
-DROP TABLE IF EXISTS public.product;
-DROP TABLE IF EXISTS public.composite_pk_test;
-DROP TABLE IF EXISTS public.type_link_test;
+USE master;
+
+-- CREATE USER IF NOT EXISTS 'sa'@'mssql_example' IDENTIFIED BY 'Mssql_pw1';
+-- GRANT ALL PRIVILEGES ON *.* TO 'sa'@'mssql_example' ;
+-- GRANT ALL PRIVILEGES ON *.* TO 'sa'@'%' ;
+-- FLUSH PRIVILEGES;
+
+DROP DATABASE IF EXISTS mssql_example;
+CREATE DATABASE mssql_example;
+USE mssql_example;
+
+DROP TABLE IF EXISTS report;
+DROP TABLE IF EXISTS service_request;
+DROP TABLE IF EXISTS login;
+DROP TABLE IF EXISTS visit;
+DROP TABLE IF EXISTS order_item;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS payment_card;
+DROP TABLE IF EXISTS employee;
+DROP TABLE IF EXISTS customer;
+DROP TABLE IF EXISTS address;
+DROP TABLE IF EXISTS product;
+DROP TABLE IF EXISTS composite_pk_test;
+DROP TABLE IF EXISTS type_link_test;
 
 
-CREATE TABLE public.product (
-    id INT PRIMARY KEY,
-    name CHARACTER VARYING(100),
-    price MONEY
-);
+CREATE TABLE product ( id INT PRIMARY KEY, name CHARACTER VARYING(100), price MONEY);
 
-CREATE TABLE public.address (
-    id BIGINT PRIMARY KEY,
-    house INT,
-    street CHARACTER VARYING(100),
-    city CHARACTER VARYING(100),
-    state CHARACTER VARYING(100),
-    zip CHARACTER VARYING(100)
-);
+CREATE TABLE address ( id BIGINT PRIMARY KEY, house INT, street CHARACTER VARYING(100), city CHARACTER VARYING(100), state CHARACTER VARYING(100), zip CHARACTER VARYING(100));
 
-CREATE TABLE public.customer (
-    id INT PRIMARY KEY,
-    email CHARACTER VARYING(100),
-    name  CHARACTER VARYING(100),
-    created TIMESTAMP,
-    address_id BIGINT
-);
+CREATE TABLE customer ( id INT PRIMARY KEY, email CHARACTER VARYING(100), name CHARACTER VARYING(100), created DATETIME, address_id BIGINT);
 
-CREATE TABLE public.employee (
-    id INT PRIMARY KEY,
-    email CHARACTER VARYING(100),
-    name CHARACTER VARYING(100),
-    address_id BIGINT
-);
+CREATE TABLE employee ( id INT PRIMARY KEY, email CHARACTER VARYING(100), name CHARACTER VARYING(100), address_id BIGINT);
 
-CREATE TABLE public.payment_card (
-    id CHARACTER VARYING(100) PRIMARY KEY,
-    name CHARACTER VARYING(100),
-    ccn BIGINT,
-    code SMALLINT,
-    preferred BOOLEAN,
-    customer_id INT,
-    billing_address_id BIGINT
-);
+CREATE TABLE payment_card ( id CHARACTER VARYING(100) PRIMARY KEY, name CHARACTER VARYING(100), ccn BIGINT, code SMALLINT, preferred BIT, customer_id INT, billing_address_id BIGINT);
 
-CREATE TABLE public.orders (
-    id CHARACTER VARYING(100) PRIMARY KEY,
-    customer_id INT,
-    shipping_address_id BIGINT,
-    payment_card_id CHARACTER VARYING(100)
-);
+CREATE TABLE orders ( id CHARACTER VARYING(100) PRIMARY KEY, customer_id INT, shipping_address_id BIGINT, payment_card_id CHARACTER VARYING(100));
 
-CREATE TABLE public.order_item (
-    order_id CHARACTER VARYING(100),
-    item_no SMALLINT,
-    product_id INT,
-    quantity SMALLINT,
-    CONSTRAINT order_item_pk PRIMARY KEY (order_id, item_no)
-);
+CREATE TABLE order_item ( order_id CHARACTER VARYING(100), item_no SMALLINT, product_id INT, quantity SMALLINT, CONSTRAINT order_item_pk PRIMARY KEY (order_id, item_no));
 
-CREATE TABLE public.visit (
-    email CHARACTER VARYING(100),
-    last_visit TIMESTAMP,
-    CONSTRAINT visit_pk PRIMARY KEY (email, last_visit)
-);
+CREATE TABLE visit ( email CHARACTER VARYING(100), last_visit DATETIME, CONSTRAINT visit_pk PRIMARY KEY (email, last_visit));
 
-CREATE TABLE public.login (
-    id INT PRIMARY KEY,
-    customer_id INT,
-    time TIMESTAMP
-);
+CREATE TABLE login ( id INT PRIMARY KEY, customer_id INT, time DATETIME);
 
-CREATE TABLE public.service_request (
-    id CHARACTER VARYING(100) PRIMARY KEY,
-    email CHARACTER VARYING(100),
-    alt_email CHARACTER VARYING(100),
-    opened DATE,
-    closed DATE,
-    employee_id INT
-);
+CREATE TABLE service_request ( id CHARACTER VARYING(100) PRIMARY KEY, email CHARACTER VARYING(100), alt_email CHARACTER VARYING(100), opened DATE, closed DATE, employee_id INT);
 
-CREATE TABLE public.report (
-    id INT PRIMARY KEY,
-    email CHARACTER VARYING(100),
-    name CHARACTER VARYING(100),
-    year INT,
-    month INT,
-    total_visits INT
-);
+CREATE TABLE report ( id INT PRIMARY KEY, email CHARACTER VARYING(100), name CHARACTER VARYING(100), year INT, month INT, total_visits INT);
 
-CREATE TABLE public.composite_pk_test (
-    id_a INT NOT NULL,
-    id_b INT NOT NULL,
-    description VARCHAR(100),
-    customer_id INT,
-    PRIMARY KEY(id_a, id_b)
-);
+CREATE TABLE composite_pk_test ( id_a INT NOT NULL, id_b INT NOT NULL, description VARCHAR(100), customer_id INT, PRIMARY KEY(id_a, id_b));
 
-INSERT INTO public.composite_pk_test VALUES
-    (1,10,'linked to customer 1',1),
-    (1,11,'linked to customer 2',2),
-    (2,10,'linked to customer 3',3);
+INSERT INTO composite_pk_test VALUES (1,10,'linked to customer 1',1), (1,11,'linked to customer 2',2), (2,10,'linked to customer 3',3);
 
-CREATE TABLE public.type_link_test (
-    id CHARACTER VARYING(100) PRIMARY KEY,
-    name CHARACTER VARYING(100)
-);
+CREATE TABLE type_link_test ( id CHARACTER VARYING(100) PRIMARY KEY, name CHARACTER VARYING(100));
 
 -- Populate tables with some public data
-INSERT INTO public.product VALUES
-(1, 'Example Product 1', '$10.00'),
-(2, 'Example Product 2', '$20.00'),
-(3, 'Example Product 3', '$50.00');
+INSERT INTO product VALUES (1, 'Example Product 1', '$10.00'), (2, 'Example Product 2', '$20.00'), (3, 'Example Product 3', '$50.00');
 
-INSERT INTO public.address VALUES
-(1, '123', 'Example Street', 'Exampletown', 'NY', '12345'),
-(2, '4', 'Example Lane', 'Exampletown', 'NY', '12321'),
-(3, '555', 'Example Ave', 'Example City', 'NY', '12000'),
-(4, '1111', 'Example Place', 'Example Mountain', 'TX', '54321');
+INSERT INTO address VALUES (1, '123', 'Example Street', 'Exampletown', 'NY', '12345'), (2, '4', 'Example Lane', 'Exampletown', 'NY', '12321'), (3, '555', 'Example Ave', 'Example City', 'NY', '12000'), (4, '1111', 'Example Place', 'Example Mountain', 'TX', '54321');
 
 
-INSERT INTO public.customer VALUES
-(1, 'customer-1@example.com', 'John Customer', '2020-04-01 11:47:42', 1),
-(2, 'customer-2@example.com', 'Jill Customer', '2020-04-01 11:47:42', 2),
-(3, 'jane@example.com', 'Jane Customer', '2020-04-01 11:47:42', 4);
+INSERT INTO customer VALUES (1, 'customer-1@example.com', 'John Customer', '2020-04-01 11:47:42', 1), (2, 'customer-2@example.com', 'Jill Customer', '2020-04-01 11:47:42', 2), (3, 'jane@example.com', 'Jane Customer', '2020-04-01 11:47:42', 4);
 
 
-INSERT INTO public.employee VALUES
-(1, 'employee-1@example.com', 'Jack Employee', 3),
-(2, 'employee-2@example.com', 'Jane Employee', 3);
+INSERT INTO employee VALUES (1, 'employee-1@example.com', 'Jack Employee', 3), (2, 'employee-2@example.com', 'Jane Employee', 3);
 
-INSERT INTO public.payment_card VALUES
-('pay_aaa-aaa', 'Example Card 1', 123456789, 321, true, 1, 1),
-('pay_bbb-bbb', 'Example Card 2', 987654321, 123, false, 2, 1),
-('pay_ccc-ccc', 'Example Card 3', 373719391, 222, false, 3, 4);
+INSERT INTO payment_card VALUES ('pay_aaa-aaa', 'Example Card 1', 123456789, 321, 1, 1, 1), ('pay_bbb-bbb', 'Example Card 2', 987654321, 123, 0, 2, 1), ('pay_ccc-ccc', 'Example Card 3', 373719391, 222, 0, 3, 4);
 
 
-INSERT INTO public.orders VALUES
-('ord_aaa-aaa', 1, 2, 'pay_aaa-aaa'),
-('ord_bbb-bbb', 2, 1, 'pay_bbb-bbb'),
-('ord_ccc-ccc', 1, 1, 'pay_aaa-aaa'),
-('ord_ddd-ddd', 1, 1, 'pay_bbb-bbb'),
-('ord_ddd-eee', 3, 4, 'pay-ccc-ccc');
+INSERT INTO orders VALUES ('ord_aaa-aaa', 1, 2, 'pay_aaa-aaa'), ('ord_bbb-bbb', 2, 1, 'pay_bbb-bbb'), ('ord_ccc-ccc', 1, 1, 'pay_aaa-aaa'), ('ord_ddd-ddd', 1, 1, 'pay_bbb-bbb'), ('ord_ddd-eee', 3, 4, 'pay-ccc-ccc');
 
 
-INSERT INTO public.order_item VALUES
-('ord_aaa-aaa', 1, 1, 1),
-('ord_bbb-bbb', 1, 1, 1),
-('ord_ccc-ccc', 1, 1, 1),
-('ord_ccc-ccc', 2, 2, 1),
-('ord_ddd-ddd', 1, 1, 1),
-('ord_eee-eee', 3, 4, 3);
+INSERT INTO order_item VALUES ('ord_aaa-aaa', 1, 1, 1), ('ord_bbb-bbb', 1, 1, 1), ('ord_ccc-ccc', 1, 1, 1), ('ord_ccc-ccc', 2, 2, 1), ('ord_ddd-ddd', 1, 1, 1), ('ord_eee-eee', 3, 4, 3);
 
 
-INSERT INTO public.visit VALUES
-('customer-1@example.com', '2021-01-06 01:00:00'),
-('customer-2@example.com', '2021-01-06 01:00:00');
+INSERT INTO visit VALUES ('customer-1@example.com', '2021-01-06 01:00:00'), ('customer-2@example.com', '2021-01-06 01:00:00');
 
-INSERT INTO public.login VALUES
-(1, 1, '2021-01-01 01:00:00'),
-(2, 1, '2021-01-02 01:00:00'),
-(3, 1, '2021-01-03 01:00:00'),
-(4, 1, '2021-01-04 01:00:00'),
-(5, 1, '2021-01-05 01:00:00'),
-(6, 1, '2021-01-06 01:00:00'),
-(7, 2, '2021-01-06 01:00:00'),
-(8, 3, '2021-01-06 01:00:00');
+INSERT INTO login VALUES (1, 1, '2021-01-01 01:00:00'), (2, 1, '2021-01-02 01:00:00'), (3, 1, '2021-01-03 01:00:00'), (4, 1, '2021-01-04 01:00:00'), (5, 1, '2021-01-05 01:00:00'), (6, 1, '2021-01-06 01:00:00'), (7, 2, '2021-01-06 01:00:00'), (8, 3, '2021-01-06 01:00:00');
 
 
-INSERT INTO public.service_request VALUES
-('ser_aaa-aaa', 'customer-1@example.com', 'customer-1-alt@example.com', '2021-01-01', '2021-01-03', 1),
-('ser_bbb-bbb', 'customer-2@example.com', null, '2021-01-04', null, 1),
-('ser_ccc-ccc', 'customer-3@example.com', null, '2021-01-05', '2020-01-07', 1),
-('ser_ddd-ddd', 'customer-3@example.com', null, '2021-05-05', '2020-05-08', 2);
+INSERT INTO service_request VALUES ('ser_aaa-aaa', 'customer-1@example.com', 'customer-1-alt@example.com', '2021-01-01', '2021-01-03', 1), ('ser_bbb-bbb', 'customer-2@example.com', null, '2021-01-04', null, 1), ('ser_ccc-ccc', 'customer-3@example.com', null, '2021-01-05', '2020-01-07', 1), ('ser_ddd-ddd', 'customer-3@example.com', null, '2021-05-05', '2020-05-08', 2);
 
-INSERT INTO public.report VALUES
-(1, 'admin-account@example.com', 'Monthly Report', 2021, 8, 100),
-(2, 'admin-account@example.com', 'Monthly Report', 2021, 9, 100),
-(3, 'admin-account@example.com', 'Monthly Report', 2021, 10, 100),
-(4, 'admin-account@example.com', 'Monthly Report', 2021, 11, 100);
+INSERT INTO report VALUES (1, 'admin-account@example.com', 'Monthly Report', 2021, 8, 100), (2, 'admin-account@example.com', 'Monthly Report', 2021, 9, 100), (3, 'admin-account@example.com', 'Monthly Report', 2021, 10, 100), (4, 'admin-account@example.com', 'Monthly Report', 2021, 11, 100);
 
-INSERT INTO public.type_link_test VALUES
-('1', 'name1'),
-('2', 'name2');
+INSERT INTO type_link_test VALUES ('1', 'name1'), ('2', 'name2');

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -54,12 +54,10 @@ services:
 
   mssql_example:
     image: mcr.microsoft.com/azure-sql-edge:latest # Equivalent to SQL Server 2016
-    volumes:
-      - ./data/sql/mssql_example.sql:/docker-entrypoint-initdb.d/mssql_example.sql
     ports:
       - 1433:1433
     environment:
-      - SA_PASSWORD=mssql_pw
+      - SA_PASSWORD=Mssql_pw1
       - ACCEPT_EULA="Y"
 
 

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -53,8 +53,7 @@ services:
       - ./data/sql/mysql_example.sql:/docker-entrypoint-initdb.d/mysql_example.sql
 
   mssql_example:
-#    image: mcr.microsoft.com/azure-sql-edge:latest
-   image: mcr.microsoft.com/mssql/server
+    image: mcr.microsoft.com/mssql/server
     volumes:
       - ./data/sql/mssql_example.sql:/docker-entrypoint-initdb.d/mssql_example.sql
     ports:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -53,8 +53,8 @@ services:
       - ./data/sql/mysql_example.sql:/docker-entrypoint-initdb.d/mysql_example.sql
 
   mssql_example:
-    image: mcr.microsoft.com/azure-sql-edge:latest
-#   image: mcr.microsoft.com/mssql/server
+#    image: mcr.microsoft.com/azure-sql-edge:latest
+   image: mcr.microsoft.com/mssql/server
     volumes:
       - ./data/sql/mssql_example.sql:/docker-entrypoint-initdb.d/mssql_example.sql
     ports:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -53,7 +53,7 @@ services:
       - ./data/sql/mysql_example.sql:/docker-entrypoint-initdb.d/mysql_example.sql
 
   mssql_example:
-    image: mcr.microsoft.com/mssql/server
+    image: mcr.microsoft.com/azure-sql-edge:latest # Equivalent to SQL Server 2016
     volumes:
       - ./data/sql/mssql_example.sql:/docker-entrypoint-initdb.d/mssql_example.sql
     ports:

--- a/docker-compose.integration-test.yml
+++ b/docker-compose.integration-test.yml
@@ -4,6 +4,7 @@ services:
       - postgres_example
       - mongodb_example
       - mysql_example
+      - mssql_example
 
   postgres_example:
     image: postgres:12
@@ -50,3 +51,16 @@ services:
       - "3306:3306"
     volumes:
       - ./data/sql/mysql_example.sql:/docker-entrypoint-initdb.d/mysql_example.sql
+
+  mssql_example:
+    image: mcr.microsoft.com/azure-sql-edge:latest
+#   image: mcr.microsoft.com/mssql/server
+    volumes:
+      - ./data/sql/mssql_example.sql:/docker-entrypoint-initdb.d/mssql_example.sql
+    ports:
+      - 1433:1433
+    environment:
+      - SA_PASSWORD=mssql_pw
+      - ACCEPT_EULA="Y"
+
+

--- a/docs/fidesops/docs/development/overview.md
+++ b/docs/fidesops/docs/development/overview.md
@@ -29,8 +29,8 @@ commands to give you different functionality.
 - `make server-shell`-  opens a shell on the Docker container, from here you can run useful commands like:
   - `ipython` - open a Python shell
 - `make pytest` - runs all unit tests except those that talk to integration databases
-- `make pytest-integration-access` - runs access integration tests
-- `make pytest-integration-erasure` - runs erasure integration tests
+- `make include_dangerous="True" pytest-integration-access` - runs access integration tests. See note below about MSSQL.
+- `make include_dangerous="True" pytest-integration-erasure` - runs erasure integration tests. See note below about MSSQL.
 - `make reset-db` - tears down the Fideops postgres db, then recreates and re-runs migrations.
 - `make quickstart` - runs a quick, five second quickstart that talks to the Fidesops API to execute privacy requests
 - `make check-migrations` - verifies there are no un-run migrations 
@@ -40,7 +40,13 @@ See [Makefile](https://github.com/ethyca/fidesops/blob/main/Makefile) for more o
 
 
 #### Issues 
-When running `make server`, if you get a `importlib.metadata.PackageNotFoundError: fidesops`, do `make server-shell`,
+
+- MSSQL: Known issues around connecting to MSSQL exist today for Apple M1 users, so the `pyodbc` dependency is not installed by default.
+If you wish to install MSSQL please add the `include_dangerous="True"` argument to the `make` commands above, e.g. `make include_dangerous="True" server`.
+
+M1 users that wish to install MSSQL please reference the workaround [here](https://github.com/mkleehammer/pyodbc/issues/846).
+
+- Package not found: When running `make server`, if you get a `importlib.metadata.PackageNotFoundError: fidesops`, do `make server-shell`,
 and then run `pip install -e .`. Verify Fidesops is installed with `pip list`. 
 
 

--- a/fidesops-integration.toml
+++ b/fidesops-integration.toml
@@ -27,4 +27,4 @@ external_uri=""
 
 [mssql_example]
 SA_PASSWORD="mssql_pw"
-
+ACCEPT_EULA="Y"

--- a/fidesops-integration.toml
+++ b/fidesops-integration.toml
@@ -26,5 +26,9 @@ external_uri=""
 external_uri=""
 
 [mssql_example]
-SA_PASSWORD="mssql_pw"
-ACCEPT_EULA="Y"
+SERVER="mssql_example"
+USER="mssql_user"
+PASSWORD="mssql_pw"
+DB="mssql_example"
+PORT_NO=5432
+

--- a/fidesops-integration.toml
+++ b/fidesops-integration.toml
@@ -27,8 +27,8 @@ external_uri=""
 
 [mssql_example]
 SERVER="mssql_example"
-USER="mssql_user"
-PASSWORD="mssql_pw"
+USER="sa"
+PASSWORD="Mssql_pw1"
 DB="mssql_example"
-PORT_NO=5432
+PORT=1433
 

--- a/fidesops-integration.toml
+++ b/fidesops-integration.toml
@@ -17,10 +17,14 @@ SERVER="mysql_example"
 USER="mysql_user"
 PASSWORD="mysql_pw"
 DB="mysql_example"
-PORT= 3306
+PORT=3306
 
 [redshift]
 external_uri=""
 
 [snowflake]
 external_uri=""
+
+[mssql_example]
+SA_PASSWORD="mssql_pw"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,6 @@ pymongo==3.12.0
 pandas==1.3.3
 click==7.1.2
 PyMySQL==1.0.2
+pyodbc==4.0.32
 sqlalchemy-redshift==0.8.8
 snowflake-sqlalchemy==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,5 @@ pymongo==3.12.0
 pandas==1.3.3
 click==7.1.2
 PyMySQL==1.0.2
-pyodbc==4.0.32
 sqlalchemy-redshift==0.8.8
 snowflake-sqlalchemy==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,16 @@ long_description = open("README.md").read()
 install_requires = open("requirements.txt").read().strip().split("\n")
 dev_requires = open("dev-requirements.txt").read().strip().split("\n")
 
-# todo- exclude pyodbc
+# Human-Readable/Reusable Extras
+mssql_connector = "pyodbc==4.0.32"
+
+extras = {
+    "mssql": [mssql_connector],
+}
+dangerous_extras = ["mssql"]  # These extras break on certain platforms
+extras["all"] = sum(
+    [value for key, value in extras.items() if key not in dangerous_extras], []
+)
 
 setup(
     name="fidesops",
@@ -26,6 +35,7 @@ setup(
     license="Apache License 2.0",
     install_requires=install_requires,
     dev_requires=dev_requires,
+    extras_require=extras,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ long_description = open("README.md").read()
 install_requires = open("requirements.txt").read().strip().split("\n")
 dev_requires = open("dev-requirements.txt").read().strip().split("\n")
 
+# todo- exclude pyodbc
+
 setup(
     name="fidesops",
     description="Automation engine for privacy requests",

--- a/src/fidesops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_endpoints.py
@@ -195,7 +195,7 @@ def connection_status(
         status: TestStatus = connector.test_connection()
     except ConnectionException as exc:
         logger.warning(
-            "Connection test failed on %s: %s", NotPii(connection_config.key), str(exc)
+            "Connection test failed on %s: %s", NotPii(connection_config.key), str(NotPii(exc))
         )
         connection_config.update_test_status(test_status=TestStatus.failed, db=db)
         return TestStatusMessage(

--- a/src/fidesops/models/connectionconfig.py
+++ b/src/fidesops/models/connectionconfig.py
@@ -35,7 +35,7 @@ class TestStatus(enum.Enum):
 
 class ConnectionType(enum.Enum):
     """
-    Supported types to which we can connect fides-ops.
+    Supported types to which we can connect fidesops.
     """
 
     postgres = "postgres"
@@ -44,11 +44,12 @@ class ConnectionType(enum.Enum):
     https = "https"
     redshift = "redshift"
     snowflake = "snowflake"
+    mssql = "mssql"
 
 
 class AccessLevel(enum.Enum):
     """
-    Perms given to the ConnectionConfig.  For example, with "read" permissions, fides-ops promises
+    Perms given to the ConnectionConfig.  For example, with "read" permissions, fidesops promises
     to not modify the data on a connected application database in any way.
 
     "Write" perms mean we can update/delete items in the connected database.
@@ -60,7 +61,7 @@ class AccessLevel(enum.Enum):
 
 class ConnectionConfig(Base):
     """
-    Stores credentials to connect fides-ops to an engineer's application databases.
+    Stores credentials to connect fidesops to an engineer's application databases.
     """
 
     name = Column(String, index=True, unique=True, nullable=False)

--- a/src/fidesops/schemas/connection_configuration/__init__.py
+++ b/src/fidesops/schemas/connection_configuration/__init__.py
@@ -7,6 +7,10 @@ from fidesops.schemas.connection_configuration.connection_secrets_mongodb import
 from fidesops.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
+from fidesops.schemas.connection_configuration.connection_secrets_mssql import (
+    MicrosoftSQLServerSchema,
+    MSSQLDocsSchema,
+)
 from fidesops.schemas.connection_configuration.connection_secrets_mysql import (
     MySQLSchema,
     MySQLDocsSchema,
@@ -35,6 +39,7 @@ secrets_validators: Dict[str, Any] = {
     ConnectionType.mysql.value: MySQLSchema,
     ConnectionType.redshift.value: RedshiftSchema,
     ConnectionType.snowflake.value: SnowflakeSchema,
+    ConnectionType.mssql.value: MicrosoftSQLServerSchema,
 }
 
 
@@ -61,4 +66,5 @@ connection_secrets_schemas = Union[
     MySQLDocsSchema,
     RedshiftDocsSchema,
     SnowflakeDocsSchema,
+    MSSQLDocsSchema,
 ]

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
@@ -10,9 +10,7 @@ class MicrosoftSQLServerSchema(ConnectionConfigSecretsSchema):
     """Schema to validate the secrets needed to connect to a MS SQL Database
 
     connection string takes the format:
-    mssql://[Server_Name[:Portno]]/[Database_Instance_Name]/[Database_Name]?FailoverPartner=[Partner_Server_Name]&InboundId=[Inbound_ID]
-
-    Will probably change some depending on SQLAlchemy dialect/DBAPI option used
+    mssql+pyodbc://[username]:[password]@[host]:[port_no]/[database_name]?driver=ODBC+Driver+17+for+SQL+Server
 
     """
 
@@ -21,9 +19,6 @@ class MicrosoftSQLServerSchema(ConnectionConfigSecretsSchema):
     host: Optional[str] = None
     port_no: Optional[int] = None
     database_name: Optional[str] = None
-    driver: Optional[str] = None
-    driver_authentication: Optional[str] = None
-
 
     _required_components: List[str] = ["host"]
 

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
@@ -16,14 +16,16 @@ class MicrosoftSQLServerSchema(ConnectionConfigSecretsSchema):
 
     """
 
-    server_name: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    host: Optional[str] = None
     port_no: Optional[int] = None
-    database_instance_name: Optional[str] = None
     database_name: Optional[str] = None
-    partner_server_name: Optional[str] = None
-    inbound_id: Optional[str] = None
+    driver: Optional[str] = None
+    driver_authentication: Optional[str] = None
 
-    _required_components: List[str] = ["server_name"]
+
+    _required_components: List[str] = ["host"]
 
 
 class MSSQLDocsSchema(MicrosoftSQLServerSchema, NoValidationSchema):

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
@@ -1,0 +1,29 @@
+from typing import Optional, List
+
+from fidesops.schemas.base_class import NoValidationSchema
+from fidesops.schemas.connection_configuration.connection_secrets import (
+    ConnectionConfigSecretsSchema,
+)
+
+
+class MicrosoftSQLServerSchema(ConnectionConfigSecretsSchema):
+    """Schema to validate the secrets needed to connect to a MS SQL Database
+
+    connection string takes the format:
+    mssql://[Server_Name[:Portno]]/[Database_Instance_Name]/[Database_Name]?FailoverPartner=[Partner_Server_Name]&InboundId=[Inbound_ID]
+
+    Will probably change some depending on SQLAlchemy dialect/DBAPI option used
+
+    """
+
+    server_name: Optional[str] = None
+    port_no: Optional[int] = None
+    database_instance_name: Optional[str] = None
+    partner_server_name: Optional[str] = None
+    inbound_id: Optional[str] = None
+
+    _required_components: List[str] = ["server_name"]
+
+
+class MSSQLDocsSchema(MicrosoftSQLServerSchema, NoValidationSchema):
+    """MS SQL Secrets Schema for API Docs"""

--- a/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
+++ b/src/fidesops/schemas/connection_configuration/connection_secrets_mssql.py
@@ -19,6 +19,7 @@ class MicrosoftSQLServerSchema(ConnectionConfigSecretsSchema):
     server_name: Optional[str] = None
     port_no: Optional[int] = None
     database_instance_name: Optional[str] = None
+    database_name: Optional[str] = None
     partner_server_name: Optional[str] = None
     inbound_id: Optional[str] = None
 

--- a/src/fidesops/service/connectors/__init__.py
+++ b/src/fidesops/service/connectors/__init__.py
@@ -8,7 +8,7 @@ from fidesops.service.connectors.sql_connector import (
     PostgreSQLConnector,
     MySQLConnector,
     RedshiftConnector,
-    SnowflakeConnector,
+    SnowflakeConnector, MicrosoftSQLServerConnector,
 )
 
 supported_connectors: Dict[str, Any] = {
@@ -18,6 +18,7 @@ supported_connectors: Dict[str, Any] = {
     ConnectionType.redshift.value: RedshiftConnector,
     ConnectionType.snowflake.value: SnowflakeConnector,
     ConnectionType.https.value: HTTPSConnector,
+    ConnectionType.mssql.value: MicrosoftSQLServerConnector
 }
 
 

--- a/src/fidesops/service/connectors/sql_connector.py
+++ b/src/fidesops/service/connectors/sql_connector.py
@@ -252,7 +252,7 @@ class MicrosoftSQLServerConnector(SQLConnector):
             port=config.port_no,
             database=config.database_name,
             query={
-                "driver": "ODBC+Driver+17+for+SQL+Server"
+                "driver": "ODBC Driver 17 for SQL Server"
             },
         )
 

--- a/src/fidesops/service/connectors/sql_connector.py
+++ b/src/fidesops/service/connectors/sql_connector.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -14,7 +15,7 @@ from fidesops.models.policy import Policy
 from fidesops.schemas.connection_configuration import (
     PostgreSQLSchema,
     RedshiftSchema,
-    SnowflakeSchema,
+    SnowflakeSchema, MicrosoftSQLServerSchema,
 )
 from fidesops.schemas.connection_configuration.connection_secrets_mysql import (
     MySQLSchema,
@@ -236,3 +237,29 @@ class MicrosoftSQLServerConnector(SQLConnector):
     """
     Connector specific to Microsoft SQL Server
     """
+    def build_uri(self) -> str:
+        """Build URI of format mssql://[Server_Name[:Portno]]/[Database_Instance_Name]/[Database_Name]
+        ?FailoverPartner=[Partner_Server_Name]&InboundId=[Inbound_ID]"""
+        config = MicrosoftSQLServerSchema(**self.configuration.secrets or {})
+
+        server_name = config.server_name
+        port = f":{config.port_no}" if config.port_no else ""
+        db_instance_name = f"/{config.database_instance_name}" if config.database_instance_name else ""
+        db_name = f"/{config.database_name}" if config.database_name else ""
+        params: Dict[str, str] = {}
+        if config.partner_server_name:
+            params["FailoverPartner"] = config.partner_server_name
+        if config.inbound_id:
+            params["InboundId"] = config.inbound_id
+        url = f"mssql://{server_name}{port}{db_instance_name}{db_name}{urllib.parse.urlencode(params)}"
+        return url
+
+    def create_client(self) -> Engine:
+        """Returns a SQLAlchemy Engine that can be used to interact with a MicrosoftSQLServer database"""
+        config = MicrosoftSQLServerSchema(**self.configuration.secrets or {})
+        uri = config.url or self.build_uri()
+        return create_engine(
+            uri,
+            hide_parameters=self.hide_parameters,
+            echo=not self.hide_parameters,
+        )

--- a/src/fidesops/service/connectors/sql_connector.py
+++ b/src/fidesops/service/connectors/sql_connector.py
@@ -230,3 +230,9 @@ class SnowflakeConnector(SQLConnector):
     def query_config(self, node: TraversalNode) -> SQLQueryConfig:
         """Query wrapper corresponding to the input traversal_node."""
         return SnowflakeQueryConfig(node)
+
+
+class MicrosoftSQLServerConnector(SQLConnector):
+    """
+    Connector specific to Microsoft SQL Server
+    """

--- a/src/fidesops/service/connectors/sql_connector.py
+++ b/src/fidesops/service/connectors/sql_connector.py
@@ -237,8 +237,11 @@ class MicrosoftSQLServerConnector(SQLConnector):
     Connector specific to Microsoft SQL Server
     """
     def build_uri(self) -> URL:
-        """Build URI of format mssql+pyodbc://[Server_Name[:Portno]]/[Database_Instance_Name]/[Database_Name]
-        ?FailoverPartner=[Partner_Server_Name]&InboundId=[Inbound_ID]"""
+        """
+        Build URI of format
+        mssql+pyodbc://[username]:[password]@[host]:[port_no]/[database_name]?driver=ODBC+Driver+17+for+SQL+Server
+        """
+
         config = MicrosoftSQLServerSchema(**self.configuration.secrets or {})
 
         url = URL.create(
@@ -249,8 +252,7 @@ class MicrosoftSQLServerConnector(SQLConnector):
             port=config.port_no,
             database=config.database_name,
             query={
-                "driver": config.driver,
-                "authentication": config.driver_authentication,
+                "driver": "ODBC+Driver+17+for+SQL+Server"
             },
         )
 

--- a/src/migrations/versions/f3841942d90c_add_mssql.py
+++ b/src/migrations/versions/f3841942d90c_add_mssql.py
@@ -1,0 +1,35 @@
+"""add mssql (Microsoft SQL Server)
+
+Revision ID: f3841942d90c
+Revises: d65e7e921814
+Create Date: 2021-12-13 22:15:25.043952
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f3841942d90c"
+down_revision = "d65e7e921814"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("alter type connectiontype add value 'mssql'")
+
+
+def downgrade():
+    op.execute("delete from connectionconfig where connection_type in ('mssql')")
+    op.execute("alter type connectiontype rename to connectiontype_old")
+    op.execute(
+        "create type connectiontype as enum('postgres', 'mongodb', 'mysql', 'https', 'snowflake', 'redshift')"
+    )
+    op.execute(
+        (
+            "alter table connectionconfig alter column connection_type type connectiontype using "
+            "connection_type::text::connectiontype"
+        )
+    )
+    op.execute("drop type connectiontype_old")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -80,6 +80,13 @@ integration_secrets = {
         "username": pydash.get(integration_config, "mysql_example.USER"),
         "password": pydash.get(integration_config, "mysql_example.PASSWORD"),
     },
+    "mssql_example": {
+        "host": pydash.get(integration_config, "mysql_example.SERVER"),
+        "port_no": pydash.get(integration_config, "mysql_example.PORT"),
+        "database_name": pydash.get(integration_config, "mysql_example.DB"),
+        "username": pydash.get(integration_config, "mysql_example.USER"),
+        "password": pydash.get(integration_config, "mysql_example.PASSWORD"),
+    },
 }
 
 
@@ -191,6 +198,22 @@ def connection_config_mysql(db: Session) -> Generator:
             "connection_type": ConnectionType.mysql,
             "access": AccessLevel.write,
             "secrets": integration_secrets["mysql_example"],
+        },
+    )
+    yield connection_config
+    connection_config.delete(db)
+
+
+@pytest.fixture(scope="function")
+def connection_config_mssql(db: Session) -> Generator:
+    connection_config = ConnectionConfig.create(
+        db=db,
+        data={
+            "name": str(uuid4()),
+            "key": "my_mssql_db_1",
+            "connection_type": ConnectionType.mssql,
+            "access": AccessLevel.write,
+            "secrets": integration_secrets["mssql_example"],
         },
     )
     yield connection_config

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -81,11 +81,11 @@ integration_secrets = {
         "password": pydash.get(integration_config, "mysql_example.PASSWORD"),
     },
     "mssql_example": {
-        "host": pydash.get(integration_config, "mysql_example.SERVER"),
-        "port_no": pydash.get(integration_config, "mysql_example.PORT"),
-        "database_name": pydash.get(integration_config, "mysql_example.DB"),
-        "username": pydash.get(integration_config, "mysql_example.USER"),
-        "password": pydash.get(integration_config, "mysql_example.PASSWORD"),
+        "host": pydash.get(integration_config, "mssql_example.SERVER"),
+        "port_no": pydash.get(integration_config, "mssql_example.PORT"),
+        "database_name": pydash.get(integration_config, "mssql_example.DB"),
+        "username": pydash.get(integration_config, "mssql_example.USER"),
+        "password": pydash.get(integration_config, "mssql_example.PASSWORD"),
     },
 }
 


### PR DESCRIPTION
# Purpose
Adds SQL Server support

# Changes
- Adds connection support for mssql
- Adds connection integration tests for mssql
- To manually test, in Postman `PUT` `{{host}}/connection/{{mssql_key}}/secret`, use the following url: `"mssql+pyodbc://sa:Mssql_pw1@mssql_example:1433/master?driver=ODBC+Driver+17+for+SQL+Server"`, alternatively you can break each part out into separate components, refer to `connection_secrets_mssql.py`. 

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage

# Ticket

Fixes #78 
 
