### PR TITLE
402 doc fixes

### DIFF
--- a/docs/fidesops/docs/index.md
+++ b/docs/fidesops/docs/index.md
@@ -23,7 +23,7 @@ In a software organization, the team that writes and delivers software is normal
 
 ![Fidesops business process](img/fides-ops-process.png "Fidesops biz process")
 
-Your policies and database annotations are written in [**Fideslang**](https://github.com/ethyca/privacy-taxonomy): the syntax that describes the attributes of your data and its allowed purposes of use. 
+Your policies and database annotations are written in [**Fideslang**](https://github.com/ethyca/fideslang): the syntax that describes the attributes of your data and its allowed purposes of use. 
 
 But after identifying what types of data are in your databases using Fideslang, how will your organization know what data is deemed sensitive? And how will your organization prevent inappropriate uses of that data? That's where [**Fidesctl**](https://github.com/ethyca/fides) comes in. Fidesctl is a CLI tool that continuously verifies Fideslang database annotations against acceptable use privacy policies.
 

--- a/docs/fidesops/docs/tutorial/define_policy.md
+++ b/docs/fidesops/docs/tutorial/define_policy.md
@@ -16,9 +16,6 @@ convenience (handy if you'll be running this script multiple times).
 ### Define helper methods
 
 ```python
-...
-
-
 def create_policy(key, access_token):
     """
     Create a request policy in fidesops with the given key.Returns the response JSON if successful, or throws an error otherwise.
@@ -40,9 +37,6 @@ def create_policy(key, access_token):
 ```   
 
 ```python
-...
-
-
 def create_policy_rule(
         policy_key, key, action_type, storage_destination_key, access_token
 ):
@@ -70,9 +64,6 @@ def create_policy_rule(
 ```    
 
 ```python
-...
-
-
 def create_policy_rule_target(policy_key, rule_key, data_category, access_token):
     """
     Create a Policy Rule Target that matches the given data_category.
@@ -94,7 +85,6 @@ def create_policy_rule_target(policy_key, rule_key, data_category, access_token)
     return response.json()
 ```
 ```python
-...
 def delete_policy_rule(policy_key, key, access_token):
     """
     Deletes a Policy rule with the given key.

--- a/docs/fidesops/docs/tutorial/execute_privacy_request.md
+++ b/docs/fidesops/docs/tutorial/execute_privacy_request.md
@@ -41,7 +41,7 @@ def create_privacy_request(email, policy_key):
         json=privacy_request_data,
     )
     logger.info(f"Executing a Privacy Request. Status {response.status_code}")
-    logger.info(f"Check fidesdemo/fidesuploads for upload package.")
+    logger.info(f"Check fidesdemo/fides_uploads for upload package.")
     return response.json()
 ```
 


### PR DESCRIPTION
# Purpose
Update the docs to fix a few small issues and nit picks.
# Changes

- Update the fideslang link on https://ethyca.github.io/fidesops/ to use the new [https://github.com/ethyca/fideslang](https://github.com/ethyca/fideslang) link instead of the old [https://github.com/ethyca/privacy-taxonomy](https://github.com/ethyca/privacy-taxonomy) link
- Update the line 18 log within `Define helper method` code snippet on https://ethyca.github.io/fidesops/tutorial/execute_privacy_request/ to have the correct file path. Changed to `fidesdemo/fides_uploads` from `fidesdemo/fidesuploads`
- Remove ellipsis (...) from the code snippets on https://ethyca.github.io/fidesops/tutorial/define_policy/ so copied snippets don't contain them


# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)). If docs have been changed, tag in @conceptualshark for review.
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #402
 
