### PR TITLE
add an issue request template for documentation [#431]

### DIFF
--- a/.github/ISSUE_TEMPLATE/fidesops_docs_request.md
+++ b/.github/ISSUE_TEMPLATE/fidesops_docs_request.md
@@ -1,0 +1,15 @@
+---
+name: Fidesops documentation request
+about: Change suggestions for the Fidesops docs
+title: ''
+labels: documentation
+
+---
+
+### Docs Update Description
+
+ _Describe what you'd like to see documented, and link the page if applicable_
+
+### Additional context
+
+_Add any other context about the problem here._


### PR DESCRIPTION
# Purpose

Add in a documentation issue template for docs requests/updates.

# Changes

- [x] Added in a docs-specific template to `.github/ISSUE_TEMPLATES`

# Checklist

- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #431 
 
