### PR TITLE
Adding fix and test for privacy request endpoint

### DIFF
--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -172,10 +172,13 @@ def create_privacy_request(
             unique_masking_strategies_by_name: Set[str] = set()
             for rule in erasure_rules:
                 strategy_name: str = rule.masking_strategy["strategy"]
+                configuration: MaskingConfiguration = rule.masking_strategy[
+                    "configuration"
+                ]
                 if strategy_name in unique_masking_strategies_by_name:
                     continue
                 unique_masking_strategies_by_name.add(strategy_name)
-                masking_strategy = get_strategy(strategy_name, {})
+                masking_strategy = get_strategy(strategy_name, configuration)
                 if masking_strategy.secrets_required():
                     masking_secrets: List[
                         MaskingSecretCache

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -79,6 +79,32 @@ class TestCreatePrivacyRequest:
         assert run_access_request_mock.called
 
     @mock.patch(
+        "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.submit"
+    )
+    def test_create_privacy_request_with_masking_configuration(
+        self,
+        run_access_request_mock,
+        url,
+        db,
+        api_client: TestClient,
+        erasure_policy_string_rewrite,
+    ):
+        data = [
+            {
+                "requested_at": "2021-08-30T16:09:37.359Z",
+                "policy_key": erasure_policy_string_rewrite.key,
+                "identity": {"email": "test@example.com"},
+            }
+        ]
+        resp = api_client.post(url, json=data)
+        assert resp.status_code == 200
+        response_data = resp.json()["succeeded"]
+        assert len(response_data) == 1
+        pr = PrivacyRequest.get(db=db, id=response_data[0]["id"])
+        pr.delete(db=db)
+        assert run_access_request_mock.called
+
+    @mock.patch(
         "fidesops.service.privacy_request.request_runner_service.run_access_request"
     )
     def test_create_privacy_request_limit_exceeded(


### PR DESCRIPTION
# Purpose
Fixes issue outlined in #269

# Changes
Updated `create_privacy_request` in `privacy_request_endpoints` with corrected `get_strategy` params

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #269
 
