### PR TITLE
add date fields to user model for last login and last password reset

### DIFF
--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -100,6 +100,9 @@ def user_login(
             status_code=HTTP_403_FORBIDDEN, detail="Incorrect password."
         )
 
+    # perform what's needed on the user model object
+    user.login(db)
+
     client: ClientDetail = user.client
     if not client:
         logger.info("Creating client for login")

--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -27,7 +27,6 @@ router = APIRouter(tags=["Users"], prefix=V1_URL_PREFIX)
 def perform_login(db: Session, user: FidesopsUser) -> ClientDetail:
     """Performs a login by updating the FidesopsUser instance and
     creating and returning an associated ClientDetail."""
-    user.last_login_at = datetime.utcnow()
 
     client: ClientDetail = user.client
     if not client:
@@ -36,7 +35,9 @@ def perform_login(db: Session, user: FidesopsUser) -> ClientDetail:
             db, SCOPE_REGISTRY, user_id=user.id
         )
 
+    user.last_login_at = datetime.utcnow()
     user.save(db)
+
     return client
 
 

--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -5,6 +5,7 @@ from starlette.status import (
     HTTP_404_NOT_FOUND,
     HTTP_403_FORBIDDEN,
 )
+from datetime import datetime
 
 from fidesops.api import deps
 from fidesops.api.v1 import urn_registry as urls
@@ -17,14 +18,26 @@ from fidesops.schemas.user import UserCreate, UserCreateResponse, UserLogin
 from fidesops.util.oauth_util import verify_oauth_client
 from sqlalchemy.orm import Session
 
-from fidesops.api.v1.scope_registry import (
-    USER_CREATE,
-    USER_DELETE,
-    SCOPE_REGISTRY,
-)
+from fidesops.api.v1.scope_registry import USER_CREATE, USER_DELETE, SCOPE_REGISTRY
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Users"], prefix=V1_URL_PREFIX)
+
+
+def perform_login(db: Session, user: FidesopsUser) -> ClientDetail:
+    """Performs a login by updating the FidesopsUser instance and
+    creating and returning an associated ClientDetail."""
+    user.last_login_at = datetime.utcnow()
+
+    client: ClientDetail = user.client
+    if not client:
+        logger.info("Creating client for login")
+        client, _ = ClientDetail.create_client_and_secret(
+            db, SCOPE_REGISTRY, user_id=user.id
+        )
+
+    user.save(db)
+    return client
 
 
 @router.post(
@@ -90,7 +103,9 @@ def user_login(
     *, db: Session = Depends(deps.get_db), user_data: UserLogin
 ) -> AccessToken:
     """Login the user by creating a client if it doesn't exist, and have that client generate a token"""
-    user = FidesopsUser.get_by(db, field="username", value=user_data.username)
+    user: FidesopsUser = FidesopsUser.get_by(
+        db, field="username", value=user_data.username
+    )
 
     if not user:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="No user found.")
@@ -100,15 +115,7 @@ def user_login(
             status_code=HTTP_403_FORBIDDEN, detail="Incorrect password."
         )
 
-    # perform what's needed on the user model object
-    user.login(db)
-
-    client: ClientDetail = user.client
-    if not client:
-        logger.info("Creating client for login")
-        client, _ = ClientDetail.create_client_and_secret(
-            db, SCOPE_REGISTRY, user_id=user.id
-        )
+    client: ClientDetail = perform_login(db, user)
 
     logger.info("Creating login access token")
     access_code = client.create_access_code_jwe()

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, DateTime
 from sqlalchemy.orm import Session, relationship
 
 from fidesops.core.config import config
@@ -14,6 +14,8 @@ class FidesopsUser(Base):
     username = Column(String, unique=True, index=True)
     hashed_password = Column(String, nullable=False)
     salt = Column(String, nullable=False)
