### PR TITLE
Admin UI Backend Tweaks

### DIFF
--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -274,14 +274,14 @@ def get_request_status(
     params: Params = Depends(),
     id: Optional[str] = None,
     status: Optional[PrivacyRequestStatus] = None,
-    created_lt: Optional[date] = None,
-    created_gt: Optional[date] = None,
-    started_lt: Optional[date] = None,
-    started_gt: Optional[date] = None,
-    completed_lt: Optional[date] = None,
-    completed_gt: Optional[date] = None,
-    errored_lt: Optional[date] = None,
-    errored_gt: Optional[date] = None,
+    created_lt: Optional[Union[date, datetime]] = None,
+    created_gt: Optional[Union[date, datetime]] = None,
+    started_lt: Optional[Union[date, datetime]] = None,
+    started_gt: Optional[Union[date, datetime]] = None,
+    completed_lt: Optional[Union[date, datetime]] = None,
+    completed_gt: Optional[Union[date, datetime]] = None,
+    errored_lt: Optional[Union[date, datetime]] = None,
+    errored_gt: Optional[Union[date, datetime]] = None,
     external_id: Optional[str] = None,
     verbose: Optional[bool] = False,
     include_identities: Optional[bool] = False,
@@ -350,6 +350,8 @@ def get_request_status(
         )
     else:
         PrivacyRequest.execution_logs_by_dataset = property(lambda self: None)
+
+    query = query.order_by(PrivacyRequest.created_at.desc())
 
     paginated = paginate(query, params)
     if include_identities:

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import List, Optional, Dict
+from fidesops.schemas.user import PrivacyRequestReviewerRespoonse
 
 from pydantic import Field, validator
 from fidesops.schemas.shared_schemas import FidesOpsKey
@@ -82,6 +83,7 @@ class PrivacyRequestResponse(BaseSchema):
     started_processing_at: Optional[datetime]
     reviewed_at: Optional[datetime]
     reviewed_by: Optional[str]
+    reviewer: Optional[PrivacyRequestReviewerRespoonse]
     finished_processing_at: Optional[datetime]
     status: PrivacyRequestStatus
     external_id: Optional[str]

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import List, Optional, Dict
-from fidesops.schemas.user import PrivacyRequestReviewerRespoonse
+from fidesops.schemas.user import PrivacyRequestReviewerResponse
 
 from pydantic import Field, validator
 from fidesops.schemas.shared_schemas import FidesOpsKey
@@ -83,7 +83,7 @@ class PrivacyRequestResponse(BaseSchema):
     started_processing_at: Optional[datetime]
     reviewed_at: Optional[datetime]
     reviewed_by: Optional[str]
-    reviewer: Optional[PrivacyRequestReviewerRespoonse]
+    reviewer: Optional[PrivacyRequestReviewerResponse]
     finished_processing_at: Optional[datetime]
     status: PrivacyRequestStatus
     external_id: Optional[str]

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from typing import List, Optional, Dict
-from fidesops.schemas.user import PrivacyRequestReviewer
 
 from pydantic import Field, validator
-from fidesops.schemas.shared_schemas import FidesOpsKey
 
 from fidesops.core.config import config
 from fidesops.models.policy import ActionType
@@ -11,10 +9,10 @@ from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
 from fidesops.schemas.policy import Policy as PolicySchema
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
 from fidesops.schemas.base_class import BaseSchema
+from fidesops.schemas.shared_schemas import FidesOpsKey
+from fidesops.schemas.user import PrivacyRequestReviewer
 from fidesops.models.privacy_request import PrivacyRequestStatus, ExecutionLogStatus
-from fidesops.util.encryption.aes_gcm_encryption_scheme import (
-    verify_encryption_key,
-)
+from fidesops.util.encryption.aes_gcm_encryption_scheme import verify_encryption_key
 
 
 class PrivacyRequestCreate(BaseSchema):

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import List, Optional, Dict
-from fidesops.schemas.user import PrivacyRequestReviewerResponse
+from fidesops.schemas.user import PrivacyRequestReviewer
 
 from pydantic import Field, validator
 from fidesops.schemas.shared_schemas import FidesOpsKey
@@ -83,7 +83,7 @@ class PrivacyRequestResponse(BaseSchema):
     started_processing_at: Optional[datetime]
     reviewed_at: Optional[datetime]
     reviewed_by: Optional[str]
-    reviewer: Optional[PrivacyRequestReviewerResponse]
+    reviewer: Optional[PrivacyRequestReviewer]
     finished_processing_at: Optional[datetime]
     status: PrivacyRequestStatus
     external_id: Optional[str]

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -51,7 +51,7 @@ class UserCreateResponse(BaseSchema):
     id: str
 
 
-class PrivacyRequestReviewerRespoonse(BaseSchema):
+class PrivacyRequestReviewerResponse(BaseSchema):
     """"""
 
     id: str

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -51,7 +51,7 @@ class UserCreateResponse(BaseSchema):
     id: str
 
 
-class PrivacyRequestReviewerResponse(BaseSchema):
+class PrivacyRequestReviewer(BaseSchema):
     """"""
 
     id: str

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from pydantic import validator
 
@@ -48,3 +49,10 @@ class UserCreateResponse(BaseSchema):
     """Response after creating a FidesopsUser"""
 
     id: str
+
+
+class PrivacyRequestReviewerRespoonse(BaseSchema):
+    """"""
+
+    id: str
+    username: str

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from pydantic import validator
 
@@ -52,7 +51,7 @@ class UserCreateResponse(BaseSchema):
 
 
 class PrivacyRequestReviewer(BaseSchema):
-    """"""
+    """Data we can expose via the PrivacyRequest.reviewer relation"""
 
     id: str
     username: str

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -399,6 +399,30 @@ class TestGetPrivacyRequests:
         )
         assert 400 == response.status_code
 
