### PR TITLE
Remove pypi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 _A part of the [greater Fides ecosystem](https://github.com/ethyca/fides)._
 
-[![Latest Version][pypi-image]][pypi-url]
 [![License][license-image]][license-url]
 [![Code style: black][black-image]][black-url]
 [![Checked with mypy][mypy-image]][mypy-url]
@@ -203,8 +202,6 @@ Fides tools are built on [Fideslang](https://github.com/ethyca/privacy-taxonomy)
 Fides is created and sponsored by [Ethyca](https://ethyca.com): a developer tools company building the trust infrastructure of the internet. If you have questions or need assistance getting started, let us know at fides@ethyca.com!
 
 
-[pypi-image]: https://img.shields.io/pypi/v/fidesctl.svg
-[pypi-url]: https://pypi.python.org/pypi/fidesctl/
 [license-image]: https://img.shields.io/:license-Apache%202-blue.svg
 [license-url]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [black-image]: https://img.shields.io/badge/code%20style-black-000000.svg


### PR DESCRIPTION
# Purpose
The current pypi badge points to fidesctl. Fidesops isn't on pypi so the badge should be removed. 

# Changes
- Remove pypi badge from readme


# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #451 
 
