### PR TITLE
Add support for custom logo

### DIFF
--- a/clients/privacy-center/__tests__/index.test.tsx
+++ b/clients/privacy-center/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 // __tests__/index.test.tsx
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Home from '../pages/index';
 
 import mockConfig from '../config/__mocks__/config.json';
@@ -41,4 +41,12 @@ describe('Home', () => {
     const modal = screen.getByRole('dialog');
     expect(modal).toBeInTheDocument();
   });
+
+  it('renders the logo from the corrrect url', async () => {
+    render(<Home />);
+    await waitFor(() => {
+      const logo = screen.getByAltText('Logo');
+      expect(logo.src).toEqual(`http://localhost${mockConfig.logo_path}`);
+    });
+  })
 });

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -56,7 +56,7 @@ const Home: NextPage = () => {
               />
             </Alert>
           ) : null}
-          <Image src="/logo.svg" height="56px" width="304px" alt="Logo" />
+          <Image src={config.logo_path} height="56px" width="304px" alt="Logo" />
         </Flex>
       </header>
 


### PR DESCRIPTION
# Purpose
Add support in Privacy Center for for using a custom logo based on the `logo_path` specified in the `config.json` file.

# Changes
- Pulls the logo image path from the `config.json` file in `index.tsx`.
- Adds a test to verify the correct image url is used.

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #346
 
