### PR TITLE
Fix Quickstart and Tutorial

### DIFF
--- a/docs/fidesops/docs/tutorial/annotate_datasets.md
+++ b/docs/fidesops/docs/tutorial/annotate_datasets.md
@@ -79,7 +79,7 @@ def create_dataset(connection_key, yaml_path, access_token):
         dataset = yaml.safe_load(file).get("dataset", [])[0]
 
     dataset_create_data = [dataset]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/connection/{connection_key}/dataset",
         headers=oauth_headers(access_token=access_token),
         json=dataset_create_data,

--- a/docs/fidesops/docs/tutorial/define_policy.md
+++ b/docs/fidesops/docs/tutorial/define_policy.md
@@ -29,7 +29,7 @@ def create_policy(key, access_token):
             "key": key,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy",
         headers=oauth_headers(access_token=access_token),
         json=policy_create_data,
@@ -56,7 +56,7 @@ def create_policy_rule(
             "storage_destination_key": storage_destination_key,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy/{policy_key}/rule",
         headers=oauth_headers(access_token=access_token),
         json=rule_create_data,
@@ -80,7 +80,7 @@ def create_policy_rule_target(policy_key, rule_key, data_category, access_token)
             "data_category": data_category,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy/{policy_key}/rule/{rule_key}/target",
         headers=oauth_headers(access_token=access_token),
         json=target_create_data,

--- a/docs/fidesops/docs/tutorial/execute_privacy_request.md
+++ b/docs/fidesops/docs/tutorial/execute_privacy_request.md
@@ -88,7 +88,8 @@ INFO:__main__:Executing a Privacy Request. Status 200
 INFO:__main__:Check fidesdemo/fidesuploads for upload package.
 ```
 
-Check your `fidesdemo/fides_uploads` directory for your data package:
+Check your `fidesdemo/fides_uploads` directory for your data package (you may have to wait a few 
+moments for the file to appear):
 
 ```json
 {

--- a/docs/fidesops/docs/tutorial/postgres_connection.md
+++ b/docs/fidesops/docs/tutorial/postgres_connection.md
@@ -26,7 +26,7 @@ def create_postgres_connection(key, access_token):
             "access": "write",
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/connection",
         headers=oauth_headers(access_token=access_token),
         json=connection_create_data,

--- a/docs/fidesops/docs/tutorial/storage_config.md
+++ b/docs/fidesops/docs/tutorial/storage_config.md
@@ -28,7 +28,7 @@ def create_local_storage(key, format, access_token):
             },
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/storage/config",
         headers=oauth_headers(access_token=access_token),
         json=storage_create_data,

--- a/quickstart.py
+++ b/quickstart.py
@@ -3,6 +3,8 @@ A five-step fidesops quickstart
 """
 import json
 import logging
+import os
+import time
 from datetime import datetime
 from os.path import exists
 from time import sleep
@@ -451,11 +453,19 @@ def print_results(request_id: str) -> None:
     print it to the console if so.
     """
     results_path = f"fides_uploads/{request_id}.json"
+
+    count = 0
+    max_allowed_waiting = 10
+    while not os.path.exists(results_path) or count > max_allowed_waiting:
+        logger.info("Waiting for privacy request results...")
+        time.sleep(5)
+        count += 1  # Only loop through a reasonable number of times
+
     if exists(results_path):
         logger.info(
             f"Successfully read fidesops privacy request results from {results_path}:"
         )
-        with open(f"fides_uploads/{request_id}.json", "r") as file:
+        with open(results_path, "r") as file:
             results_json = json.loads(file.read())
             print(json.dumps(results_json, indent=4))
     else:
@@ -586,7 +596,9 @@ if __name__ == "__main__":
     print(
         "-------------------------------------------------------------------------------------"
     )
-    print("Press [enter] to define the data categories and relationships in your Postgres tables...")
+    print(
+        "Press [enter] to define the data categories and relationships in your Postgres tables..."
+    )
     input()
 
     validate_dataset(
@@ -602,7 +614,9 @@ if __name__ == "__main__":
     print(
         "-------------------------------------------------------------------------------------"
     )
-    print("Press [enter] to define the data categories and relationships in your Mongo collections...")
+    print(
+        "Press [enter] to define the data categories and relationships in your Mongo collections..."
+    )
     input()
 
     mongo_dataset = create_dataset(
@@ -628,15 +642,17 @@ if __name__ == "__main__":
     print(
         "-------------------------------------------------------------------------------------"
     )
-    print("""
+    print(
+        """
     ┌─┐┌┬┐┌─┐┌─┐  ┌┬┐┬ ┬┌─┐
     └─┐ │ ├┤ ├─┘   │ ││││ │  ...  Create an access policy rule
     └─┘ ┴ └─┘┴     ┴ └┴┘└─┘
-    """)
+    """
+    )
     print(
         "-------------------------------------------------------------------------------------"
     )
-    data_category = 'user.provided.identifiable'
+    data_category = "user.provided.identifiable"
     print(
         f"Press [enter] to create a Policy Rule that accesses information with the data category '{data_category}':"
     )
@@ -665,18 +681,22 @@ if __name__ == "__main__":
     print(
         "-------------------------------------------------------------------------------------"
     )
-    print("""
+    print(
+        """
     ┌─┐┌┬┐┌─┐┌─┐  ┌┬┐┬ ┬┬─┐┌─┐┌─┐
     └─┐ │ ├┤ ├─┘   │ ├─┤├┬┘├┤ ├┤    ...  Run an access privacy request
     └─┘ ┴ └─┘┴     ┴ ┴ ┴┴└─└─┘└─┘
-    """)
+    """
+    )
 
     # Execute a privacy request
     print(
         "-------------------------------------------------------------------------------------"
     )
     email = "jane@example.com"
-    print(f"Press [enter] to run an access request for {email} with Policy `example_request_policy`:")
+    print(
+        f"Press [enter] to run an access request for {email} with Policy `example_request_policy`:"
+    )
     input()
     print("Please wait...")
     privacy_requests = create_privacy_request(
@@ -692,7 +712,7 @@ if __name__ == "__main__":
         "-------------------------------------------------------------------------------------"
     )
     print(
-    """
+        """
     ┌─┐┌┬┐┌─┐┌─┐  ┌─┐┌─┐┬ ┬┬─┐
     └─┐ │ ├┤ ├─┘  ├┤ │ ││ │├┬┘   ...  Create an erasure policy rule
     └─┘ ┴ └─┘┴    └  └─┘└─┘┴└─    
@@ -743,7 +763,9 @@ if __name__ == "__main__":
 
     # Execute a privacy request for jane@example.com
     email = "jane@example.com"
-    print(f"Press [enter] to issue an erasure request for email {email}: with policy `example_erasure_policy`")
+    print(
+        f"Press [enter] to issue an erasure request for email {email}: with policy `example_erasure_policy`"
+    )
     input()
     print("Please wait...")
     privacy_requests = create_privacy_request(


### PR DESCRIPTION
# Purpose
The quickstart (`make quickstart`) was broken by the fire and forget behavior and the tutorial was broken when we moved several endpoints from PUT -> PATCH https://github.com/ethyca/fidesops/pull/53 

# Changes
- In the quickstart, wait for the access request package to appear in fides_uploads in a while loop, since this request is no longer synchronous
- Update the relevant requests to be PUT instead of PATCH in the tutorial instructions 

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage

# Ticket

Fixes #121 
 
