### PR TITLE
update SaasConnector.send behavior on ignore_errors to return raw response

### DIFF
--- a/src/fidesops/service/connectors/saas_connector.py
+++ b/src/fidesops/service/connectors/saas_connector.py
@@ -256,7 +256,7 @@ class SaaSConnector(BaseConnector[AuthenticatedClient]):
         # replace errored response with empty dictionary if we are ignoring errors
         if saas_request.ignore_errors and not response.ok:
             logger.info(
-                f"Ignoring errored response with status code {response.status_code}."
+                f"Ignoring and clearing errored response with status code {response.status_code}."
             )
             response = Response()
             response._content = b"{}"  # pylint: disable=W0212

--- a/src/fidesops/service/connectors/saas_connector.py
+++ b/src/fidesops/service/connectors/saas_connector.py
@@ -251,27 +251,9 @@ class SaaSConnector(BaseConnector[AuthenticatedClient]):
         Returns processed data and request_params for next page of data if available.
         """
         client: AuthenticatedClient = self.create_client_from_request(saas_request)
-        response: Response = client.send(prepared_request, saas_request.ignore_errors)
-
-        # replace errored response with empty dictionary if we are ignoring errors
-        if saas_request.ignore_errors and not response.ok:
-            logger.info(
-                f"Ignoring and clearing errored response with status code {response.status_code}."
-            )
-            response = Response()
-            response._content = b"{}"  # pylint: disable=W0212
-
-        # unwrap response using data_path
-        try:
-            response_data = (
-                pydash.get(response.json(), saas_request.data_path)
-                if saas_request.data_path
-                else response.json()
-            )
-        except JSONDecodeError:
-            raise FidesopsException(
-                f"Unable to parse JSON response from {saas_request.path}"
-            )
+        response: Response = client.send(prepared_request, saas_request)
+        response = self._handle_errored_response(saas_request, response)
+        response_data = self._unwrap_response_data(saas_request, response)
 
         # process response and add to rows
         rows = self.process_response_data(
@@ -394,3 +376,35 @@ class SaaSConnector(BaseConnector[AuthenticatedClient]):
 
     def close(self) -> None:
         """Not required for this type"""
+
+    @staticmethod
+    def _handle_errored_response(
+        saas_request: SaaSRequest, response: Response
+    ) -> Response:
+        """
+        Checks if given Response is an error and if SaasRequest is configured to ignore errors.
+        If so, replaces given Response with empty dictionary.
+        """
+        if saas_request.ignore_errors and not response.ok:
+            logger.info(
+                f"Ignoring and clearing errored response with status code {response.status_code}."
+            )
+            response = Response()
+            response._content = b"{}"  # pylint: disable=W0212
+        return response
+
+    @staticmethod
+    def _unwrap_response_data(saas_request: SaaSRequest, response: Response) -> Any:
+        """
+        Unwrap given Response using data_path in the given SaasRequest
+        """
+        try:
+            return (
+                pydash.get(response.json(), saas_request.data_path)
+                if saas_request.data_path
+                else response.json()
+            )
+        except JSONDecodeError:
+            raise FidesopsException(
+                f"Unable to parse JSON response from {saas_request.path}"
+            )

--- a/tests/integration_tests/test_connection_configuration_integration.py
+++ b/tests/integration_tests/test_connection_configuration_integration.py
@@ -1,5 +1,3 @@
-from fidesops.core.config import config
-from fidesops.schemas.saas.saas_config import SaaSRequest
 from fidesops.service.connectors.saas_connector import AuthenticatedClient
 import pytest
 import json
@@ -1425,7 +1423,7 @@ class TestSaaSConnectionTestSecretsAPI:
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_mailchimp
-class TestSaasConnector:
+class TestSaasConnectorIntegration:
     def test_saas_connector(
         self, db: Session, mailchimp_connection_config, mailchimp_dataset_config
     ):
@@ -1441,32 +1439,3 @@ class TestSaasConnector:
         connector = get_connector(mailchimp_connection_config)
         with pytest.raises(ConnectionException):
             connector.test_connection()
-
-
-class TestSaaSConnectorMethods:
-    def test_create_client_from_request(
-        self, db: Session, segment_connection_config, segment_dataset_config
-    ):
-        connector: SaaSConnector = get_connector(segment_connection_config)
-        # Base ClientConfig uses bearer auth
-        assert (
-            connector.client_config.authentication.strategy == "bearer_authentication"
-        )
-
-        segment_user_endpoint = next(
-            end for end in connector.saas_config.endpoints if end.name == "segment_user"
-        )
-        saas_request: SaaSRequest = segment_user_endpoint.requests["read"]
-
-        client = connector.create_client_from_request(saas_request)
-        # ClientConfig on read segment user request uses basic auth, and we've overridden client config to match
-        assert connector.client_config.authentication.strategy == "basic_authentication"
-        assert client.client_config.authentication.strategy == "basic_authentication"
-
-        # Test request users bearer auth - creating the client from the request also updates the connector's auth.
-        test_request: SaaSRequest = connector.saas_config.test_request
-        client = connector.create_client_from_request(test_request)
-        assert (
-            connector.client_config.authentication.strategy == "bearer_authentication"
-        )
-        assert client.client_config.authentication.strategy == "bearer_authentication"

--- a/tests/service/connectors/test_saas_connector.py
+++ b/tests/service/connectors/test_saas_connector.py
@@ -1,12 +1,12 @@
-from typing import Dict, Any, Set, Optional
 from requests import Response
-from src.fidesops.schemas.saas.saas_config import SaaSConfig
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_200_OK
+from sqlalchemy.orm import Session
 import pytest
 import json
 
-from fidesops.util.data_category import DataCategory
+
 from fidesops.service.connectors.saas_connector import SaaSConnector
+from fidesops.service.connectors import get_connector
 from fidesops.schemas.saas.saas_config import SaaSRequest
 from fidesops.schemas.saas.shared_schemas import HTTPMethod
 
@@ -17,7 +17,10 @@ class TestSaasConnector:
     Unit tests on SaasConnector class functionality
     """
 
