### PR TITLE
Fix BigQuery secrets formatting

### DIFF
--- a/tests/fixtures/bigquery_fixtures.py
+++ b/tests/fixtures/bigquery_fixtures.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import os
 from typing import Generator, List, Dict
@@ -76,9 +77,9 @@ def bigquery_test_engine() -> Generator:
     )
 
     # Pulling from integration config file or GitHub secrets
-    keyfile_creds = integration_config.get("bigquery", {}).get("keyfile_creds") or os.environ.get(
+    keyfile_creds = integration_config.get("bigquery", {}).get("keyfile_creds") or ast.literal_eval(os.environ.get(
         "BIGQUERY_KEYFILE_CREDS"
-    )
+    ))
     dataset = integration_config.get("bigquery", {}).get(
         "dataset"
     ) or os.environ.get("BIGQUERY_DATASET")


### PR DESCRIPTION
# Purpose
BigQuery GH secrets are not being retrieved in the correct format. This breaks our unsafe CI checks

# Changes
- Expect a str that contains dict of secrets from env, needs associated change in GH secrets to wrap in quotes

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging

# Ticket

Unticketed
 
