### PR TITLE
Update Privacy Request Search Mechanics

### DIFF
--- a/docs/fidesops/docs/guides/reporting.md
+++ b/docs/fidesops/docs/guides/reporting.md
@@ -51,6 +51,8 @@ If an `external_id` was provided at request creation, we can also track the priv
 
 `GET api/v1/privacy-request?external_id=<external_id>`
 
+NB. These parameters will return matching Privacy Requests based on startswith matches.
+
 ### Privacy Request Filtering Options
 
 Use the following query params to further filter your privacy requests.  Filters can be chained, for example, 

--- a/docs/fidesops/docs/guides/reporting.md
+++ b/docs/fidesops/docs/guides/reporting.md
@@ -51,7 +51,7 @@ If an `external_id` was provided at request creation, we can also track the priv
 
 `GET api/v1/privacy-request?external_id=<external_id>`
 
-NB. These parameters will return matching Privacy Requests based on startswith matches.
+Please note: These parameters will return matching Privacy Requests based on startswith matches.
 
 ### Privacy Request Filtering Options
 

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -303,7 +303,7 @@ def get_request_status(
 
     # Further restrict all PrivacyRequests by query params
     if id:
-        query = query.filter(PrivacyRequest.id == id)
+        query = query.filter(PrivacyRequest.id.ilike(f"{id}%"))
     if external_id:
         query = query.filter(PrivacyRequest.external_id == external_id)
     if status:

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -305,7 +305,7 @@ def get_request_status(
     if id:
         query = query.filter(PrivacyRequest.id.ilike(f"{id}%"))
     if external_id:
-        query = query.filter(PrivacyRequest.external_id == external_id)
+        query = query.filter(PrivacyRequest.external_id.ilike(f"{external_id}%"))
     if status:
         query = query.filter(PrivacyRequest.status == status)
     if created_lt:

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -442,6 +442,49 @@ class TestGetPrivacyRequests:
         resp = response.json()
         assert resp == expected_resp
 
+    def test_get_privacy_requests_by_partial_id(
+        self,
+        api_client: TestClient,
+        url,
+        generate_auth_header,
+        privacy_request,
+        postgres_execution_log,
+        mongo_execution_log,
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        response = api_client.get(
+            url + f"?id={privacy_request.id[:5]}", headers=auth_header
+        )
+        assert 200 == response.status_code
+
+        expected_resp = {
+            "items": [
+                {
+                    "id": privacy_request.id,
+                    "created_at": stringify_date(privacy_request.created_at),
+                    "started_processing_at": stringify_date(
+                        privacy_request.started_processing_at
+                    ),
+                    "finished_processing_at": None,
+                    "status": privacy_request.status.value,
+                    "external_id": privacy_request.external_id,
+                    "identity": None,
+                    "reviewed_at": None,
+                    "reviewed_by": None,
+                    "policy": {
+                        "name": privacy_request.policy.name,
+                        "key": privacy_request.policy.key,
+                    },
+                }
+            ],
+            "total": 1,
+            "page": 1,
+            "size": page_size,
+        }
+
+        resp = response.json()
+        assert resp == expected_resp
+
     def test_get_privacy_requests_with_identity(
         self,
         api_client: TestClient,


### PR DESCRIPTION
# Changes

- This PR changes the way in which we search for Privacy Requests by IDs
- For `PrivacyRequest.id` and `PrivacyRequest.external_id` we now look for matches that start with the value provided.
- For example `?id=12345` will return privacy requests with ids `12345` and `123456`


# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
 
