### PR TITLE
Make scripts in Makefile POSIX-compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,17 +48,17 @@ server-shell: compose-build
 
 integration-shell:
 	@virtualenv -p python3 fidesops_test_dispatch; \
-		source fidesops_test_dispatch/bin/activate; \
+		. fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --open_shell --datastores $(datastores)
 
 integration-env:
 	@virtualenv -p python3 fidesops_test_dispatch; \
-		source fidesops_test_dispatch/bin/activate; \
+		. fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --run_application --datastores $(datastores)
 
 quickstart:
 	@virtualenv -p python3 fidesops_test_dispatch; \
-		source fidesops_test_dispatch/bin/activate; \
+		. fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --datastores mongodb postgres --run_quickstart
 
 ####################
@@ -110,7 +110,7 @@ pytest: compose-build
 
 pytest-integration:
 	@virtualenv -p python3 fidesops_test_dispatch; \
-		source fidesops_test_dispatch/bin/activate; \
+		. fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --run_tests --datastores $(datastores)
 
 # These tests connect to external third-party test databases
@@ -178,5 +178,5 @@ docs-serve: docs-build
 
 user:
 	@virtualenv -p python3 fidesops_test_dispatch; \
-		source fidesops_test_dispatch/bin/activate; \
+		. fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --datastores postgres --run_create_superuser


### PR DESCRIPTION
# Purpose

Some scripts in Makefile use the command `source`, which is not POSIX-compliant. This PR replaces `source <file>` with `. <file>`.

# Changes

-
# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md))
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