+    last_login_at = Column(DateTime(timezone=True), nullable=True)
+    password_reset_at = Column(DateTime(timezone=True), nullable=True)
 
     client = relationship(
         "ClientDetail", backref="user", cascade="all, delete", uselist=False

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -63,7 +63,7 @@ class FidesopsUser(Base):
         self.last_login_at = datetime.utcnow()
         self.save(db)
 
-    def update_password(self, db: Session, new_password: str):
+    def update_password(self, db: Session, new_password: str) -> None:
         """Updates the user's password to the specified value.
         No validations are performed on the old/existing password within this function."""
 

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -57,7 +57,7 @@ class FidesopsUser(Base):
 
         return provided_password_hash == self.hashed_password
 
-    def login(self, db:Session) -> None:
+    def login(self, db: Session) -> None:
         """Performs any update to the user model object needed when logging in"""
         self.last_login_at = datetime.utcnow()
         self.save(db)

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -58,11 +58,6 @@ class FidesopsUser(Base):
 
         return provided_password_hash == self.hashed_password
 
-    def login(self, db: Session) -> None:
-        """Performs any update to the user model object needed when logging in"""
-        self.last_login_at = datetime.utcnow()
-        self.save(db)
-
     def update_password(self, db: Session, new_password: str) -> None:
         """Updates the user's password to the specified value.
         No validations are performed on the old/existing password within this function."""

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -24,6 +24,7 @@ class FidesopsUser(Base):
 
     @classmethod
     def hash_password(cls, password: str) -> Tuple[str, str]:
+        """Utility function to hash a user's password with a generated salt"""
         salt = generate_salt()
         hashed_password = hash_with_salt(
             password.encode(config.security.ENCODING),

--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -67,7 +67,7 @@ class FidesopsUser(Base):
         No validations are performed on the old/existing password within this function."""
 
         hashed_password, salt = FidesopsUser.hash_password(new_password)
-        self.hash_password = hashed_password
+        self.hashed_password = hashed_password
         self.salt = salt
         self.password_reset_at = datetime.utcnow()
         self.save(db)

--- a/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
+++ b/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
@@ -19,10 +19,10 @@ depends_on = None
 def upgrade():
     op.add_column(
         "fidesopsuser",
-        sa.Column("last_login_at", sa.Date(), nullable=True),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
     )
     op.add_column(
-        "fidesopsuser", sa.Column("password_reset_at", sa.Date(), nullable=True)
+        "fidesopsuser", sa.Column("password_reset_at", sa.DateTime(), nullable=True)
     )
 
 

--- a/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
+++ b/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
@@ -1,0 +1,33 @@
+"""add user login and password reset dates
+
+Revision ID: c9759675b5d3
+Revises: 906d7198df28
+Create Date: 2022-04-14 13:16:58.940571
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c9759675b5d3'
+down_revision = '906d7198df28'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "fidesopsuser",
+        sa.Column("last_login_at", sa.Date(), nullable=True),
+    )
+    op.add_column(
+        "fidesopsuser",
+        sa.Column("password_reset_at", sa.Date(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("fidesopsuser", "last_login_at")
+    op.drop_column("fidesopsuser", "password_reset_at")
+

--- a/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
+++ b/src/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'c9759675b5d3'
-down_revision = '906d7198df28'
+revision = "c9759675b5d3"
+down_revision = "906d7198df28"
 branch_labels = None
 depends_on = None
 
@@ -22,12 +22,10 @@ def upgrade():
         sa.Column("last_login_at", sa.Date(), nullable=True),
     )
     op.add_column(
-        "fidesopsuser",
-        sa.Column("password_reset_at", sa.Date(), nullable=True)
+        "fidesopsuser", sa.Column("password_reset_at", sa.Date(), nullable=True)
     )
 
 
 def downgrade():
     op.drop_column("fidesopsuser", "last_login_at")
     op.drop_column("fidesopsuser", "password_reset_at")
-

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -330,7 +330,11 @@ class TestUserLogout:
 
         # Assert user is not deleted
         user_search = FidesopsUser.get_by(db, field="id", value=user_id)
+        db.refresh(user_search)
         assert user_search is not None
+
+        # Assert user does not still have client reference
+        assert user_search.client is None
 
     def test_logout(self, db, url, api_client, generate_auth_header, oauth_client):
         oauth_client_id = oauth_client.id

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -314,10 +314,11 @@ class TestUserLogout:
     def test_user_not_deleted_on_logout(self, db, url, api_client, user):
         user_id = user.id
         client_id = user.client.id
+        scopes = user.client.scopes
 
         payload = {
-            JWE_PAYLOAD_SCOPES: user.client.scopes,
-            JWE_PAYLOAD_CLIENT_ID: user.client.id,
+            JWE_PAYLOAD_SCOPES: scopes,
+            JWE_PAYLOAD_CLIENT_ID: client_id,
             JWE_ISSUED_AT: datetime.now().isoformat(),
         }
         auth_header = {"Authorization": "Bearer " + generate_jwe(json.dumps(payload))}
@@ -335,6 +336,18 @@ class TestUserLogout:
 
         # Assert user does not still have client reference
         assert user_search.client is None
+
+        # Ensure that the client token is invalidated after logout
+        # Assert a request with the outdated client token gives a 401
+        payload = {
+            JWE_PAYLOAD_SCOPES: scopes,
+            JWE_PAYLOAD_CLIENT_ID: client_id,
+            JWE_ISSUED_AT: datetime.now().isoformat(),
+        }
+        auth_header = {"Authorization": "Bearer " + generate_jwe(json.dumps(payload))}
+        response = api_client.post(url, headers=auth_header, json={})
+        assert 403 == response.status_code
+
 
     def test_logout(self, db, url, api_client, generate_auth_header, oauth_client):
         oauth_client_id = oauth_client.id

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -275,6 +275,15 @@ class TestUserLogin:
 
         user.client.delete(db)
 
+    def test_login_updates_last_login_date(self, db, url, user, api_client):
+        body = {"username": user.username, "password": "TESTdcnG@wzJeu0&%3Qe2fGo7"}
+
+        response = api_client.post(url, headers={}, json=body)
+        assert response.status_code == 200
+
+        db.refresh(user)
+        assert user.last_login_at is not None
+
     def test_login_uses_existing_client(self, db, url, user, api_client):
         body = {"username": user.username, "password": "TESTdcnG@wzJeu0&%3Qe2fGo7"}
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -719,7 +719,10 @@ def user(db: Session):
     db.commit()
     db.refresh(client)
     yield user
-    client.delete(db)
+    try:
+        client.delete(db)
+    except ObjectDeletedError:
+        pass
     user.delete(db)
 
 

--- a/tests/models/test_fidesopsuser.py
+++ b/tests/models/test_fidesopsuser.py
@@ -15,6 +15,8 @@ class TestFidesopsUser:
         assert user.created_at is not None
         assert user.updated_at is not None
         assert user.hashed_password != "test_password"
+        assert user.last_login_at is None
+        assert user.password_reset_at is None
 
         assert not user.credentials_valid("bad_password")
         assert user.credentials_valid("test_password")

--- a/tests/models/test_fidesopsuser.py
+++ b/tests/models/test_fidesopsuser.py
@@ -29,3 +29,23 @@ class TestFidesopsUser:
                 db=db,
                 data={},
             )
+
+    def test_update_user_password(self, db: Session) -> None:
+        user = FidesopsUser.create(
+            db=db,
+            data={"username": "user_1", "password": "test_password"},
+        )
+
+        assert user.username == "user_1"
+        assert user.password_reset_at is None
+        assert user.credentials_valid("test_password")
+
+        user.update_password(db, "new_test_password")
+
+        assert user.username == "user_1"
+        assert user.password_reset_at is not None
+        assert user.credentials_valid("new_test_password")
+        assert user.hashed_password != "new_test_password"
+        assert not user.credentials_valid("test_password")
+
+        user.delete(db)


### PR DESCRIPTION
# Purpose
User model support for resetting passwords
# Changes
-add `last_login_at` and `password_reset_at` datetime fields to the FidesopsUser model class
-corresponding db migration to add these fields
-add functions to login and reset password on the FidesopsUser model class
-invoke login function as part of login API endpoint
# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [x] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket
Fixes https://github.com/ethyca/fidesops/issues/383

 
