### PR TITLE
Returning an empty list instead of None when post-processors filter a…

### DIFF
--- a/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy.py
+++ b/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 
 class PostProcessorStrategy(ABC):
@@ -10,5 +10,7 @@ class PostProcessorStrategy(ABC):
         """Returns strategy name"""
 
     @abstractmethod
-    def process(self, data: Any, identity_data: Dict[str, Any] = None) -> Any:
+    def process(
+        self, data: Any, identity_data: Dict[str, Any] = None
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """Process data from SaaS connector"""

--- a/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_filter.py
+++ b/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_filter.py
@@ -77,9 +77,8 @@ class FilterPostProcessorStrategy(PostProcessorStrategy):
 
         try:
             if isinstance(data, list):
-                filtered = [item for item in data if item[self.field] == filter_value]
-                return filtered if filtered else None
-            return data if data[self.field] == filter_value else None
+                return [item for item in data if item[self.field] == filter_value]
+            return data if data[self.field] == filter_value else []
         except KeyError:
             logger.warning(
                 f"{self.field} could not be found on data for the following post processing strategy: {self.get_strategy_name()}"

--- a/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_filter.py
+++ b/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_filter.py
@@ -85,7 +85,6 @@ class FilterPostProcessorStrategy(PostProcessorStrategy):
             )
             return []
 
-
     @staticmethod
     def get_configuration_model() -> StrategyConfiguration:
         return FilterPostProcessorConfiguration

--- a/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_unwrap.py
+++ b/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_unwrap.py
@@ -59,16 +59,20 @@ class UnwrapPostProcessorStrategy(PostProcessorStrategy):
         if isinstance(data, dict):
             unwrapped = pydash.get(data, self.data_path)
             if unwrapped is None:
-                logger.warning(f"{self.data_path} could not be found for the following "
-                    f"post processing strategy: {self.get_strategy_name()}")
+                logger.warning(
+                    f"{self.data_path} could not be found for the following "
+                    f"post processing strategy: {self.get_strategy_name()}"
+                )
             else:
                 result = unwrapped
         elif isinstance(data, list):
             for item in data:
                 unwrapped = pydash.get(item, self.data_path)
                 if unwrapped is None:
-                    logger.warning(f"{self.data_path} could not be found for the following "
-                    f"post processing strategy: {self.get_strategy_name()}")
+                    logger.warning(
+                        f"{self.data_path} could not be found for the following "
+                        f"post processing strategy: {self.get_strategy_name()}"
+                    )
                 else:
                     result.append(unwrapped)
             # flatten the list to account for the event where the output of unwrapped

--- a/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_unwrap.py
+++ b/src/fidesops/service/processors/post_processor_strategy/post_processor_strategy_unwrap.py
@@ -48,30 +48,34 @@ class UnwrapPostProcessorStrategy(PostProcessorStrategy):
         self,
         data: Union[List[Dict[str, Any]], Dict[str, Any]],
         identity_data: Dict[str, Any] = None,
-    ) -> Optional[Any]:
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """
         :param data: A list or dict
-        :param identity_data: Dict of cached identity data
-        :return: unwrapped list or dict
+        :param identity_data: dict of cached identity data
+        :return: unwrapped list, dict, or empty list
         """
-        unwrapped = None
+
+        result = []
         if isinstance(data, dict):
             unwrapped = pydash.get(data, self.data_path)
-
+            if unwrapped is None:
+                logger.warning(f"{self.data_path} could not be found for the following "
+                    f"post processing strategy: {self.get_strategy_name()}")
+            else:
+                result = unwrapped
         elif isinstance(data, list):
-            unwrapped = []
             for item in data:
-                unwrapped.append(pydash.get(item, self.data_path))
+                unwrapped = pydash.get(item, self.data_path)
+                if unwrapped is None:
+                    logger.warning(f"{self.data_path} could not be found for the following "
+                    f"post processing strategy: {self.get_strategy_name()}")
+                else:
+                    result.append(unwrapped)
             # flatten the list to account for the event where the output of unwrapped
             # is a list of lists
