### PR TITLE
[#275] Seed DB with test data

### DIFF
--- a/src/migrations/versions/295b9b40e54d_seed_privacy_request_data.py
+++ b/src/migrations/versions/295b9b40e54d_seed_privacy_request_data.py
@@ -1,0 +1,124 @@
+"""seed privacy request data
+
+Revision ID: 295b9b40e54d
+Revises: 906d7198df28
+Create Date: 2022-03-31 20:21:49.222391
+
+"""
+from datetime import datetime, timedelta
+import string
+from uuid import uuid4
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from fidesops.models.client import ClientDetail
+from fidesops.models.policy import ActionType, Policy, Rule, RuleTarget
+from fidesops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
+from fidesops.util.data_category import DataCategory
+
+
+# revision identifiers, used by Alembic.
+revision = "295b9b40e54d"
+down_revision = "906d7198df28"
+branch_labels = None
+depends_on = None
+
+MIGRATED_DATA_KEY = "migrated_example_data"
+
+
+def _create_policy(db: orm.Session, action_type: str, client_id: str) -> Policy:
+    rand = string.ascii_lowercase[:5]
+    policy = Policy.create(
+        db=db,
+        data={
+            "name": f"example {action_type} policy {rand}",
+            "key": f"example_{action_type}_policy_{rand}",
+            "client_id": client_id,
+        },
+    )
+
+    rule = Rule.create(
+        db=db,
+        data={
+            "action_type": ActionType.erasure.value,
+            "name": f"{action_type} Rule {rand}",
+            "policy_id": policy.id,
+            "masking_strategy": {
+                "strategy": "null_rewrite",
+                "configuration": {},
+            },
+            "client_id": client_id,
+        },
+    )
+
+    RuleTarget.create(
+        db=db,
+        data={
+            "data_category": DataCategory("user.provided.identifiable.name").value,
+            "rule_id": rule.id,
+            "client_id": client_id,
+        },
+    )
+    return policy
+
+
+def upgrade():
+    """
+    Adds some demo data to this Fidesops instance
+    """
+    bind = op.get_bind()
+    db = orm.Session(bind=bind)
+
+    client = ClientDetail.create(
+        db=db,
+        data={
+            "fides_key": MIGRATED_DATA_KEY,
+            "hashed_secret": "autoseededdata",
+            "salt": "autoseededdata",
+            "scopes": [],
+        },
+    )
+
+    for action in ActionType.__members__.values():
+        policy = _create_policy(db, action.value, client.id)
+
+        for status in PrivacyRequestStatus.__members__.values():
+            PrivacyRequest.create(
+                db=db,
+                data={
+                    "external_id": f"ext-{uuid4()}",
+                    "started_processing_at": datetime.utcnow(),
+                    "requested_at": datetime.utcnow() - timedelta(days=1),
+                    "status": status,
+                    "origin": f"https://example.com/{status.value}/",
+                    "policy_id": policy.id,
+                    "client_id": policy.client_id,
+                },
+            )
+
+
+def downgrade():
+    """
+    Removes the demo data added in `upgrade()`
+    """
+    bind = op.get_bind()
+    db = orm.Session(bind=bind)
+
+    client = ClientDetail.get_by(
+        db=db,
+        field="fides_key",
+        value=MIGRATED_DATA_KEY,
+    )
+
+    if client is None:
+        return
+
+    models = [PrivacyRequest, RuleTarget, Rule, Policy]
+    for Model in models:
+        qs = Model.filter(db=db, conditions=(Model.client_id == client.id))
+        for obj in qs:
+            obj.delete(db=db)
+
+    client.delete(db=db)

--- a/src/migrations/versions/906d7198df28_privacy_request_approve.py
+++ b/src/migrations/versions/906d7198df28_privacy_request_approve.py
@@ -17,8 +17,9 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("alter type privacyrequeststatus add value 'approved'")
-    op.execute("alter type privacyrequeststatus add value 'denied'")
+    with op.get_context().autocommit_block():
+        op.execute("alter type privacyrequeststatus add value 'approved'")
+        op.execute("alter type privacyrequeststatus add value 'denied'")
 
     op.add_column(
         "privacyrequest",


### PR DESCRIPTION
# Purpose

@elliotbonneville has requested some example data with which to test the Fidesops Admin UI.

# Changes

- Adds a data migration to seed some example policies and privacy requests
- This migration adds a `PrivacyRequest` in every permutation of status and policy

# Note

As this is done via a migration, it will be automatically run every time the migrations are run. As such, we shouldn't merge this to `main`. @elliotbonneville the best course of action here is to merge this branch into your fork, and include the migration in your local stack, then before merging the Admin UI back into `main` from your fork, we remove this migration.

To execute the migration:
- SSH into the app server shell: `make server-shell`
- Navigate to the Alembic source `cd src/`
- Apply the migration: `alembic upgrade head`
- Unapply with migration: `alembic downgrade 906d7198df28`

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #275 
 
