### PR TITLE
[Misc. Devops] Don't run the build step twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ pytest-integration-erasure: compose-build
 # These tests connect to external third-party test databases
 pytest-integration-external: compose-build
 	@echo "Running tests that connect to external third party test databases"
-	@docker-compose run -e REDSHIFT_TEST_URI -e SNOWFLAKE_TEST_URI -e REDSHIFT_TEST_DB_SCHEMA \
+	@docker-compose run \
+		-e REDSHIFT_TEST_URI \
+		-e SNOWFLAKE_TEST_URI -e REDSHIFT_TEST_DB_SCHEMA \
 		-e BIGQUERY_KEYFILE_CREDS -e BIGQUERY_DATASET \
 		$(IMAGE_NAME) pytest $(pytestpath) -m "integration_external"
 

--- a/Makefile
+++ b/Makefile
@@ -46,17 +46,17 @@ server: compose-build
 server-shell: compose-build
 	@docker-compose run $(IMAGE_NAME) /bin/bash
 
-integration-shell: compose-build
+integration-shell:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --open_shell --datastores $(datastores)
 
-integration-env: compose-build
+integration-env:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --run_application --datastores $(datastores)
 
-quickstart: compose-build
+quickstart:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --datastores mongodb postgres --run_quickstart
@@ -108,7 +108,7 @@ pytest: compose-build
 	@docker-compose run $(IMAGE_NAME) \
 		pytest $(pytestpath) -m "not integration and not integration_erasure and not integration_external"
 
-pytest-integration: compose-build
+pytest-integration:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --run_tests --datastores $(datastores)


### PR DESCRIPTION
# Purpose

This PR stops the `compose build` step being run as a precursor to the `run_infrastructure.py` script, saving about ~1min from the CI process.