+    def test_get_privacy_requests_displays_reviewer(
+        self,
+        api_client: TestClient,
+        db,
+        url,
+        generate_auth_header,
+        privacy_request,
+        user,
+        postgres_execution_log,
+        mongo_execution_log,
+    ):
+        privacy_request.reviewer = user
+        privacy_request.save(db=db)
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        response = api_client.get(
+            url + f"?id={privacy_request.id}", headers=auth_header
+        )
+        assert 200 == response.status_code
+
+        reviewer = response.json()["items"][0]["reviewer"]
+        assert reviewer
+        assert user.id == reviewer["id"]
+        assert user.username == reviewer["username"]
+
     def test_get_privacy_requests_by_id(
         self,
         api_client: TestClient,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -423,6 +423,26 @@ class TestGetPrivacyRequests:
         assert user.id == reviewer["id"]
         assert user.username == reviewer["username"]
 
+    def test_get_privacy_requests_accept_datetime(
+        self,
+        api_client: TestClient,
+        db,
+        url,
+        generate_auth_header,
+        privacy_request,
+        postgres_execution_log,
+        mongo_execution_log,
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        for date_format in ["%Y-%m-%dT00:00:00.000Z", "%Y-%m-%d"]:
+            date_input = privacy_request.created_at.strftime(date_format)
+            response = api_client.get(
+                url + f"?created_gt={date_input}",
+                headers=auth_header,
+            )
+
+        assert 200 == response.status_code
+
     def test_get_privacy_requests_by_id(
         self,
         api_client: TestClient,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -472,6 +472,7 @@ class TestGetPrivacyRequests:
                     "identity": None,
                     "reviewed_at": None,
                     "reviewed_by": None,
+                    "reviewer": None,
                     "policy": {
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
@@ -515,6 +516,7 @@ class TestGetPrivacyRequests:
                     "identity": None,
                     "reviewed_at": None,
                     "reviewed_by": None,
+                    "reviewer": None,
                     "policy": {
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
@@ -640,9 +642,9 @@ class TestGetPrivacyRequests:
         assert 200 == response.status_code
         resp = response.json()
         assert len(resp["items"]) == 3
-        assert resp["items"][0]["id"] == privacy_request.id
+        assert resp["items"][0]["id"] == failed_privacy_request.id
         assert resp["items"][1]["id"] == succeeded_privacy_request.id
-        assert resp["items"][2]["id"] == failed_privacy_request.id
+        assert resp["items"][2]["id"] == privacy_request.id
 
     def test_filter_privacy_requests_by_started(
         self,
@@ -658,8 +660,8 @@ class TestGetPrivacyRequests:
         assert 200 == response.status_code
         resp = response.json()
         assert len(resp["items"]) == 2
-        assert resp["items"][0]["id"] == privacy_request.id
-        assert resp["items"][1]["id"] == failed_privacy_request.id
+        assert resp["items"][0]["id"] == failed_privacy_request.id
+        assert resp["items"][1]["id"] == privacy_request.id
 
         response = api_client.get(url + f"?started_gt=2021-05-01", headers=auth_header)
         assert 200 == response.status_code
@@ -747,6 +749,7 @@ class TestGetPrivacyRequests:
                     "identity": None,
                     "reviewed_at": None,
                     "reviewed_by": None,
+                    "reviewer": None,
                     "policy": {
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
@@ -1474,6 +1477,7 @@ class TestResumePrivacyRequest:
             "identity": None,
             "reviewed_at": None,
             "reviewed_by": None,
+            "reviewer": None,
             "policy": {
                 "key": privacy_request.policy.key,
                 "name": privacy_request.policy.name,

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -706,8 +706,8 @@ def user(db: Session):
         db=db,
         data={
             "username": "test_fidesops_user",
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7"
-        }
+            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+        },
     )
     client = ClientDetail(
         hashed_secret="thisisatest",


### PR DESCRIPTION
# Changes

- Adds `PrivacyRequestReviewer` for the purpose of exposing certain `PrivacyRequest.reviewer` fields over the API.
- Adds a default sort order `-created_at` to the PrivacyRequest status endpoint.
- Updates the PrivacyRequest status endpoint to accept date fields as both `date` and `datetime`.

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

Fixes #366 