### PR TITLE
adds policy data to the privacy request API response

### DIFF
--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -7,6 +7,7 @@ from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.core.config import config
 from fidesops.models.policy import ActionType
 from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
+from fidesops.schemas.policy import Policy as PolicySchema
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
 from fidesops.schemas.base_class import BaseSchema
 from fidesops.models.privacy_request import PrivacyRequestStatus, ExecutionLogStatus
@@ -89,6 +90,7 @@ class PrivacyRequestResponse(BaseSchema):
     # about our PII structure than is explicitly stored in the cache on request
     # creation.
     identity: Optional[Dict[str, str]]
+    policy: PolicySchema
 
     class Config:
         """Set orm_mode and use_enum_values"""

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -459,6 +459,9 @@ class TestGetPrivacyRequests:
             == succeeded_privacy_request.get_cached_identity_data()
         )
 
+        assert resp["items"][0]["policy"]["key"] == privacy_request.policy.key
+        assert resp["items"][0]["policy"]["name"] == privacy_request.policy.name
+
         # Now test the identities are omitted if not explicitly requested
         response = api_client.get(url + f"?status=complete", headers=auth_header)
         assert 200 == response.status_code


### PR DESCRIPTION
# Purpose

This PR adds `Policy` schema information to the privacy request list response.

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #338 
 
