### PR TITLE
updates docs for supported masking strategies and associated configs

### DIFF
--- a/docs/fidesops/docs/guides/masking_strategies.md
+++ b/docs/fidesops/docs/guides/masking_strategies.md
@@ -24,9 +24,7 @@ pseudonymized in most cases, and (at worst) may still be identifiable if the mas
 which is a common mistake!
 
 In fidesops, your options to pseudonymize data are captured in "masking strategies". Fidesops supports a wide variety
-of masking strategies for different purposes when used directly as an API including HMAC, hashing, encryption, and 
-randomization. However, note that fidesops only supports the `null_rewrite` strategy when processing privacy requests right now,
-but we'll be adding support for all masking strategies in an upcoming release!
+of masking strategies for different purposes when used directly as an API including HMAC, Hash, AES encryption, string rewrite, random string rewrite, and null rewrite.
 
 
 ### Why mask instead of delete?

--- a/docs/fidesops/docs/guides/masking_strategies.md
+++ b/docs/fidesops/docs/guides/masking_strategies.md
@@ -109,55 +109,69 @@ Issue a PATCH request to `/policy/policy_key/rule`:
 
 ## Supported Masking Strategies and Associated Configuration options
 
-`null_rewrite`
+### Null Rewrite
 
-Masks the input value with a null value. No config needed.
+Masks the input value with a null value.
 
-`string_rewrite`
+`strategy`: `null_rewrite`
+
+No config needed.
+
+### String Rewrite
 
 Masks the input value with a default string value.
 
-Configuration:
+`strategy`: `string_rewrite`
+
+`configuration`:
 
 - `rewrite_value`: `str` that will replace input values
 - `format_preservation` (optional): `Dict` with the following key/vals:
     - `suffix`: `str` that specifies suffix to append to masked value
 
-`hash`
+### Hash
 
 Masks the input value by returning a hashed version of the input value. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
 
-Configuration:
+`strategy`: `hash`
+
+`configuration`:
 
 - `algorithm` (optional): `str` that specifies Hash masking algorithm. Options include `SHA-512` or `SHA_256`. Default = `SHA_256`
 - `format_preservation` (optional): `Dict` with the following key/vals:
     - `suffix`: `str` that specifies suffix to append to masked value
 
-`random_string_rewrite`
+### Random String Rewrite
 
 Masks the input value with a random string of a specified length.
 
-Configuration:
+`strategy`: `random_string_rewrite`
+
+`configuration`:
 
 - `length` (optional): `int` that specifies length of randomly generated string. Default = `30`
 - `format_preservation` (optional): `Dict` with the following key/vals:
     - `suffix`: `str` that specifies suffix to append to masked value
 
-`aes_encrypt`
+### AES Encrypt
 
 Masks by encrypting the value using AES. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
 
-Configuration:
+`strategy`: `aes_encrypt`
+
+`configuration`:
 
 - `mode` (optional): `str` that specifies AES encryption mode. Only supported option is `GCM`. Default = `GCM`
 - `format_preservation` (optional): `Dict` with the following key/vals:
     - `suffix`: `str` that specifies suffix to append to masked value
 
-`hmac`
+### HMAC
 
 Masks the input value by using the HMAC algorithm along with a hashed version of the data and a secret key. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
 
-Configuration:
+`strategy`: `hmac`
+
+`configuration`:
 
 - `algorithm` (optional): `str` that specifies HMAC masking algorithm. Options include `SHA-512` or `SHA_256`. Default = `SHA_256`
 - `format_preservation` (optional): `Dict` with the following key/vals:

--- a/docs/fidesops/docs/guides/masking_strategies.md
+++ b/docs/fidesops/docs/guides/masking_strategies.md
@@ -80,7 +80,7 @@ See [Masking values API docs](/fidesops/api#operations-tag-Masking) on how to us
 
 ## Configuration
 
-Erasure requests will replace mask data with the chosen masking strategy.
+Erasure requests will mask data with the chosen masking strategy.
 
 To configure a specific masking strategy to be used for a Policy, you will create an `erasure` rule
 that captures that strategy for the Policy.
@@ -129,7 +129,7 @@ Masks the input value with a default string value.
 
 ### Hash
 
-Masks the input value by returning a hashed version of the input value. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
+Masks the data by hashing the input before returning it. The hash is deterministic such that the same input will return the same output within the context of the same privacy request. This is not the case when the masking service is called as a standalone service, outside the context of a privacy request.
 
 `strategy`: `hash`
 
@@ -153,7 +153,7 @@ Masks the input value with a random string of a specified length.
 
 ### AES Encrypt
 
-Masks by encrypting the value using AES. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
+Masks the data using AES encryption before returning it. The AES encryption strategy is deterministic such that the same input will return the same output within the context of the same privacy request. This is not the case when the masking service is called as a standalone service, outside the context of a privacy request.
 
 `strategy`: `aes_encrypt`
 
@@ -165,7 +165,7 @@ Masks by encrypting the value using AES. Is deterministic such that the same inp
 
 ### HMAC
 
-Masks the input value by using the HMAC algorithm along with a hashed version of the data and a secret key. Is deterministic such that the same input value will mask to the same value within the same privacy request. This is not the case when the masking service is called as standalone service (outside of a privacy request).
+Masks the data using HMAC before returning it. The HMAC encryption strategy is deterministic such that the same input will return the same output within the context of the same privacy request. This is not the case when the masking service is called as a standalone service, outside the context of a privacy request.
 
 `strategy`: `hmac`
 


### PR DESCRIPTION
# Purpose
Update docs to reflect current supported masking strategies

# Changes
- Adds to `masking_strategies.md`. Screenshot of page for ease of review:

![screencapture-0-0-0-0-8000-fidesops-guides-masking-strategies-2022-01-25-12_34_57](https://user-images.githubusercontent.com/7697292/151037947-3ff31361-77e3-4361-b9a0-618d3e512dc8.png)




# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage

# Ticket

Fixes #155
 

