### PR TITLE
update pr template for documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,10 @@
 -
 # Checklist
 
-- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)). If docs have been changed, tag in @conceptualshark for review.
+- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
+- If docs updated (select one):
+  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
+  - [ ] documentation issue created (tag docs-team to complete issue separately)
 - [ ] Good unit test/integration test coverage
 - [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
 - [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services


### PR DESCRIPTION
# Purpose

# Changes
Update the PR template to provide more documentation specificity.

-
# Checklist

- [X] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md)).
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
