### PR TITLE
expose mysql to external network on port 3307 [unticketed]

### DIFF
--- a/docker-compose.integration-mysql.yml
+++ b/docker-compose.integration-mysql.yml
@@ -15,8 +15,8 @@ services:
       - MYSQL_USER=mysql_user
       - MYSQL_PASSWORD=mysql_pw
     expose:
-      - 3306
+      - 3307
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - ./data/sql/mysql_example.sql:/docker-entrypoint-initdb.d/mysql_example.sql


### PR DESCRIPTION
# Purpose

This PR fixes a port conflict on Docker Compose when running `mysql` and `mariadb` at the same time.

# Changes

- Expose `mysql_example` to external connections on  port `3307`


# Solution Description

- Docker Compose exposes all containers under one network. This means that we cannot expose two containers within the internal network on the same external ports.
- Internally however, because each service is its own container, we can expose them on their default ports.
- This error was localised to testing, and is Docker specific.

![Screenshot 2022-02-07 at 11 46 31](https://user-images.githubusercontent.com/1667340/152832988-eb448ce7-7f1e-493e-817d-20a3c4b22231.png)