-    def test_handle_errored_response(self):
+    def test_handle_errored_response_ignore_errors(self):
+        """
+        Test that _handle_errored_response method correctly clears an errored response if `ignore_errors` is True
+        """
         fake_request: SaaSRequest = SaaSRequest(
             path="test/path", method=HTTPMethod.GET, ignore_errors=True
         )
@@ -29,9 +32,52 @@ class TestSaasConnector:
         cleaned_response = SaaSConnector._handle_errored_response(
             fake_request, fake_errored_response
         )
-        # if we're here, we've ensured an exception hasn't been raised
-        # we also want to assert response can be deserialized successfully to an empty dict
+
+        # assert response can be deserialized successfully to an empty dict
         assert {} == cleaned_response.json()
+
+    def test_handle_errored_response(self):
+        """
+        Test that _handle_errored_response method doesn't touch an errored response if `ignore_errors` is False.
+        """
+        fake_request: SaaSRequest = SaaSRequest(
+            path="test/path", method=HTTPMethod.GET, ignore_errors=False
+        )
+        fake_errored_response: Response = Response()
+        fake_errored_response.status_code = HTTP_404_NOT_FOUND  # some errored status
+        fake_errored_response._content = (
+            b"an ugly plaintext error message"  # some bad error message
+        )
+
+        # if we're not ignoring errors, response should be untouched
+        # and we should get an error trying to deserialize response body
+        with pytest.raises(json.JSONDecodeError):
+            cleaned_response = SaaSConnector._handle_errored_response(
+                fake_request, fake_errored_response
+            )
+            cleaned_response.json()
+
+    def test_handle_errored_response_good_response(self):
+        """
+        Test that _handle_errored_response method doesn't touch a good (non-errored) response.
+        """
+        fake_request: SaaSRequest = SaaSRequest(
+            path="test/path", method=HTTPMethod.GET, ignore_errors=True
+        )
+        nested_field_key = "nested_field"
+        response_body = {
+            "flat_field": "foo",
+            nested_field_key: {"nested_field1": "nested_value1"},
+            "array_field": ["array_value1", "array_value2"],
+        }
+        fake_errored_response: Response = Response()
+        fake_errored_response.status_code = HTTP_200_OK
+        fake_errored_response._content = str.encode(json.dumps(response_body))
+
+        cleaned_response = SaaSConnector._handle_errored_response(
+            fake_request, fake_errored_response
+        )
+        assert response_body == cleaned_response.json()
 
     def test_unwrap_response_data_with_data_path(self):
         nested_field_key = "nested_field"
@@ -70,3 +116,33 @@ class TestSaasConnector:
 
         unwrapped = SaaSConnector._unwrap_response_data(fake_request, fake_response)
         assert response_body == unwrapped
