### PR TITLE
Privacy Centre [331] - Hide status bar

### DIFF
--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import {
@@ -22,6 +22,14 @@ import config from '../config/config.json';
 const Home: NextPage = () => {
   const [alert, setAlert] = useState<AlertState | null>(null);
   const { isOpen, onClose, onOpen, openAction } = useRequestModal();
+
+  useEffect(() => {
+    if(alert?.status === 'error') {
+      const closeAlertTimer = setTimeout(() => setAlert(null), 8000);
+      return () => clearTimeout(closeAlertTimer)
+    }
+  }, [alert])
+  
   return (
     <div>
       <Head>

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -24,7 +24,7 @@ const Home: NextPage = () => {
   const { isOpen, onClose, onOpen, openAction } = useRequestModal();
 
   useEffect(() => {
-    if(alert?.status === 'error') {
+    if(alert?.status) {
       const closeAlertTimer = setTimeout(() => setAlert(null), 8000);
       return () => clearTimeout(closeAlertTimer)
     }


### PR DESCRIPTION
# Purpose
Hide status bar after some seconds pass.

# Changes
Setting the alert only to be hidden after 8 seconds pass.

**~~Questions:~~**
- ~~Would the Toast component from the chakra UI be more useful in this case rather than using Alerts since it has a duration prop built-in? This would require changing from Alerts to Toasts.~~
- ~~Do we only want to hide the error alerts, and no other cases?~~
- ~~Does 8 seconds seem reasonable given the length of the text?~~

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #331 
 
