### PR TITLE
[feature] #390: Update date filter format to datetime

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/RequestFilters.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestFilters.tsx
@@ -38,21 +38,15 @@ const useRequestFilters = () => {
   const token = useSelector(selectUserToken);
   const dispatch = useDispatch();
   const toast = useToast();
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     dispatch(setRequestId(event.target.value));
-  };
-  const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) =>
     dispatch(setRequestStatus(event.target.value as PrivacyRequestStatus));
-  };
-  const handleFromChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFromChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     dispatch(setRequestFrom(event?.target.value));
-  };
-  const handleToChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleToChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     dispatch(setRequestTo(event?.target.value));
-  };
-  const handleClearAllFilters = () => {
-    dispatch(clearAllFilters());
-  };
+  const handleClearAllFilters = () => dispatch(clearAllFilters());
   const handleDownloadClick = async () => {
     let message;
     try {

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -18,15 +18,29 @@ export const mapFiltersToSearchParams = ({
   to,
   page,
   size,
-}: Partial<PrivacyRequestParams>) => ({
-  include_identities: 'true',
-  ...(status ? { status } : {}),
-  ...(id ? { id } : {}),
-  ...(from ? { created_gt: from } : {}),
-  ...(to ? { created_lt: to } : {}),
-  ...(page ? { page: `${page}` } : {}),
-  ...(typeof size !== 'undefined' ? { size: `${size}` } : {}),
-});
+}: Partial<PrivacyRequestParams>) => {
+  let fromISO;
+  if (from) {
+    fromISO = new Date(from);
+    fromISO.setUTCHours(0, 0, 0);
+  }
+
+  let toISO;
+  if (to) {
+    toISO = new Date(to);
+    toISO.setUTCHours(23, 59, 59);
+  }
+
+  return {
+    include_identities: 'true',
+    ...(status ? { status } : {}),
+    ...(id ? { id } : {}),
+    ...(fromISO ? { created_gt: fromISO.toISOString() } : {}),
+    ...(toISO ? { created_lt: toISO.toISOString() } : {}),
+    ...(page ? { page: `${page}` } : {}),
+    ...(typeof size !== 'undefined' ? { size: `${size}` } : {}),
+  };
+};
 
 // Subject requests API
 export const privacyRequestApi = createApi({


### PR DESCRIPTION
# Purpose

Fixes the bug where no requests are returned when you select the same date in both filters.

# Changes

- Sends ISO-8601 date times instead of pure dates as part of privacy requests request

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)). If docs have been changed, tag in @conceptualshark for review.
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes ethyca/fidesops#390 
 