+
+
+@pytest.mark.unit_saas
+class TestSaaSConnectorMethods:
+    def test_create_client_from_request(
+        self, db: Session, segment_connection_config, segment_dataset_config
+    ):
+        connector: SaaSConnector = get_connector(segment_connection_config)
+        # Base ClientConfig uses bearer auth
+        assert (
+            connector.client_config.authentication.strategy == "bearer_authentication"
+        )
+
+        segment_user_endpoint = next(
+            end for end in connector.saas_config.endpoints if end.name == "segment_user"
+        )
+        saas_request: SaaSRequest = segment_user_endpoint.requests["read"]
+
+        client = connector.create_client_from_request(saas_request)
+        # ClientConfig on read segment user request uses basic auth, and we've overridden client config to match
+        assert connector.client_config.authentication.strategy == "basic_authentication"
+        assert client.client_config.authentication.strategy == "basic_authentication"
+
+        # Test request users bearer auth - creating the client from the request also updates the connector's auth.
+        test_request: SaaSRequest = connector.saas_config.test_request
+        client = connector.create_client_from_request(test_request)
+        assert (
+            connector.client_config.authentication.strategy == "bearer_authentication"
+        )
+        assert client.client_config.authentication.strategy == "bearer_authentication"

--- a/tests/service/connectors/test_saas_connector.py
+++ b/tests/service/connectors/test_saas_connector.py
@@ -1,0 +1,72 @@
+from typing import Dict, Any, Set, Optional
+from requests import Response
+from src.fidesops.schemas.saas.saas_config import SaaSConfig
+from starlette.status import HTTP_404_NOT_FOUND, HTTP_200_OK
+import pytest
+import json
+
+from fidesops.util.data_category import DataCategory
+from fidesops.service.connectors.saas_connector import SaaSConnector
+from fidesops.schemas.saas.saas_config import SaaSRequest
+from fidesops.schemas.saas.shared_schemas import HTTPMethod
+
+
+@pytest.mark.unit_saas
+class TestSaasConnector:
+    """
+    Unit tests on SaasConnector class functionality
+    """
+
+    def test_handle_errored_response(self):
+        fake_request: SaaSRequest = SaaSRequest(
+            path="test/path", method=HTTPMethod.GET, ignore_errors=True
+        )
+        fake_errored_response: Response = Response()
+        fake_errored_response.status_code = HTTP_404_NOT_FOUND  # some errored status
+        fake_errored_response._content = (
+            "an ugly plaintext error message"  # some bad error message
+        )
+        cleaned_response = SaaSConnector._handle_errored_response(
+            fake_request, fake_errored_response
+        )
+        # if we're here, we've ensured an exception hasn't been raised
+        # we also want to assert response can be deserialized successfully to an empty dict
+        assert {} == cleaned_response.json()
+
+    def test_unwrap_response_data_with_data_path(self):
+        nested_field_key = "nested_field"
+        fake_request: SaaSRequest = SaaSRequest(
+            path="test/path",
+            method=HTTPMethod.GET,
+            ignore_errors=True,
+            data_path=nested_field_key,
+        )
+
+        response_body = {
+            "flat_field": "foo",
+            nested_field_key: {"nested_field1": "nested_value1"},
+            "array_field": ["array_value1", "array_value2"],
+        }
+        fake_response: Response = Response()
+        fake_response.status_code = HTTP_200_OK
+        fake_response._content = str.encode(json.dumps(response_body))
+
+        unwrapped = SaaSConnector._unwrap_response_data(fake_request, fake_response)
+        assert response_body[nested_field_key] == unwrapped
+
+    def test_unwrap_response_data_no_data_path(self):
+        fake_request: SaaSRequest = SaaSRequest(
+            path="test/path", method=HTTPMethod.GET, ignore_errors=True
+        )
+        nested_field_key = "nested_field"
+        response_body = {
+            "flat_field": "foo",
+            nested_field_key: {"nested_field1": "nested_value1"},
+            "array_field": ["array_value1", "array_value2"],
+        }
+        fake_response: Response = Response()
+        fake_response.status_code = HTTP_200_OK
+        fake_response._content = str.encode(json.dumps(response_body))
+
+        unwrapped = SaaSConnector._unwrap_response_data(fake_request, fake_response)
+        assert response_body == unwrapped


### PR DESCRIPTION
# Purpose
Fix for https://github.com/ethyca/fidesops/issues/457, allows more flexibility in how `SaasConnector.send` can be used

Verified locally that sentry access request test is still passing, which relied on the original `ignore_errors` functionality (https://github.com/ethyca/fidesops/issues/307)
# Changes
-move the conversion of errored request further up the stack

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes https://github.com/ethyca/fidesops/issues/457
 
