### PR TITLE
Contributing docs update

### DIFF
--- a/docs/fidesops/docs/development/contributing_details.md
+++ b/docs/fidesops/docs/development/contributing_details.md
@@ -1,0 +1,134 @@
+# Contributing Details
+
+---
+
+## API Endpoints
+
+### Postman API Collection
+Our [Fidesops Postman Collection](../postman/Fidesops.postman_collection.json) can be used to test Fidesops endpoints.
+
+Follow our [Using Postman](../postman/using_postman.md) guide to learn more about the how to use the collection.
+
+### API URLs
+
+We define API URLs for specific API versions as constants within `app.api.v1.urn_registry` (where `v1` can be substituted for that particular API version), then import those URLs into their specific API views. Since we are on the first version, there is no clear precedent set for overriding URLs between versions yet. The most likely change is that we'll override the `APIRouter` class instantiation with a different base path (ie. `/api/v2` instead of `/api/v1`). For example:
+
+```
+PRIVACY_REQUEST = "/privacy-request"
+PRIVACY_REQUEST_DETAIL = "/privacy-request/{privacy_request_id}"
+```
+
+would both resolve as `/api/v1/privacy-request` and `/api/v1/privacy-request/{privacy_request_id}` respectively.
+
+
+## Database and Models
+
+### The ORM -- SQLAlchemy
+
+SQLAlchemy is an Object Relational Mapper, allowing us to avoid writing direct database queries within our codebase, and access the database via Python code instead. The ORM provides an additional configuration layer allowing user-defined Python classes to be mapped to database tables and other constructs, as well as an object persistence mechanism known as the `Session`. Some common uses cases are listed below, for a more comprehensive guide see: https://docs.sqlalchemy.org/en/14/tutorial/index.html
+
+
+### Adding models
+
+Database tables are defined with model classes. Model files should live in `src/app/models/`. Individual model classes must inherit from our custom base class at `app.db.base_class.Base` to ensure uniformity within the database. Multiple models per file are encouraged so long as they fit the same logical delineation within the project. An example model declaration is added below. For a comprehensive guide see: https://docs.sqlalchemy.org/en/14/orm/mapping_styles.html#declarative-mapping
+
+```
+class Book(Base):
+    __tablename__ = 'book'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, index=True)
+    page_count = Column(Integer, nullable=True)
+    author_id = Column(Integer, ForeignKey("author.id"), nullable=False)
+```
+When models are added to the project, we must then add them to the database in a recordable and repeatable fashion using migrations.
+
+
+### Using the database via models
+
+Once you've added database tables via project models, you're ready to read, write and update them via Python code. Some examples of common use cases here are listed below. Official documentation is here: https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.
+
+- Import our application's database session: `from fidesops.db.session import get_db_session`
+- Instantiate the database interaction object:
+```
+SessionLocal = get_db_session()
+db = SessionLocal()
+```
+- Create a new row in a table:
+```
+db_obj = User(
+    email="admin@fidesops.app",
+    full_name="Fidesops Admin",
+    is_superuser=True,
+    is_active=True,
+)
+db.add(db_obj)
+db.commit()
+db.refresh(db_obj)
+```
+- Fetch all objects in a table: `users = db.query(User).all()`
+- Fetch all objects in a table that meet some criteria: `active_users = db.query(User).filter(User.is_active == True)`
+- Get a specific row in a table: `user = db.query(User).get(User.email == "admin@fidesops.app")`
+- Update a specific row in a table:
+```
+user.email = "updated@fidesops.app"
+db.add(user)
+db.commit()
+db.refresh()
+```
+
+### Connecting to the database
+When you run `make server` or `make server-shell`, the database will be spun up in a Docker container with port `5432` exposed on localhost. You can connect to it using the credentials found in `.fidesops.toml`, e.g.
+
+- Hostname: `localhost`
+- Port: `5432`
+- Username: see `database.USER` in `.fidesops.toml`
+- Password: see `database.PASSWORD` in `.fidesops.toml`
+
+
+### Alembic migrations
+
+Some common Alembic commands are listed below. For a comprehensive guide see: https://alembic.sqlalchemy.org/en/latest/tutorial.html. 
+
+The commands will need to be run inside a shell on your Docker containers, which can be opened with `make server-shell`.
+
+In the `/src` directory:
+
+- Migrate your database to the latest state: `alembic upgrade head`
+- Get revision id of previous migration: `alembic current`
+- Automatically generate a new migration: `alembic revision --autogenerate -m "<a message describing your changes>"`
+- Create a new migration file to manually fill out: `alembic revision -m "<a message describing your changes>"`
+- Migrate your database to a specific state `alembic upgrade <revision-id>` or `alembic downgrade <revision-id>`, (or if you want to be smart `alembic upgrade <revision-id> || alembic downgrade <revision-id>` is handy when you don't know whether the target revision is an upgrade or downgrade)
+    - NB. You can find the `revision-id` inside each migration file in `alembic/versions/` on line 3 next to `Revision ID: ...`
+
+When working on a PR with a migration, ensure that `down_revision` in the generated migration file correctly references the previous migration before submitting/merging the PR.
+
+## Exception Handling
+
+Our preference for exception handling is by overriding the nearest sensible error, for example:
+
+```
+class SomeException(ValueError):
+    "a docstring"
+
+
+def some_method():
+    raise SomeException("a message")
+```
+
+
+## General debugging -- pdb
+
+The project uses `pdb` for debugging as a `dev-requirement`. You can set breakpoints with `pdb` in much the same way you'd set them using `debugger` in Javascript. Insert `import pdb; pdb.set_trace()` into the line where you want the breakpoint to set, then run your Python code.
+
+
+## Docker
+
+Occasionally when developing you'll run into issues where it's beneficial to remove all existing Docker instances in order to recreate them based on some updated spec. Some commands to do this are below:
+
+- Stop all running containers: `docker-compose down`
+- Delete all local containers: `docker rm -f $(docker ps -a -q)`
+- Delete all local Docker volumes: `docker volume rm $(docker volume ls -q)`
+- Remove temp. files and installed dependencies: `make clean`
+- Delete all stopped containers, all networks not used by a container, all dangling images, and all build cache: `docker system prune`
+- Recreate the project: `make compose-build`

--- a/docs/fidesops/docs/development/overview.md
+++ b/docs/fidesops/docs/development/overview.md
@@ -24,18 +24,18 @@ commands to give you different functionality.
 - `make server` - this spins up the Fastapi server and supporting resources (a Postgres database and a Redis cache), which you can visit at `http://0.0.0.0:8080`. Check out the docs at `http://0.0.0.0:8000/fidesops/`
 - `make integration-env` - spins up everything in make server, plus additional postgres, mongo, and mysql databases for you to execute privacy requests against.
     - Try this out locally with our [Fidesops Postman Collection](../postman/Fidesops.postman_collection.json)
-    - `make integration-env datastores="mysql mariadb"`- brings up only mysql and mariadb datastores, use 
+    - `make integration-env datastores="mysql mariadb"`- brings up only mysql and mariadb datastores 
 - `make integration-shell` - spins up everything in make server, plus all Docker Compose specified datastores (Postgres, MySQL, MSSQL, Mongodb) and opens a server shell. This is most useful for running `pytest -k ...` commands within the integration shell to test connected datastores.
 - `make black`, `make mypy`, and `make pylint` - auto-formats code
 - `make check-all` - runs the CI checks locally and verifies that your code meets project standards
 - `make server-shell`-  opens a shell on the Docker container, from here you can run useful commands like:
-  - `ipython` - open a Python shell
-  - `cd src` then `alembic revision --autogenerate -m "adds enum for mysql connection type"` - auto-generates DB migration
+   - `ipython` - open a Python shell
+   - `cd src` then `alembic revision --autogenerate -m "adds enum for mysql connection type"` - auto-generates DB migration
 - `make pytest` - runs all unit tests except those that talk to integration databases
 - `make pytest-integration` - runs access integration tests.
 - `make pytest-integration datastores="postgres snowflake mssql"` - runs access integration tests for the Postgres, Snowflake and MSSQL environments.
 - `make pytest-integration-erasure` - runs erasure integration tests.
-- `make reset-db` - tears down the Fideops postgres db, then recreates and re-runs migrations.
+- `make reset-db` - tears down the Fidesops postgres db, then recreates and re-runs migrations.
 - `make quickstart` - runs a quick, five minute quickstart that talks to the Fidesops API to execute privacy requests
 - `make check-migrations` - verifies there are no un-run migrations 
 - `make docs-serve` - spins up just the docs
@@ -48,19 +48,22 @@ See [Makefile](https://github.com/ethyca/fidesops/blob/main/Makefile) for more o
 - MSSQL: Known issues around connecting to MSSQL exist today for Apple M1 users. M1 users that wish to install `pyodbc` locally, please reference the workaround [here](https://github.com/mkleehammer/pyodbc/issues/846).
 
 - Package not found: When running `make server`, if you get a `importlib.metadata.PackageNotFoundError: fidesops`, do `make server-shell`,
-and then run `pip install -e .`. Verify Fidesops is installed with `pip list`. 
+and then run `pip install -e .`. Verify Fidesops is installed with `pip list`.
 
 
-### Write your code
+## Write your code
 
-We have no doubt you can write amazing code! However, we want to help you ensure your code plays nicely with the rest of the Fidesops ecosystem. Many projects describe code style and documentation as a suggestion; in Fidesops it's a CI-checked requirement.
+See the [contributing details](contributing_details.md) guide for more 
+
+We want to help you ensure your code plays nicely with the rest of the Fidesops ecosystem. Many projects describe code style and documentation as a suggestion; in Fidesops it's a CI-checked requirement.
 
 * To learn how to style your code, see the [style guide](code_style.md).
 * To learn how to document your code, see the [docs guide](documentation.md).
 * To learn how to test your code, see the [tests guide](testing.md).
 * To learn what format your PR should follow, make sure to follow the [pull request guidelines](pull_requests.md).
 
-### Submit your code
+
+## Submit your code
 
 In order to submit code to Fidesops, please:
 
@@ -79,10 +82,10 @@ In order to submit code to Fidesops, please:
     git push origin my-new-branch 
     ```
 * [Open a Pull Request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) once your work is ready for review
-  * Submit the pull request from *your* repo
+  * Submit the pull request from *your* repo. Pull requests should be submitted with a clear description of the issue being handled, including links to any external specifications or Github issues. PRs should not be merged by the person submitting them, except in rare and urgent circumstances.
   * Once automated tests have passed, a maintainer will review your PR and provide feedback on any changes it requires to be approved. Once approved, your PR will be merged into Fidesops.
   
 
-### Congratulations
+## Congratulations
 
 You're a Fidesops contributor - welcome to the team! 🎉

--- a/docs/fidesops/docs/development/overview.md
+++ b/docs/fidesops/docs/development/overview.md
@@ -29,8 +29,8 @@ commands to give you different functionality.
 - `make black`, `make mypy`, and `make pylint` - auto-formats code
 - `make check-all` - runs the CI checks locally and verifies that your code meets project standards
 - `make server-shell`-  opens a shell on the Docker container, from here you can run useful commands like:
-   - `ipython` - open a Python shell
-   - `cd src` then `alembic revision --autogenerate -m "adds enum for mysql connection type"` - auto-generates DB migration
+    - `ipython` - open a Python shell
+    - `cd src` then `alembic revision --autogenerate -m "adds enum for mysql connection type"` - auto-generates DB migration
 - `make pytest` - runs all unit tests except those that talk to integration databases
 - `make pytest-integration` - runs access integration tests.
 - `make pytest-integration datastores="postgres snowflake mssql"` - runs access integration tests for the Postgres, Snowflake and MSSQL environments.
@@ -38,7 +38,7 @@ commands to give you different functionality.
 - `make reset-db` - tears down the Fidesops postgres db, then recreates and re-runs migrations.
 - `make quickstart` - runs a quick, five minute quickstart that talks to the Fidesops API to execute privacy requests
 - `make check-migrations` - verifies there are no un-run migrations 
-- `make docs-serve` - spins up just the docs
+- `make docs-serve` - spins up just the docs, which you can visit at `http://0.0.0.0:8000/fidesops/`
 
 See [Makefile](https://github.com/ethyca/fidesops/blob/main/Makefile) for more options. 
 
@@ -53,7 +53,7 @@ and then run `pip install -e .`. Verify Fidesops is installed with `pip list`.
 
 ## Write your code
 
-See the [contributing details](contributing_details.md) guide for more 
+See the [contributing details](contributing_details.md) guide to get familiar with writing and testing API endpoints, database models, and more. 
 
 We want to help you ensure your code plays nicely with the rest of the Fidesops ecosystem. Many projects describe code style and documentation as a suggestion; in Fidesops it's a CI-checked requirement.
 

--- a/docs/fidesops/docs/development/testing.md
+++ b/docs/fidesops/docs/development/testing.md
@@ -49,11 +49,19 @@ Fidesops has a few [`pytest` fixtures](https://docs.pytest.org/en/stable/fixture
 
 ## Running tests
 
-Fidesops uses `pytest` for unit testing. Once in the Fidesops container shell (`make server-shell`, or `make integration-shell` if running integration tests), invoke `pytest` from the root Fidesops directory:
+Fidesops uses `pytest` for unit testing. As with other `make` commands, you have the option to run `pytest` in command-line or in application shell:
+
+1. In shell: Once in the Fidesops container shell (`make server-shell`, or `make integration-shell` if running integration tests), invoke `pytest` from the root Fidesops directory:
 
 ```bash
 cd fidesops
 pytest
+```
+
+2. From regular command-line: 
+
+```bash
+make pytest
 ```
 
 ### Running specific tests
@@ -64,6 +72,16 @@ To run a subset of tests, provide a filename or directory; to match a specific t
 # run all tests in the tests/integration directory that contain the word "api" in their title
 pytest tests/integration/ -k api
 ```
+
+Other commands you may need are listed below. The full documentation can be found at: https://docs.pytest.org/en/6.2.x/.
+
+- Run all tests in a directory: `make pytestpath=path/to/dir/ pytest`
+- Run all tests in a file: `make pytestpath=path/to/file.py pytest`
+- Run all tests within a class within a file: `make pytestpath=path/to/file.py::ClassName pytest`
+- Run a specific test within a class within a file: `make pytestpath=path/to/file.py::ClassName::method_name pytest`
+- Run a specific test within a file: `make pytestpath=path/to/file.py::method_name pytest`
+- Run integration tests (access): `make pytest-integration`
+- Run integration tests (erasure): `make pytest-integration-erasure`
 
 #### Debugging
 

--- a/docs/fidesops/docs/guides/configuration_reference.md
+++ b/docs/fidesops/docs/guides/configuration_reference.md
@@ -27,29 +27,29 @@ Fidesops is also able to be run exclusively from environment variables. For more
 The `fidesops.toml` file should specify the following variables:
 
 
-| TOML Variable | ENV Variable | Type | Example | Default | Description |
-|---|---|---|---|---|---|
-| `SERVER` | `FIDESOPS__DATABASE__SERVER` | string | postgres.internal | N/A | The networking address for the Fideops Postgres database server |
-| `USER` | `FIDESOPS__DATABASE_USER` | string | postgres | N/A | The database user with which to login to the Fidesops application database |
-| `PASSWORD` | `FIDESOPS__DATABASE_PASSWORD` | string | apassword | N/A | The password with which to login to the Fidesops application database |
-| `PORT` | `FIDESOPS__DATABASE__PORT` | int | 5432 | 5432 | The port at which the Fidesops application database will be accessible |
-| `DB` | `FIDESOPS__DATABASE_DB` | string | db | N/A | The name of the database to use in the Fidesops application database |
-|---|---|---|---|---|---|
-| `HOST` | `FIDESOPS__REDIS__HOST` | string | redis.internal | N/A | The networking address for the Fidesops application Redis cache |
-| `PORT` | `FIDESOPS__REDIS__PORT` | int | 6379 | 6379 | The port at which the Fidesops application cache will be accessible |
-| `PASSWORD` | `FIDESOPS__REDIS__PASSWORD` | string | anotherpassword | N/A | The password with which to login to the Fidesops application cache |
-| `DB_INDEX` | `FIDESOPS__REDIS__DB_INDEX` | int | 0 | 0 | The Fidesops application will use this index in the Redis cache to cache data |
-| `DEFAULT_TTL_SECONDS` | `FIDESOPS__REDIS__DEFAULT_TTL_SECONDS` | int | 3600 | 3600 | The number of seconds for which data will live in Redis before automatically expiring |
-|---|---|---|---|---|---|
-| `APP_ENCRYPTION_KEY` | `FIDESOPS__SECURITY__APP_ENCRYPTION_KEY` | string | OLMkv91j8DHiDAULnK5Lxx3kSCov30b3 | N/A | The key used to sign Fidesops API access tokens |
+| TOML Variable | ENV Variable | Type | Example | Default | Description                                                                                             |
+|---|---|---|---|---|---------------------------------------------------------------------------------------------------------|
+| `SERVER` | `FIDESOPS__DATABASE__SERVER` | string | postgres.internal | N/A | The networking address for the Fidesops Postgres database server                                        |
+| `USER` | `FIDESOPS__DATABASE_USER` | string | postgres | N/A | The database user with which to login to the Fidesops application database                              |
+| `PASSWORD` | `FIDESOPS__DATABASE_PASSWORD` | string | apassword | N/A | The password with which to login to the Fidesops application database                                   |
+| `PORT` | `FIDESOPS__DATABASE__PORT` | int | 5432 | 5432 | The port at which the Fidesops application database will be accessible                                  |
+| `DB` | `FIDESOPS__DATABASE_DB` | string | db | N/A | The name of the database to use in the Fidesops application database                                    |
+|---|---|---|---|---| ---                                                                                                     |
+| `HOST` | `FIDESOPS__REDIS__HOST` | string | redis.internal | N/A | The networking address for the Fidesops application Redis cache                                         |
+| `PORT` | `FIDESOPS__REDIS__PORT` | int | 6379 | 6379 | The port at which the Fidesops application cache will be accessible                                     |
+| `PASSWORD` | `FIDESOPS__REDIS__PASSWORD` | string | anotherpassword | N/A | The password with which to login to the Fidesops application cache                                      |
+| `DB_INDEX` | `FIDESOPS__REDIS__DB_INDEX` | int | 0 | 0 | The Fidesops application will use this index in the Redis cache to cache data                           |
+| `DEFAULT_TTL_SECONDS` | `FIDESOPS__REDIS__DEFAULT_TTL_SECONDS` | int | 3600 | 3600 | The number of seconds for which data will live in Redis before automatically expiring                   |
+|---|---|---|---|---| ---                                                                                                     |
+| `APP_ENCRYPTION_KEY` | `FIDESOPS__SECURITY__APP_ENCRYPTION_KEY` | string | OLMkv91j8DHiDAULnK5Lxx3kSCov30b3 | N/A | The key used to sign Fidesops API access tokens                                                         |
 | `CORS_ORIGINS` | `FIDESOPS__SECURITY__CORS_ORIGINS` | List[AnyHttpUrl] | ["https://a-client.com/", "https://another-client.com"/] | N/A | A list of pre-approved addresses of clients allowed to communicate with the Fidesops application server |
-| `OAUTH_ROOT_CLIENT_ID` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID` | string | fidesopsadmin | N/A | The value used to identify the Fidesops application root API client |
-| `OAUTH_ROOT_CLIENT_SECRET` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET` | string | fidesopsadminsecret | N/A | The secret value used to authenticate the Fidesops application root API client |
-| `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `FIDESOPS__SECURITY__OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | int | 1 | 11520 | The time period Fidesops API tokens will be valid |
-|---|---|---|---|---|---|
-|`TASK_RETRY_COUNT` | `FIDESOPS__EXECUTION__TASK_RETRY_COUNT` | int | 5 | 2 | The number of times a failed request will be retried
-|`TASK_RETRY_DELAY` | `FIDESOPS__EXECUTION__TASK_RETRY_DELAY` | int | 20 | 5 | The delays between retries in seconds
-|`TASK_RETRY_BACKOFF` | `FIDESOPS__EXECUTION__TASK_RETRY_BACKOFF` | int | 2 | 2 | The backoff factor for retries, to space out repeated retries.
+| `OAUTH_ROOT_CLIENT_ID` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID` | string | fidesopsadmin | N/A | The value used to identify the Fidesops application root API client                                     |
+| `OAUTH_ROOT_CLIENT_SECRET` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET` | string | fidesopsadminsecret | N/A | The secret value used to authenticate the Fidesops application root API client                          |
+| `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `FIDESOPS__SECURITY__OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | int | 1 | 11520 | The time period Fidesops API tokens will be valid                                                       |
+|---|---|---|---|---| ---                                                                                                     |
+|`TASK_RETRY_COUNT` | `FIDESOPS__EXECUTION__TASK_RETRY_COUNT` | int | 5 | 2 | The number of times a failed request will be retried                                                    
+|`TASK_RETRY_DELAY` | `FIDESOPS__EXECUTION__TASK_RETRY_DELAY` | int | 20 | 5 | The delays between retries in seconds                                                                   
+|`TASK_RETRY_BACKOFF` | `FIDESOPS__EXECUTION__TASK_RETRY_BACKOFF` | int | 2 | 2 | The backoff factor for retries, to space out repeated retries.                                          
 
 
 ## An example `fidesops.toml` configuration file

--- a/docs/fidesops/docs/guides/configuration_reference.md
+++ b/docs/fidesops/docs/guides/configuration_reference.md
@@ -27,29 +27,29 @@ Fidesops is also able to be run exclusively from environment variables. For more
 The `fidesops.toml` file should specify the following variables:
 
 
-| TOML Variable | ENV Variable | Type | Example | Default | Description                                                                                             |
-|---|---|---|---|---|---------------------------------------------------------------------------------------------------------|
-| `SERVER` | `FIDESOPS__DATABASE__SERVER` | string | postgres.internal | N/A | The networking address for the Fidesops Postgres database server                                        |
-| `USER` | `FIDESOPS__DATABASE_USER` | string | postgres | N/A | The database user with which to login to the Fidesops application database                              |
-| `PASSWORD` | `FIDESOPS__DATABASE_PASSWORD` | string | apassword | N/A | The password with which to login to the Fidesops application database                                   |
-| `PORT` | `FIDESOPS__DATABASE__PORT` | int | 5432 | 5432 | The port at which the Fidesops application database will be accessible                                  |
-| `DB` | `FIDESOPS__DATABASE_DB` | string | db | N/A | The name of the database to use in the Fidesops application database                                    |
-|---|---|---|---|---| ---                                                                                                     |
-| `HOST` | `FIDESOPS__REDIS__HOST` | string | redis.internal | N/A | The networking address for the Fidesops application Redis cache                                         |
-| `PORT` | `FIDESOPS__REDIS__PORT` | int | 6379 | 6379 | The port at which the Fidesops application cache will be accessible                                     |
-| `PASSWORD` | `FIDESOPS__REDIS__PASSWORD` | string | anotherpassword | N/A | The password with which to login to the Fidesops application cache                                      |
-| `DB_INDEX` | `FIDESOPS__REDIS__DB_INDEX` | int | 0 | 0 | The Fidesops application will use this index in the Redis cache to cache data                           |
-| `DEFAULT_TTL_SECONDS` | `FIDESOPS__REDIS__DEFAULT_TTL_SECONDS` | int | 3600 | 3600 | The number of seconds for which data will live in Redis before automatically expiring                   |
-|---|---|---|---|---| ---                                                                                                     |
-| `APP_ENCRYPTION_KEY` | `FIDESOPS__SECURITY__APP_ENCRYPTION_KEY` | string | OLMkv91j8DHiDAULnK5Lxx3kSCov30b3 | N/A | The key used to sign Fidesops API access tokens                                                         |
+| TOML Variable | ENV Variable | Type | Example | Default | Description |
+|---|---|---|---|---|---|
+| `SERVER` | `FIDESOPS__DATABASE__SERVER` | string | postgres.internal | N/A | The networking address for the Fideops Postgres database server |
+| `USER` | `FIDESOPS__DATABASE_USER` | string | postgres | N/A | The database user with which to login to the Fidesops application database |
+| `PASSWORD` | `FIDESOPS__DATABASE_PASSWORD` | string | apassword | N/A | The password with which to login to the Fidesops application database |
+| `PORT` | `FIDESOPS__DATABASE__PORT` | int | 5432 | 5432 | The port at which the Fidesops application database will be accessible |
+| `DB` | `FIDESOPS__DATABASE_DB` | string | db | N/A | The name of the database to use in the Fidesops application database |
+|---|---|---|---|---|---|
+| `HOST` | `FIDESOPS__REDIS__HOST` | string | redis.internal | N/A | The networking address for the Fidesops application Redis cache |
+| `PORT` | `FIDESOPS__REDIS__PORT` | int | 6379 | 6379 | The port at which the Fidesops application cache will be accessible |
+| `PASSWORD` | `FIDESOPS__REDIS__PASSWORD` | string | anotherpassword | N/A | The password with which to login to the Fidesops application cache |
+| `DB_INDEX` | `FIDESOPS__REDIS__DB_INDEX` | int | 0 | 0 | The Fidesops application will use this index in the Redis cache to cache data |
+| `DEFAULT_TTL_SECONDS` | `FIDESOPS__REDIS__DEFAULT_TTL_SECONDS` | int | 3600 | 3600 | The number of seconds for which data will live in Redis before automatically expiring |
+|---|---|---|---|---|---|
+| `APP_ENCRYPTION_KEY` | `FIDESOPS__SECURITY__APP_ENCRYPTION_KEY` | string | OLMkv91j8DHiDAULnK5Lxx3kSCov30b3 | N/A | The key used to sign Fidesops API access tokens |
 | `CORS_ORIGINS` | `FIDESOPS__SECURITY__CORS_ORIGINS` | List[AnyHttpUrl] | ["https://a-client.com/", "https://another-client.com"/] | N/A | A list of pre-approved addresses of clients allowed to communicate with the Fidesops application server |
-| `OAUTH_ROOT_CLIENT_ID` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID` | string | fidesopsadmin | N/A | The value used to identify the Fidesops application root API client                                     |
-| `OAUTH_ROOT_CLIENT_SECRET` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET` | string | fidesopsadminsecret | N/A | The secret value used to authenticate the Fidesops application root API client                          |
-| `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `FIDESOPS__SECURITY__OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | int | 1 | 11520 | The time period Fidesops API tokens will be valid                                                       |
-|---|---|---|---|---| ---                                                                                                     |
-|`TASK_RETRY_COUNT` | `FIDESOPS__EXECUTION__TASK_RETRY_COUNT` | int | 5 | 2 | The number of times a failed request will be retried                                                    
-|`TASK_RETRY_DELAY` | `FIDESOPS__EXECUTION__TASK_RETRY_DELAY` | int | 20 | 5 | The delays between retries in seconds                                                                   
-|`TASK_RETRY_BACKOFF` | `FIDESOPS__EXECUTION__TASK_RETRY_BACKOFF` | int | 2 | 2 | The backoff factor for retries, to space out repeated retries.                                          
+| `OAUTH_ROOT_CLIENT_ID` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID` | string | fidesopsadmin | N/A | The value used to identify the Fidesops application root API client |
+| `OAUTH_ROOT_CLIENT_SECRET` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET` | string | fidesopsadminsecret | N/A | The secret value used to authenticate the Fidesops application root API client |
+| `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `FIDESOPS__SECURITY__OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | int | 1 | 11520 | The time period Fidesops API tokens will be valid |
+|---|---|---|---|---|---|
+|`TASK_RETRY_COUNT` | `FIDESOPS__EXECUTION__TASK_RETRY_COUNT` | int | 5 | 2 | The number of times a failed request will be retried
+|`TASK_RETRY_DELAY` | `FIDESOPS__EXECUTION__TASK_RETRY_DELAY` | int | 20 | 5 | The delays between retries in seconds
+|`TASK_RETRY_BACKOFF` | `FIDESOPS__EXECUTION__TASK_RETRY_BACKOFF` | int | 2 | 2 | The backoff factor for retries, to space out repeated retries.
 
 
 ## An example `fidesops.toml` configuration file

--- a/docs/fidesops/docs/index.md
+++ b/docs/fidesops/docs/index.md
@@ -19,7 +19,7 @@ Fidesops is open & extensible, meaning it can easily be integrated into your exi
 Lots of databases? Tons of microservices? Connect as many databases and services as you'd like, and let Fidesops do the heavy lifting.
 
 ## How does Fidesops work with Fidesctl and Fideslang?
-In a software organization, the team that writes and delivers software is normally the same team responsible for executing a privacy request when it comes in from customer support or legal . When your organization receives a privacy request, Fideops will automatically fulfill it per the execution policies your legal and business owners have created by querying your databases directly. 
+In a software organization, the team that writes and delivers software is normally the same team responsible for executing a privacy request when it comes in from customer support or legal . When your organization receives a privacy request, Fidesops will automatically fulfill it per the execution policies your legal and business owners have created by querying your databases directly. 
 
 ![Fidesops business process](img/fides-ops-process.png "Fidesops biz process")
 

--- a/docs/fidesops/mkdocs.yml
+++ b/docs/fidesops/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - API: api/index.md
   - Development:
       - Overview: development/overview.md
+      - Contributing Details: development/contributing_details.md
       - Code Style: development/code_style.md
       - Documentation: development/documentation.md
       - Testing: development/testing.md


### PR DESCRIPTION
# Purpose
Adds some content that was removed from `CONTRIBUTING.md`, with additional updates and clarity.

# Changes
- Adds a new section in `development` docs: `contributing details`. This section houses key dev info around API endpoints (including the API postman collection), DB, models, Alembic migrations, debugging, and Docker.
- Updates the old content to reflect current project
- Other minor tweaks for clarify across all docs

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage

# Ticket

Not Ticketed
 
![screencapture-0-0-0-0-8000-fidesops-development-contributing-details-2022-02-15-09_32_57](https://user-images.githubusercontent.com/7697292/154094678-74e18ede-a95d-4467-af2c-5bf95be3c7ba.png)

