### PR TITLE
Convert HTTP Status Codes to Starlette constant values

### DIFF
--- a/src/fidesops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/oauth_endpoints.py
@@ -1,27 +1,19 @@
 import logging
-from typing import (
-    List,
-)
+from typing import List
 
-from fastapi import (
-    APIRouter,
-    Body,
-    Depends,
-    Request,
-    Security,
-    HTTPException,
-)
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Security
 from fastapi.security import HTTPBasic
 from sqlalchemy.orm import Session
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from fidesops.api.deps import get_db
 from fidesops.api.v1.scope_registry import (
+    CLIENT_CREATE,
     CLIENT_DELETE,
     CLIENT_READ,
-    CLIENT_CREATE,
+    CLIENT_UPDATE,
     SCOPE_READ,
     SCOPE_REGISTRY,
-    CLIENT_UPDATE,
 )
 from fidesops.api.v1.urn_registry import (
     CLIENT,
@@ -34,7 +26,6 @@ from fidesops.api.v1.urn_registry import (
 from fidesops.common_exceptions import AuthenticationFailure
 from fidesops.models.client import ClientDetail
 from fidesops.schemas.client import ClientCreatedResponse
-
 from fidesops.schemas.oauth import AccessToken, OAuth2ClientCredentialsRequestForm
 from fidesops.util.oauth_util import verify_oauth_client
 
@@ -93,7 +84,7 @@ def create_client(
     logging.info("Creating new client")
     if not all([scope in SCOPE_REGISTRY for scope in scopes]):
         raise HTTPException(
-            status_code=422,
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Invalid Scope. Scopes must be one of {SCOPE_REGISTRY}.",
         )
 
@@ -149,7 +140,7 @@ def set_client_scopes(
 
     if not all(elem in SCOPE_REGISTRY for elem in scopes):
         raise HTTPException(
-            status_code=422,
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Invalid Scope. Scopes must be one of {SCOPE_REGISTRY}.",
         )
 

--- a/src/fidesops/api/v1/endpoints/policy_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/policy_endpoints.py
@@ -2,42 +2,32 @@ import logging
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Body, Depends, Security
-from fastapi_pagination import (
-    Page,
-    Params,
-)
+from fastapi_pagination import Page, Params
 from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
-
-from fidesops.schemas.shared_schemas import FidesOpsKey
 from pydantic import conlist
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException
-from starlette.status import HTTP_404_NOT_FOUND
+from starlette.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
 
 from fidesops.api import deps
 from fidesops.api.v1 import scope_registry as scopes
 from fidesops.api.v1 import urn_registry as urls
 from fidesops.common_exceptions import (
     DataCategoryNotSupported,
-    PolicyValidationError,
-    RuleValidationError,
-    RuleTargetValidationError,
     KeyOrNameAlreadyExists,
+    PolicyValidationError,
+    RuleTargetValidationError,
+    RuleValidationError,
 )
 from fidesops.models.client import ClientDetail
-from fidesops.models.policy import (
-    ActionType,
-    Policy,
-    Rule,
-    RuleTarget,
-)
+from fidesops.models.policy import ActionType, Policy, Rule, RuleTarget
 from fidesops.models.storage import StorageConfig
 from fidesops.schemas import policy as schemas
 from fidesops.schemas.api import BulkUpdateFailed
+from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.util.oauth_util import verify_oauth_client
-
 
 router = APIRouter(tags=["Policy"], prefix=urls.V1_URL_PREFIX)
 
@@ -46,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 @router.get(
     urls.POLICY_LIST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=Page[schemas.PolicyResponse],
     dependencies=[Security(verify_oauth_client, scopes=[scopes.POLICY_READ])],
 )
@@ -78,7 +68,7 @@ def get_policy_or_error(db: Session, policy_key: FidesOpsKey) -> Policy:
 
 @router.get(
     urls.POLICY_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.PolicyResponse,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.POLICY_READ])],
 )
@@ -95,7 +85,7 @@ def get_policy(
 
 @router.patch(
     urls.POLICY_LIST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.BulkPutPolicyResponse,
 )
 def create_or_update_policies(
@@ -153,7 +143,7 @@ def create_or_update_policies(
 
 @router.patch(
     urls.RULE_LIST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.BulkPutRuleResponse,
 )
 def create_or_update_rules(
@@ -262,7 +252,7 @@ def create_or_update_rules(
 
 @router.delete(
     urls.RULE_DETAIL,
-    status_code=204,
+    status_code=HTTP_204_NO_CONTENT,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.RULE_DELETE])],
 )
 def delete_rule(
@@ -293,7 +283,7 @@ def delete_rule(
 
 @router.patch(
     urls.RULE_TARGET_LIST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.BulkPutRuleTargetResponse,
 )
 def create_or_update_rule_targets(
@@ -383,7 +373,7 @@ def create_or_update_rule_targets(
 
 @router.delete(
     urls.RULE_TARGET_DETAIL,
-    status_code=204,
+    status_code=HTTP_204_NO_CONTENT,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.RULE_DELETE])],
 )
 def delete_rule_target(

--- a/src/fidesops/api/v1/endpoints/policy_webhook_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/policy_webhook_endpoints.py
@@ -2,41 +2,33 @@ import logging
 from typing import List, Union
 
 from fastapi import APIRouter, Body, Depends, Security
-from fastapi_pagination import (
-    Page,
-    Params,
-)
+from fastapi_pagination import Page, Params
 from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
-
-from fidesops.api.v1.endpoints.connection_endpoints import (
-    get_connection_config_or_error,
-)
-from fidesops.api.v1.endpoints.policy_endpoints import get_policy_or_error
-from fidesops.db.base_class import get_key_from_data
-from fidesops.schemas.policy_webhooks import PolicyWebhookDeleteResponse
-from fidesops.schemas.shared_schemas import FidesOpsKey
 from pydantic import conlist
 from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException
-from starlette.status import HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST
+from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from fidesops.api import deps
 from fidesops.api.v1 import scope_registry as scopes
 from fidesops.api.v1 import urn_registry as urls
-from fidesops.common_exceptions import (
-    KeyOrNameAlreadyExists,
-    WebhookOrderException,
+from fidesops.api.v1.endpoints.connection_endpoints import (
+    get_connection_config_or_error,
 )
+from fidesops.api.v1.endpoints.policy_endpoints import get_policy_or_error
+from fidesops.common_exceptions import KeyOrNameAlreadyExists, WebhookOrderException
+from fidesops.db.base_class import get_key_from_data
 from fidesops.models.policy import (
     Policy,
-    PolicyPreWebhook,
     PolicyPostWebhook,
+    PolicyPreWebhook,
     WebhookTypes,
 )
 from fidesops.schemas import policy_webhooks as schemas
+from fidesops.schemas.policy_webhooks import PolicyWebhookDeleteResponse
+from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.util.oauth_util import verify_oauth_client
-
 
 router = APIRouter(tags=["Policy Webhooks"], prefix=urls.V1_URL_PREFIX)
 
@@ -45,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 @router.get(
     urls.POLICY_WEBHOOKS_PRE,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=Page[schemas.PolicyWebhookResponse],
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_READ])],
 )
@@ -69,7 +61,7 @@ def get_policy_pre_execution_webhooks(
 
 @router.get(
     urls.POLICY_WEBHOOKS_POST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=Page[schemas.PolicyWebhookResponse],
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_READ])],
 )
@@ -166,7 +158,7 @@ def put_webhooks(
 
 @router.put(
     urls.POLICY_WEBHOOKS_PRE,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[
         Security(verify_oauth_client, scopes=[scopes.WEBHOOK_CREATE_OR_UPDATE])
     ],
@@ -189,7 +181,7 @@ def create_or_update_pre_execution_webhooks(
 
 @router.put(
     urls.POLICY_WEBHOOKS_POST,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[
         Security(verify_oauth_client, scopes=[scopes.WEBHOOK_CREATE_OR_UPDATE])
     ],
@@ -239,7 +231,7 @@ def get_policy_webhook_or_error(
 
 @router.get(
     urls.POLICY_PRE_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.PolicyWebhookResponse,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_READ])],
 )
@@ -258,7 +250,7 @@ def get_policy_pre_execution_webhook(
 
 @router.get(
     urls.POLICY_POST_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=schemas.PolicyWebhookResponse,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_READ])],
 )
@@ -340,7 +332,7 @@ def _patch_webhook(
 
 @router.patch(
     urls.POLICY_PRE_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[
         Security(verify_oauth_client, scopes=[scopes.WEBHOOK_CREATE_OR_UPDATE])
     ],
@@ -368,7 +360,7 @@ def update_pre_execution_webhook(
 
 @router.patch(
     urls.POLICY_POST_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[
         Security(verify_oauth_client, scopes=[scopes.WEBHOOK_CREATE_OR_UPDATE])
     ],
@@ -434,7 +426,7 @@ def delete_webhook(
 
 @router.delete(
     urls.POLICY_PRE_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_DELETE])],
     response_model=schemas.PolicyWebhookDeleteResponse,
 )
@@ -455,7 +447,7 @@ def delete_pre_execution_webhook(
 
 @router.delete(
     urls.POLICY_POST_WEBHOOK_DETAIL,
-    status_code=200,
+    status_code=HTTP_200_OK,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_DELETE])],
     response_model=schemas.PolicyWebhookDeleteResponse,
 )

--- a/src/fidesops/api/v1/endpoints/saas_config_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/saas_config_endpoints.py
@@ -1,11 +1,14 @@
 import logging
-from fastapi import APIRouter, HTTPException, Depends
-from fastapi.params import Security
-from starlette.status import HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST
-from sqlalchemy.orm import Session
 
-from fidesops.models.datasetconfig import DatasetConfig
-from fidesops.schemas.shared_schemas import FidesOpsKey
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.params import Security
+from sqlalchemy.orm import Session
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
+)
 
 from fidesops.api import deps
 from fidesops.api.v1.scope_registry import (
@@ -13,20 +16,20 @@ from fidesops.api.v1.scope_registry import (
     SAAS_CONFIG_DELETE,
     SAAS_CONFIG_READ,
 )
-
 from fidesops.api.v1.urn_registry import (
     SAAS_CONFIG,
     SAAS_CONFIG_VALIDATE,
     V1_URL_PREFIX,
 )
 from fidesops.models.connectionconfig import ConnectionConfig, ConnectionType
+from fidesops.models.datasetconfig import DatasetConfig
 from fidesops.schemas.saas.saas_config import (
     SaaSConfig,
     SaaSConfigValidationDetails,
     ValidateSaaSConfigResponse,
 )
+from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.util.oauth_util import verify_oauth_client
-
 
 router = APIRouter(tags=["SaaS Configs"], prefix=V1_URL_PREFIX)
 logger = logging.getLogger(__name__)
@@ -53,7 +56,7 @@ def _get_saas_connection_config(
 @router.put(
     SAAS_CONFIG_VALIDATE,
     dependencies=[Security(verify_oauth_client, scopes=[SAAS_CONFIG_READ])],
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=ValidateSaaSConfigResponse,
 )
 def validate_saas_config(
@@ -80,7 +83,7 @@ def validate_saas_config(
 @router.patch(
     SAAS_CONFIG,
     dependencies=[Security(verify_oauth_client, scopes=[SAAS_CONFIG_CREATE_OR_UPDATE])],
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=SaaSConfig,
 )
 def patch_saas_config(
@@ -122,7 +125,7 @@ def get_saas_config(
 @router.delete(
     SAAS_CONFIG,
     dependencies=[Security(verify_oauth_client, scopes=[SAAS_CONFIG_DELETE])],
-    status_code=204,
+    status_code=HTTP_204_NO_CONTENT,
 )
 def delete_saas_config(
     db: Session = Depends(deps.get_db),

--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -1,24 +1,26 @@
 import logging
-from fastapi import Security, Depends, APIRouter, HTTPException
-from starlette.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_403_FORBIDDEN,
-)
 from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Security
+from sqlalchemy.orm import Session
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_404_NOT_FOUND,
+)
 
 from fidesops.api import deps
 from fidesops.api.v1 import urn_registry as urls
+from fidesops.api.v1.scope_registry import SCOPE_REGISTRY, USER_CREATE, USER_DELETE
 from fidesops.api.v1.urn_registry import V1_URL_PREFIX
-from fidesops.models.client import ClientDetail, ADMIN_UI_ROOT
+from fidesops.models.client import ADMIN_UI_ROOT, ClientDetail
 from fidesops.models.fidesops_user import FidesopsUser
 from fidesops.schemas.oauth import AccessToken
 from fidesops.schemas.user import UserCreate, UserCreateResponse, UserLogin
-
 from fidesops.util.oauth_util import verify_oauth_client
-from sqlalchemy.orm import Session
-
-from fidesops.api.v1.scope_registry import USER_CREATE, USER_DELETE, SCOPE_REGISTRY
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Users"], prefix=V1_URL_PREFIX)
@@ -44,7 +46,7 @@ def perform_login(db: Session, user: FidesopsUser) -> ClientDetail:
 @router.post(
     urls.USERS,
     dependencies=[Security(verify_oauth_client, scopes=[USER_CREATE])],
-    status_code=201,
+    status_code=HTTP_201_CREATED,
     response_model=UserCreateResponse,
 )
 def create_user(
@@ -65,7 +67,7 @@ def create_user(
 
 @router.delete(
     urls.USER_DETAIL,
-    status_code=204,
+    status_code=HTTP_204_NO_CONTENT,
 )
 def delete_user(
     *,
@@ -97,7 +99,7 @@ def delete_user(
 
 @router.post(
     urls.LOGIN,
-    status_code=200,
+    status_code=HTTP_200_OK,
     response_model=AccessToken,
 )
 def user_login(
@@ -125,7 +127,7 @@ def user_login(
 
 @router.post(
     urls.LOGOUT,
-    status_code=204,
+    status_code=HTTP_204_NO_CONTENT,
 )
 def user_logout(
     *,

--- a/src/fidesops/service/connectors/http_connector.py
+++ b/src/fidesops/service/connectors/http_connector.py
@@ -1,8 +1,9 @@
 import json
-
 import logging
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
+
 import requests
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 
 from fidesops.common_exceptions import ClientUnsuccessfulException
 from fidesops.graph.traversal import TraversalNode
@@ -10,7 +11,6 @@ from fidesops.models.connectionconfig import ConnectionTestStatus
 from fidesops.models.policy import Policy
 from fidesops.models.privacy_request import PrivacyRequest
 from fidesops.schemas.connection_configuration import HttpsSchema
-
 from fidesops.service.connectors.base_connector import BaseConnector
 from fidesops.service.connectors.query_config import QueryConfig
 from fidesops.util.collection_util import Row
@@ -50,7 +50,9 @@ class HTTPSConnector(BaseConnector[None]):
             response = requests.post(url=config.url, headers=headers, json=request_body)
         except requests.ConnectionError:
             logger.info("Requests connection error received.")
-            raise ClientUnsuccessfulException(status_code=500)
+            raise ClientUnsuccessfulException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         if not response_expected:
             return {}


### PR DESCRIPTION
# Purpose

Make the use of status codes consistent.

# Changes

- Change status code number (i.e. 200) to the starlette constants (i.e. HTTP_200_OK).

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #413
 
