### PR TITLE
Proof of concept for custom functions that override the config-derive…

### DIFF
--- a/data/saas/config/mailchimp_config.yml
+++ b/data/saas/config/mailchimp_config.yml
@@ -28,7 +28,7 @@ saas_config:
   - name: messages
     requests:
       read:
-        path: /3.0/conversations/<conversation_id>/messages
+        custom_function: mailchimp.read_messages
         request_params:
           - name: conversation_id
             type: path
@@ -36,13 +36,6 @@ saas_config:
               - dataset: mailchimp_connector_example
                 field: conversations.id
                 direction: from
-        data_path: conversation_messages
-        postprocessors:
-          - strategy: filter
-            configuration:
-              field: from_email
-              value:
-                identity: email
   - name: conversations
     requests:
       read:

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -72,11 +72,14 @@ class SaaSRequest(BaseModel):
     Also includes optional strategies for postprocessing and pagination.
     """
 
-    path: str
+    custom_function: Optional[str]
+    path: Optional[str]
     request_params: Optional[List[RequestParam]]
     data_path: Optional[str]
     postprocessors: Optional[List[Strategy]]
     pagination: Optional[Strategy]
+
+    # TODO: make path required if custom_function is not present
 
     @root_validator(pre=True)
     def validate_request_for_pagination(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/fidesops/service/saas_custom_functions/mailchimp.py
+++ b/src/fidesops/service/saas_custom_functions/mailchimp.py
@@ -1,0 +1,62 @@
+import pydash
+from typing import Any, Dict, List
+import requests
+from requests import Session
+from fidesops.graph.traversal import TraversalNode
+from fidesops.models.policy import Policy
+from fidesops.models.privacy_request import PrivacyRequest
+from fidesops.util.collection_util import Row
+
+
+def read_messages(
+    node: TraversalNode,
+    policy: Policy,
+    privacy_request: PrivacyRequest,
+    input_data: Dict[str, List[Any]],
+    identity_data: Dict[str, Any],
+    secrets: Dict[str, Any],
+) -> List[Row]:
+    """
+    Equivalent SaaS config for the code in this function.
+    
+    Request params still need to be defined for endpoints with custom functions.
+    This is to provide the necessary reference and identity data as part
+    of graph traversal. The resulting values are passed in as parameters
+    so we don't need to define the data retrieval here.
+
+    path: /3.0/conversations/<conversation_id>/messages
+    request_params:
+      - name: conversation_id
+        type: path
+        references:
+        - dataset: mailchimp_connector_example
+          field: conversations.id
+          direction: from
+    data_path: conversation_messages
+    postprocessors:
+      - strategy: filter
+        configuration:
+          field: from_email
+          value:
+            identity: email
+    """
+
+    # gather request params
+    conversation_ids = input_data.get("conversation_id")
+    
+    # build and execute request for each input data value
+    processed_data = []
+    for conversation_id in conversation_ids:
+        response = requests.get(
+            url=f'https://{secrets["domain"]}/3.0/conversations/{conversation_id}/messages',
+            auth=(secrets["username"], secrets["api_key"]),
+        )
+
+        # unwrap and post-process response
+        response_data = pydash.get(response.json(), "conversation_messages")
+        filtered_data = pydash.filter_(response_data, {"from_email": identity_data.get("email")})
+
+        # build up final result
+        processed_data.extend(filtered_data)
+
+    return processed_data

--- a/tests/service/saas_custom_functions/test_custom_functions.py
+++ b/tests/service/saas_custom_functions/test_custom_functions.py
@@ -1,0 +1,8 @@
+import importlib
+
+def test_get_custom_functions():
+    saas_connector = "mailchimp"
+    custom_function_name = "read_messages"
+    module = importlib.import_module(f"fidesops.service.saas_custom_functions.{saas_connector}")
+    custom_function = getattr(module, custom_function_name)
+    assert callable(custom_function)


### PR DESCRIPTION
# Purpose
A proof-of-concept for custom functions that override the config-derived implementation of retrieve_data.

One of the challenges in building config-based SaaS connectors is that we need to replicate functionality that exists within the Python Requests library in YAML. The long-term goal is to provide enough "building blocks" that someone without Python experience can piece together a new integration just using the SaaS config. Even with this goal in mind, there might be some behavior that is specific to an integration and might not warrant creating a reusable strategy for.

This POC is not very robust (no error handling) but I'd like to introduce it as a conversation starter.

# Changes
- New `saas_custom_functions` directory to store custom functions
- Added `custom_function` property to `endpoints` in the `saas_config` schema
- Added to a check to `retrieve_data`  in `saas_connector` to call the custom function if available
- Added a function in `saas_connector` to dynamically load functions from the `saas_custom_functions` directory

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

