### PR TITLE
add project requirements to tutorial start (#293)

### DIFF
--- a/docs/fidesops/docs/tutorial/installation.md
+++ b/docs/fidesops/docs/tutorial/installation.md
@@ -1,5 +1,14 @@
 # Installation
 
+## Requirements 
+To run this project, ensure you have the following requirements installed and running on your machine:
+
+* [Docker 12+](https://docs.docker.com/desktop/#download-and-install)
+* Python 3.7+
+* Make
+* pg_config (`brew install libpq` or `brew install postgres` on Mac)
+
+
 ## Clone the fidesdemo repo
 
 Let's clone [Fides Demo](https://github.com/ethyca/fidesdemo), and rewind to an earlier tag, so we can build out 


### PR DESCRIPTION
# Purpose
- Following the tutorial from scratch can lead to issues if all of the requirements aren't already installed and running. There is a mismatch between the tutorial start and the fidesdemo readme. This pr adds the missing requirements.

# Changes
- Added a requirements section to the fidesops tutorial to match the readme in the demo.

# Checklist
- [X] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))

Fixes #293 
