### PR TITLE
Segment Masking Test Failures

### DIFF
--- a/tests/integration_tests/saas/test_segment_task.py
+++ b/tests/integration_tests/saas/test_segment_task.py
@@ -224,6 +224,7 @@ def test_segment_saas_erasure_request_task(
 
     # Create user for GDPR delete
     erasure_email = create_segment_test_data(segment_connection_config, segment_identity_email)
+    time.sleep(2)  # Pause before making access/erasure requests
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )

--- a/tests/integration_tests/saas/test_segment_task.py
+++ b/tests/integration_tests/saas/test_segment_task.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import time
 import random
 import requests
@@ -146,9 +145,10 @@ def _create_test_segment_email(base_email: str, timestamp: int) -> str:
 
 
 def create_segment_test_data(
-    segment_secrets: Dict[str, str], segment_identity_email: str
+    segment_connection_config, segment_identity_email: str
 ):
     """Seeds a segment user and event"""
+    segment_secrets = segment_connection_config.secrets
     if not segment_identity_email:  # Don't run unnecessarily locally
         return
 
@@ -218,13 +218,13 @@ def test_segment_saas_erasure_request_task(
     segment_connection_config,
     segment_dataset_config,
     segment_identity_email,
-    segment_secrets,
 ) -> None:
     """Full erasure request based on the Segment SaaS config"""
     config.execution.MASKING_STRICT = False  # Allow GDPR Delete
 
     # Create user for GDPR delete
-    erasure_email = create_segment_test_data(segment_secrets, segment_identity_email)
+    erasure_email = create_segment_test_data(segment_connection_config, segment_identity_email)
+    time.sleep(2)
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )

--- a/tests/integration_tests/saas/test_segment_task.py
+++ b/tests/integration_tests/saas/test_segment_task.py
@@ -224,7 +224,6 @@ def test_segment_saas_erasure_request_task(
 
     # Create user for GDPR delete
     erasure_email = create_segment_test_data(segment_connection_config, segment_identity_email)
-    time.sleep(2)
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )

--- a/tests/integration_tests/saas/test_sentry_task.py
+++ b/tests/integration_tests/saas/test_sentry_task.py
@@ -205,7 +205,8 @@ def test_sentry_saas_access_request_task(
     )
 
 
-def sentry_erasure_test_prep(sentry_secrets, sentry_connection_config, db):
+def sentry_erasure_test_prep(sentry_connection_config, db):
+    sentry_secrets = sentry_connection_config.secrets
     # Set the assignedTo field on a sentry issue to a given employee
     token = sentry_secrets.get("erasure_access_token")
     issue_url = sentry_secrets.get("issue_url")
@@ -235,11 +236,11 @@ def sentry_erasure_test_prep(sentry_secrets, sentry_connection_config, db):
 @pytest.mark.integration_saas
 @pytest.mark.integration_sentry
 def test_sentry_saas_erasure_request_task(
-    db, policy, sentry_connection_config, sentry_dataset_config, sentry_secrets
+    db, policy, sentry_connection_config, sentry_dataset_config
 ) -> None:
     """Full erasure request based on the Sentry SaaS config. Also verifies issue data in access request"""
     erasure_email, issue_url, headers = sentry_erasure_test_prep(
-        sentry_secrets, sentry_connection_config, db
+        sentry_connection_config, db
     )
 
     privacy_request = PrivacyRequest(


### PR DESCRIPTION
# Purpose
Segment masking failures - add a slight pause after creating data before running the access/gdpr delete request.

# Changes

-
# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
