### PR TITLE
[Bug] Error when integration tests fail in CI

### DIFF
--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -9,12 +9,12 @@ from typing import (
     List,
 )
 
-DOCKER_WAIT = 15
+DOCKER_WAIT = 5
 DOCKERFILE_DATASTORES = [
+    "mssql",
     "postgres",
     "mysql",
     "mongodb",
-    "mssql",
     "mariadb",
 ]
 EXTERNAL_DATASTORE_CONFIG = {
@@ -56,7 +56,7 @@ def run_infrastructure(
     path: str = get_path_for_datastores(datastores)
 
     _run_cmd_or_err(f'echo "infrastructure path: {path}"')
-    _run_cmd_or_err(f"docker-compose {path} build")
+    _run_cmd_or_err(f"docker-compose {path} up -d")
     _run_cmd_or_err(f'echo "sleeping for: {DOCKER_WAIT} while infrastructure loads"')
     _run_cmd_or_err(f"sleep {DOCKER_WAIT}")
 

--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -9,7 +9,7 @@ from typing import (
     List,
 )
 
-DOCKER_WAIT = 5
+DOCKER_WAIT = 15
 DOCKERFILE_DATASTORES = [
     "mssql",
     "postgres",

--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -3,7 +3,7 @@ This file invokes a command used to setup infrastructure for use in testing Fide
 and related workflows.
 """
 import argparse
-import os
+import subprocess
 import sys
 from typing import (
     List,
@@ -42,12 +42,12 @@ def run_infrastructure(
     """
 
     if len(datastores) == 0:
-        os.system(
+        _run_cmd_or_err(
             f'echo "no datastores specified, configuring infrastructure for all datastores"'
         )
         datastores = DOCKERFILE_DATASTORES + EXTERNAL_DATASTORES
     else:
-        os.system(f'echo "datastores specified: {", ".join(datastores)}"')
+        _run_cmd_or_err(f'echo "datastores specified: {", ".join(datastores)}"')
 
     # De-duplicate datastores
     datastores = set(datastores)
@@ -55,10 +55,10 @@ def run_infrastructure(
     # Configure docker-compose path
     path: str = get_path_for_datastores(datastores)
 
-    os.system(f'echo "infrastructure path: {path}"')
-    os.system(f"docker-compose {path} build")
-    os.system(f'echo "sleeping for: {DOCKER_WAIT} while infrastructure loads"')
-    os.system(f"sleep {DOCKER_WAIT}")
+    _run_cmd_or_err(f'echo "infrastructure path: {path}"')
+    _run_cmd_or_err(f"docker-compose {path} build")
+    _run_cmd_or_err(f'echo "sleeping for: {DOCKER_WAIT} while infrastructure loads"')
+    _run_cmd_or_err(f"sleep {DOCKER_WAIT}")
 
     seed_initial_data(
         datastores,
@@ -92,14 +92,14 @@ def seed_initial_data(
     """
     Seed the datastores with initial data as defined in the file at `setup_path`
     """
-    os.system('echo "Seeding initial data for all datastores..."')
+    _run_cmd_or_err('echo "Seeding initial data for all datastores..."')
     for datastore in datastores:
         if datastore in DOCKERFILE_DATASTORES:
             setup_path = f"tests/integration_tests/{datastore}_setup.py"
-            os.system(
+            _run_cmd_or_err(
                 f'echo "Attempting to create schema and seed initial data for {datastore} from {setup_path}..."'
             )
-            os.system(
+            _run_cmd_or_err(
                 f'docker-compose {path} run {base_image} python {setup_path} || echo "no custom setup logic found for {datastore}, skipping"'
             )
 
@@ -110,15 +110,24 @@ def get_path_for_datastores(datastores: List[str]) -> str:
     """
     path: str = "-f docker-compose.yml"
     for datastore in datastores:
-        os.system(f'echo "configuring infrastructure for {datastore}"')
+        _run_cmd_or_err(f'echo "configuring infrastructure for {datastore}"')
         if datastore in DOCKERFILE_DATASTORES:
             # We only need to locate the docker-compose file if the datastore runs in Docker
             path += f" -f docker-compose.integration-{datastore}.yml"
         elif datastore not in EXTERNAL_DATASTORES:
             # If the specified datastore is not known to us
-            os.system(f'echo "Datastore {datastore} is currently not supported"')
+            _run_cmd_or_err(f'echo "Datastore {datastore} is currently not supported"')
 
     return path
+
+
+def _run_cmd_or_err(cmd: str) -> None:
+    """
+    Runs a command in the bash prompt and throws an error if the command was not successful
+    """
+    res = subprocess.Popen(cmd, shell=True).wait()
+    if res > 0:
+        raise Exception(f"Error executing command: {cmd}")
 
 
 def _run_quickstart(
@@ -128,9 +137,9 @@ def _run_quickstart(
     """
     Invokes the Fidesops command line quickstart
     """
-    os.system(f'echo "Running the quickstart..."')
-    os.system(f"docker-compose {path} up -d")
-    os.system(f"docker exec -it {image_name} python quickstart.py")
+    _run_cmd_or_err(f'echo "Running the quickstart..."')
+    _run_cmd_or_err(f"docker-compose {path} up -d")
+    _run_cmd_or_err(f"docker exec -it {image_name} python quickstart.py")
 
 
 def _open_shell(
@@ -140,16 +149,16 @@ def _open_shell(
     """
     Opens a bash shell on the container at `image_name`
     """
-    os.system(f'echo "Opening bash shell on {image_name}"')
-    os.system(f"docker-compose {path} run {image_name} /bin/bash")
+    _run_cmd_or_err(f'echo "Opening bash shell on {image_name}"')
+    _run_cmd_or_err(f"docker-compose {path} run {image_name} /bin/bash")
 
 
 def _run_application(docker_compose_path: str) -> None:
     """
     Runs the application at `docker_compose_path` without detaching it from the shell
     """
-    os.system(f'echo "Running application"')
-    os.system(f"docker-compose {docker_compose_path} up")
+    _run_cmd_or_err(f'echo "Running application"')
+    _run_cmd_or_err(f"docker-compose {docker_compose_path} up")
 
 
 def _run_tests(
@@ -186,16 +195,16 @@ def _run_tests(
 
     pytest_path += f' -m "{pytest_markers}"'
 
-    os.system(
+    _run_cmd_or_err(
         f'echo "running pytest for conditions: {pytest_path} with environment variables: {environment_variables}"'
     )
-    os.system(
+    _run_cmd_or_err(
         f"docker-compose {docker_compose_path} run {environment_variables} {IMAGE_NAME} pytest {pytest_path}"
     )
 
     # Now tear down the infrastructure
-    os.system(f"docker-compose {docker_compose_path} down --remove-orphans")
-    os.system(f'echo "fin."')
+    _run_cmd_or_err(f"docker-compose {docker_compose_path} down --remove-orphans")
+    _run_cmd_or_err(f'echo "fin."')
 
 
 if __name__ == "__main__":

--- a/src/fidesops/db/session.py
+++ b/src/fidesops/db/session.py
@@ -29,11 +29,15 @@ def get_db_engine(database_uri: Optional[str] = None) -> Engine:
 ENGINE = get_db_engine()
 
 
-def get_db_session(engine: Optional[Engine] = None) -> sessionmaker:
+def get_db_session(
+    autocommit: bool = False,
+    autoflush: bool = False,
+    engine: Optional[Engine] = None
+) -> sessionmaker:
     """Return a database SessionLocal"""
     return sessionmaker(
-        autocommit=False,
-        autoflush=False,
+        autocommit=autocommit,
+        autoflush=autoflush,
         bind=engine or ENGINE,
         class_=ExtendedSession,
     )

--- a/src/fidesops/db/session.py
+++ b/src/fidesops/db/session.py
@@ -32,7 +32,7 @@ ENGINE = get_db_engine()
 def get_db_session(
     autocommit: bool = False,
     autoflush: bool = False,
-    engine: Optional[Engine] = None
+    engine: Optional[Engine] = None,
 ) -> sessionmaker:
     """Return a database SessionLocal"""
     return sessionmaker(

--- a/tests/fixtures/mariadb_fixtures.py
+++ b/tests/fixtures/mariadb_fixtures.py
@@ -79,7 +79,11 @@ def mariadb_example_test_dataset_config(
 def mariadb_integration_session(connection_config_mariadb):
     example_mariadb_uri = MariaDBConnector(connection_config_mariadb).build_uri()
     engine = get_db_engine(database_uri=example_mariadb_uri)
-    SessionLocal = get_db_session(engine=engine)
+    SessionLocal = get_db_session(
+        engine=engine,
+        autocommit=True,
+        autoflush=True,
+    )
     yield SessionLocal()
 
 

--- a/tests/integration_tests/test_sql_task.py
+++ b/tests/integration_tests/test_sql_task.py
@@ -505,8 +505,12 @@ def test_mysql_access_request_task(db, policy, connection_config_mysql) -> None:
 
 @pytest.mark.integration_mariadb
 @pytest.mark.integration
-def test_mariadb_access_request_task(db, policy, connection_config_mariadb) -> None:
-
+def test_mariadb_access_request_task(
+    db,
+    policy,
+    connection_config_mariadb,
+    mariadb_integration_db,
+) -> None:
     privacy_request = PrivacyRequest(
         id=f"test_mariadb_access_request_task_{random.randint(0, 1000)}"
     )

--- a/tests/integration_tests/test_sql_task.py
+++ b/tests/integration_tests/test_sql_task.py
@@ -380,44 +380,44 @@ def test_mssql_access_request_task(db, policy, connection_config_mssql) -> None:
 
     logs = (
         ExecutionLog.query(db=db)
-            .filter(ExecutionLog.privacy_request_id == privacy_request.id)
-            .all()
+        .filter(ExecutionLog.privacy_request_id == privacy_request.id)
+        .all()
     )
 
     logs = [log.__dict__ for log in logs]
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mssql_db_1", collection_name="customer"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mssql_db_1", collection_name="customer"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mssql_db_1", collection_name="address"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mssql_db_1", collection_name="address"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mssql_db_1", collection_name="orders"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mssql_db_1", collection_name="orders"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs,
-                    dataset_name="my_mssql_db_1",
-                    collection_name="payment_card",
-                )
+        len(
+            records_matching_fields(
+                logs,
+                dataset_name="my_mssql_db_1",
+                collection_name="payment_card",
             )
-            > 0
+        )
+        > 0
     )
 
 
@@ -462,47 +462,48 @@ def test_mysql_access_request_task(db, policy, connection_config_mysql) -> None:
 
     logs = (
         ExecutionLog.query(db=db)
-            .filter(ExecutionLog.privacy_request_id == privacy_request.id)
-            .all()
+        .filter(ExecutionLog.privacy_request_id == privacy_request.id)
+        .all()
     )
 
     logs = [log.__dict__ for log in logs]
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mysql_db_1", collection_name="customer"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mysql_db_1", collection_name="customer"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mysql_db_1", collection_name="address"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mysql_db_1", collection_name="address"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_mysql_db_1", collection_name="orders"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_mysql_db_1", collection_name="orders"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs,
-                    dataset_name="my_mysql_db_1",
-                    collection_name="payment_card",
-                )
+        len(
+            records_matching_fields(
+                logs,
+                dataset_name="my_mysql_db_1",
+                collection_name="payment_card",
             )
-            > 0
+        )
+        > 0
     )
 
 
+@pytest.mark.integration_mariadb
 @pytest.mark.integration
 def test_mariadb_access_request_task(db, policy, connection_config_mariadb) -> None:
 
@@ -544,44 +545,44 @@ def test_mariadb_access_request_task(db, policy, connection_config_mariadb) -> N
 
     logs = (
         ExecutionLog.query(db=db)
-            .filter(ExecutionLog.privacy_request_id == privacy_request.id)
-            .all()
+        .filter(ExecutionLog.privacy_request_id == privacy_request.id)
+        .all()
     )
 
     logs = [log.__dict__ for log in logs]
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_maria_db_1", collection_name="customer"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_maria_db_1", collection_name="customer"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_maria_db_1", collection_name="address"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_maria_db_1", collection_name="address"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs, dataset_name="my_maria_db_1", collection_name="orders"
-                )
+        len(
+            records_matching_fields(
+                logs, dataset_name="my_maria_db_1", collection_name="orders"
             )
-            > 0
+        )
+        > 0
     )
     assert (
-            len(
-                records_matching_fields(
-                    logs,
-                    dataset_name="my_maria_db_1",
-                    collection_name="payment_card",
-                )
+        len(
+            records_matching_fields(
+                logs,
+                dataset_name="my_maria_db_1",
+                collection_name="payment_card",
             )
-            > 0
+        )
+        > 0
     )
 
 
@@ -631,7 +632,9 @@ def test_filter_on_data_categories(
 
     target_categories = {target.data_category for target in rule.targets}
     filtered_results = filter_data_categories(
-        access_request_results, target_categories, dataset_graph.data_category_field_mapping
+        access_request_results,
+        target_categories,
+        dataset_graph.data_category_field_mapping,
     )
 
     # One rule target, with data category that maps to house/street on address collection only.
@@ -645,7 +648,9 @@ def test_filter_on_data_categories(
     # Specify the target category:
     target_categories = {"user.provided.identifiable.contact"}
     filtered_results = filter_data_categories(
-        access_request_results, target_categories, dataset_graph.data_category_field_mapping
+        access_request_results,
+        target_categories,
+        dataset_graph.data_category_field_mapping,
     )
 
     assert filtered_results == {
@@ -697,7 +702,9 @@ def test_filter_on_data_categories(
 
     target_categories = {target.data_category for target in rule.targets}
     filtered_results = filter_data_categories(
-        access_request_results, target_categories, dataset_graph.data_category_field_mapping
+        access_request_results,
+        target_categories,
+        dataset_graph.data_category_field_mapping,
     )
     assert filtered_results == {
         "postgres_example_test_dataset:service_request": [

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -31,7 +31,8 @@ from fidesops.service.connectors.sql_connector import (
     SnowflakeConnector,
     RedshiftConnector,
     MicrosoftSQLServerConnector,
-    MySQLConnector, MariaDBConnector,
+    MySQLConnector,
+    MariaDBConnector,
 )
 from fidesops.service.masking.strategy.masking_strategy_factory import get_strategy
 from fidesops.service.privacy_request.request_runner_service import PrivacyRequestRunner
@@ -179,13 +180,13 @@ def test_create_and_process_access_request(
 @pytest.mark.integration
 @mock.patch("fidesops.models.privacy_request.PrivacyRequest.trigger_policy_webhook")
 def test_create_and_process_access_request_mssql(
-        trigger_webhook_mock,
-        mssql_example_test_dataset_config,
-        db,
-        cache,
-        policy,
-        policy_pre_execution_webhooks,
-        policy_post_execution_webhooks,
+    trigger_webhook_mock,
+    mssql_example_test_dataset_config,
+    db,
+    cache,
+    policy,
+    policy_pre_execution_webhooks,
+    policy_post_execution_webhooks,
 ):
 
     customer_email = "customer-1@example.com"
@@ -218,13 +219,13 @@ def test_create_and_process_access_request_mssql(
 @pytest.mark.integration
 @mock.patch("fidesops.models.privacy_request.PrivacyRequest.trigger_policy_webhook")
 def test_create_and_process_access_request_mysql(
-        trigger_webhook_mock,
-        mysql_example_test_dataset_config,
-        db,
-        cache,
-        policy,
-        policy_pre_execution_webhooks,
-        policy_post_execution_webhooks,
+    trigger_webhook_mock,
+    mysql_example_test_dataset_config,
+    db,
+    cache,
+    policy,
+    policy_pre_execution_webhooks,
+    policy_post_execution_webhooks,
 ):
 
     customer_email = "customer-1@example.com"
@@ -254,16 +255,17 @@ def test_create_and_process_access_request_mysql(
     pr.delete(db=db)
 
 
+@pytest.mark.integration_mariadb
 @pytest.mark.integration
 @mock.patch("fidesops.models.privacy_request.PrivacyRequest.trigger_policy_webhook")
 def test_create_and_process_access_request_mariadb(
-        trigger_webhook_mock,
-        mariadb_example_test_dataset_config,
-        db,
-        cache,
-        policy,
-        policy_pre_execution_webhooks,
-        policy_post_execution_webhooks,
+    trigger_webhook_mock,
+    mariadb_example_test_dataset_config,
+    db,
+    cache,
+    policy,
+    policy_pre_execution_webhooks,
+    policy_post_execution_webhooks,
 ):
 
     customer_email = "customer-1@example.com"
@@ -334,12 +336,12 @@ def test_create_and_process_erasure_request_specific_category(
 
 @pytest.mark.integration_erasure
 def test_create_and_process_erasure_request_specific_category_mssql(
-        mssql_example_test_dataset_config,
-        cache,
-        db,
-        generate_auth_header,
-        erasure_policy,
-        connection_config_mssql,
+    mssql_example_test_dataset_config,
+    cache,
+    db,
+    generate_auth_header,
+    erasure_policy,
+    connection_config_mssql,
 ):
     customer_email = "customer-1@example.com"
     customer_id = 1
@@ -373,12 +375,12 @@ def test_create_and_process_erasure_request_specific_category_mssql(
 
 @pytest.mark.integration_erasure
 def test_create_and_process_erasure_request_specific_category_mysql(
-        mysql_example_test_dataset_config,
-        cache,
-        db,
-        generate_auth_header,
-        erasure_policy,
-        connection_config_mysql,
+    mysql_example_test_dataset_config,
+    cache,
+    db,
+    generate_auth_header,
+    erasure_policy,
+    connection_config_mysql,
 ):
     customer_email = "customer-1@example.com"
     customer_id = 1
@@ -412,12 +414,12 @@ def test_create_and_process_erasure_request_specific_category_mysql(
 
 @pytest.mark.integration_erasure
 def test_create_and_process_erasure_request_specific_category_mariadb(
-        mariadb_example_test_dataset_config,
-        cache,
-        db,
-        generate_auth_header,
-        erasure_policy,
-        connection_config_mariadb,
+    mariadb_example_test_dataset_config,
+    cache,
+    db,
+    generate_auth_header,
+    erasure_policy,
+    connection_config_mariadb,
 ):
     customer_email = "customer-1@example.com"
     customer_id = 1

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -261,6 +261,7 @@ def test_create_and_process_access_request_mysql(
 def test_create_and_process_access_request_mariadb(
     trigger_webhook_mock,
     mariadb_example_test_dataset_config,
+    mariadb_integration_db,
     db,
     cache,
     policy,


### PR DESCRIPTION
# Purpose

The `run_infrastructure.py` script was no longer checking the results of commands executed via `os.system`, so tests invoked through that cmd that should have failed were passing.

# Solution

- Use `subprocess.Popen(cmd, shell=True).wait()` to execute shell commands
- Check for non-0 responses and raise an error if they occur

# Ticket

Fixes #207
 