-            unwrapped = pydash.flatten(unwrapped)
+            result = pydash.flatten(result)
 
-        if unwrapped is None:
-            logger.warning(
-                f"{self.data_path} could not be found for the following post processing strategy: {self.get_strategy_name()}"
-            )
-
-        return unwrapped
+        return result
 
     @staticmethod
     def get_configuration_model() -> StrategyConfiguration:

--- a/tests/service/processors/post_processor_strategy/test_post_processor_strategy_filter.py
+++ b/tests/service/processors/post_processor_strategy/test_post_processor_strategy_filter.py
@@ -1,17 +1,18 @@
+import pytest
 from typing import Dict, Any
-
-import pytest as pytest
-
-from fidesops.schemas.saas.strategy_configuration import FilterPostProcessorConfiguration
-from fidesops.service.processors.post_processor_strategy.post_processor_strategy_filter import \
-    FilterPostProcessorStrategy
+from fidesops.common_exceptions import FidesopsException
+from fidesops.schemas.saas.strategy_configuration import (
+    FilterPostProcessorConfiguration,
+)
+from fidesops.service.processors.post_processor_strategy.post_processor_strategy_filter import (
+    FilterPostProcessorStrategy,
+)
 
 
 def test_filter_array_by_identity_reference():
     identity_data: Dict[str, Any] = {"email": "somebody@email.com"}
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value={"identity": "email"}
+        field="email_contact", value={"identity": "email"}
     )
     data = [
         {
@@ -22,23 +23,24 @@ def test_filter_array_by_identity_reference():
         {
             "id": 238475234,
             "email_contact": "somebody-else@email.com",
-            "name": "Somebody Cool"
-        }
+            "name": "Somebody Cool",
+        },
     ]
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data, identity_data)
-    assert result == [{
-        "id": 1397429347,
-        "email_contact": "somebody@email.com",
-        "name": "Somebody Awesome",
-    }]
+    assert result == [
+        {
+            "id": 1397429347,
+            "email_contact": "somebody@email.com",
+            "name": "Somebody Awesome",
+        }
+    ]
 
 
 def test_filter_array_by_identity_reference_no_results():
     identity_data: Dict[str, Any] = {"email": "someone-nice@email.com"}
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value={"identity": "email"}
+        field="email_contact", value={"identity": "email"}
     )
     data = [
         {
@@ -49,18 +51,17 @@ def test_filter_array_by_identity_reference_no_results():
         {
             "id": 238475234,
             "email_contact": "somebody-else@email.com",
-            "name": "Somebody Cool"
-        }
+            "name": "Somebody Cool",
+        },
     ]
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data, identity_data)
-    assert result is None
+    assert result == []
 
 
 def test_filter_array_with_static_val():
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value="somebody@email.com"
+        field="email_contact", value="somebody@email.com"
     )
     data = [
         {
@@ -71,72 +72,70 @@ def test_filter_array_with_static_val():
         {
             "id": 238475234,
             "email_contact": "somebody-else@email.com",
-            "name": "Somebody Cool"
-        }
+            "name": "Somebody Cool",
+        },
     ]
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data)
-    assert result == [{
-        "id": 1397429347,
-        "email_contact": "somebody@email.com",
-        "name": "Somebody Awesome",
-    }]
+    assert result == [
+        {
+            "id": 1397429347,
+            "email_contact": "somebody@email.com",
+            "name": "Somebody Awesome",
+        }
+    ]
 
 
 def test_filter_object():
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value="somebody-else@email.com"
+        field="email_contact", value="somebody-else@email.com"
     )
     data = {
         "id": 238475234,
         "email_contact": "somebody-else@email.com",
-        "name": "Somebody Cool"
+        "name": "Somebody Cool",
     }
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data)
     assert result == {
         "id": 238475234,
         "email_contact": "somebody-else@email.com",
-        "name": "Somebody Cool"
+        "name": "Somebody Cool",
     }
 
 
 def test_filter_object_no_results():
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value="somebody@email.com"
+        field="email_contact", value="somebody@email.com"
     )
     data = {
         "id": 238475234,
         "email_contact": "somebody-else@email.com",
-        "name": "Somebody Cool"
+        "name": "Somebody Cool",
     }
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data)
-    assert result is None
+    assert result == []
 
 
 def test_filter_nonexistent_field():
     config = FilterPostProcessorConfiguration(
-        field="nonexistent_field",
-        value="somebody@email.com"
+        field="nonexistent_field", value="somebody@email.com"
     )
     data = {
         "id": 238475234,
         "email_contact": "somebody@email.com",
-        "name": "Somebody Cool"
+        "name": "Somebody Cool",
     }
     processor = FilterPostProcessorStrategy(configuration=config)
     result = processor.process(data)
