### PR TITLE
Seed super user permissions

### DIFF
--- a/create_superuser.py
+++ b/create_superuser.py
@@ -10,6 +10,7 @@ from fidesops.db.database import init_db
 from fidesops.db.session import get_db_session
 from fidesops.models.client import ClientDetail, ADMIN_UI_ROOT
 from fidesops.models.fidesops_user import FidesopsUser
+from fidesops.models.fidesops_user_permissions import FidesopsUserPermissions
 from fidesops.schemas.user import UserCreate
 
 
@@ -60,6 +61,10 @@ def create_user_and_client(db: Session) -> FidesopsUser:
 
     ClientDetail.create_client_and_secret(
         db, scopes, fides_key=ADMIN_UI_ROOT, user_id=superuser.id
+    )
+
+    FidesopsUserPermissions.create(
+        db=db, data={"user_id": superuser.id, "scopes": scopes}
     )
     print(f"Superuser '{user_data.username}' created successfully!")
     return superuser

--- a/tests/scripts/test_create_superuser.py
+++ b/tests/scripts/test_create_superuser.py
@@ -8,6 +8,7 @@ from create_superuser import (
 from fidesops.common_exceptions import KeyOrNameAlreadyExists
 from fidesops.models.client import ClientDetail, ADMIN_UI_ROOT
 from fidesops.models.fidesops_user import FidesopsUser
+from fidesops.models.fidesops_user_permissions import FidesopsUserPermissions
 from fidesops.schemas.user import UserCreate
 from fidesops.api.v1.scope_registry import CLIENT_CREATE
 
@@ -63,6 +64,9 @@ class TestCreateSuperuserScript:
         assert superuser.client == client_detail
         assert client_detail.fides_key == ADMIN_UI_ROOT
         assert CLIENT_CREATE not in client_detail.scopes
+
+        user_permissions = FidesopsUserPermissions.get_by(db=db, field="user_id", value=superuser.id)
+        assert user_permissions is not None
 
         with pytest.raises(KeyOrNameAlreadyExists):
             create_user_and_client(db)


### PR DESCRIPTION
# Purpose
The current version of the `create_superuser.py` script doesn't seed the new `FidesopsUserPermissions` table. 

# Changes
- Update `create_user_and_client` function to seed the `FidesopsUserPermissions` record.

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #467 
 
