### PR TITLE
Adding missing import

### DIFF
--- a/src/fidesops/service/connectors/saas_connector.py
+++ b/src/fidesops/service/connectors/saas_connector.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import pydash
 from requests import Session, Request, PreparedRequest, Response
 from fidesops.common_exceptions import FidesopsException
+from fidesops.core.config import config
 from fidesops.service.pagination.pagination_strategy import PaginationStrategy
 from fidesops.schemas.saas.shared_schemas import SaaSRequestParams
 from fidesops.service.connectors.saas_query_config import SaaSQueryConfig

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -367,7 +367,9 @@ def test_create_and_process_erasure_request_saas(
 
     connector = SaaSConnector(mailchimp_connection_config)
     request: SaaSRequestParams = SaaSRequestParams(
-        method=HTTPMethod.GET, path="/3.0/search-members", query_params={"query": mailchimp_identity_email}
+        method=HTTPMethod.GET,
+        path="/3.0/search-members",
+        query_params={"query": mailchimp_identity_email},
     )
     resp = connector.create_client().send(request)
     body = resp.json()
@@ -376,11 +378,17 @@ def test_create_and_process_erasure_request_saas(
     masking_configuration = HmacMaskingConfiguration()
     masking_strategy = HmacMaskingStrategy(masking_configuration)
 
-    assert merge_fields["FNAME"] == masking_strategy.mask(
-        reset_mailchimp_data["merge_fields"]["FNAME"], pr.id
+    assert (
+        merge_fields["FNAME"]
+        == masking_strategy.mask(
+            [reset_mailchimp_data["merge_fields"]["FNAME"]], pr.id
+        )[0]
     )
-    assert merge_fields["LNAME"] == masking_strategy.mask(
-        reset_mailchimp_data["merge_fields"]["LNAME"], pr.id
+    assert (
+        merge_fields["LNAME"]
+        == masking_strategy.mask(
+            [reset_mailchimp_data["merge_fields"]["LNAME"]], pr.id
+        )[0]
     )
 
     pr.delete(db=db)
@@ -390,15 +398,15 @@ def test_create_and_process_erasure_request_saas(
 @pytest.mark.integration_hubspot
 @mock.patch("fidesops.models.privacy_request.PrivacyRequest.trigger_policy_webhook")
 def test_create_and_process_access_request_saas_hubspot(
-        trigger_webhook_mock,
-        connection_config_hubspot,
-        dataset_config_hubspot,
-        db,
-        cache,
-        policy,
-        policy_pre_execution_webhooks,
-        policy_post_execution_webhooks,
-        hubspot_identity_email,
+    trigger_webhook_mock,
+    connection_config_hubspot,
+    dataset_config_hubspot,
+    db,
+    cache,
+    policy,
+    policy_pre_execution_webhooks,
+    policy_post_execution_webhooks,
+    hubspot_identity_email,
 ):
     customer_email = hubspot_identity_email
     data = {


### PR DESCRIPTION
# Purpose
To fix linter issue on `main` where `fidesops.core.config` is missing from `saas_connector.py`

# Changes
- adding missing import

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