-    assert result is None
+    assert result == []
 
 
 def test_filter_by_nonexistent_identity_reference():
     identity_data: Dict[str, Any] = {"phone": "123-1234-1235"}
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value={"identity": "email"}
+        field="email_contact", value={"identity": "email"}
     )
     data = [
         {
@@ -147,19 +146,17 @@ def test_filter_by_nonexistent_identity_reference():
         {
             "id": 238475234,
             "email_contact": "somebody-else@email.com",
-            "name": "Somebody Cool"
-        }
+            "name": "Somebody Cool",
+        },
     ]
     processor = FilterPostProcessorStrategy(configuration=config)
-    result = processor.process(data, identity_data)
-    assert result is None
-
+    result = processor.process(data)
+    assert result == []
 
 def test_filter_by_identity_reference_with_no_identity_data():
     identity_data = None
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value={"identity": "email"}
+        field="email_contact", value={"identity": "email"}
     )
     data = [
         {
@@ -170,18 +167,17 @@ def test_filter_by_identity_reference_with_no_identity_data():
         {
             "id": 238475234,
             "email_contact": "somebody-else@email.com",
-            "name": "Somebody Cool"
-        }
+            "name": "Somebody Cool",
+        },
     ]
     processor = FilterPostProcessorStrategy(configuration=config)
-    result = processor.process(data, identity_data)
-    assert result is None
+    result = processor.process(data)
+    assert result == []
 
 
 def test_filter_no_value():
     config = FilterPostProcessorConfiguration(
-        field="email_contact",
-        value="somebody@email.com"
+        field="email_contact", value="somebody@email.com"
     )
     processor = FilterPostProcessorStrategy(configuration=config)
-    assert None is processor.process(None)
+    assert processor.process(None) == []

--- a/tests/service/processors/post_processor_strategy/test_post_processor_strategy_unwrap.py
+++ b/tests/service/processors/post_processor_strategy/test_post_processor_strategy_unwrap.py
@@ -42,20 +42,22 @@ def test_unwrap_path_not_found():
     }
     processor = UnwrapPostProcessorStrategy(configuration=config)
     result = processor.process(data)
-    assert result is None
+    assert result == []
 
 
 def test_unwrap_unexpected_format():
     config = UnwrapPostProcessorConfiguration(data_path="exact_matches.members")
     data = "not-a-list-or-dict"
     processor = UnwrapPostProcessorStrategy(configuration=config)
-    assert processor.process(data) == None
+    result = processor.process(data)
+    assert result == []
 
 
 def test_unwrap_no_value():
     config = UnwrapPostProcessorConfiguration(data_path="exact_matches.members")
     processor = UnwrapPostProcessorStrategy(configuration=config)
-    assert None is processor.process(None)
+    result = processor.process(None)
+    assert result == []
 
 
 def test_unwrap_list():


### PR DESCRIPTION
# Purpose

To fix the issue described in #308.

# Changes

Modified the filter and unwrap post-processors to return an empty list `[]` for the following scenarios:

### Filter
- Empty data passed into filter
- Identity data missing
- Field not available on the object being filtered
- No results remaining after filter (how this issue was originally discovered)

### Unwrap
- No data found at `data_path`

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #308
 
