### PR TITLE
update mkdocs version (#332)

### DIFF
--- a/docs/fidesops/requirements.txt
+++ b/docs/fidesops/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material==7.2.5
+mkdocs-material==8.2.7
 mkdocs-minify-plugin==0.4.0
 mkdocs-render-swagger-plugin==0.0.3


### PR DESCRIPTION
### Purpose
Mkdocs pushed [a patch](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.7) to limit the jinja version range. Updating the pinned version in the docs' `requirements.txt` will resolve the issue for now, but might not be the best strategy for versioning in the future.

### Changes
* update mkdocs version to be compatible with recent jinja2 release 

Fixes #332 
 
