### PR TITLE
[#382] Update User API Endpoints

### DIFF
--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -156,7 +156,7 @@ def update_user_password(
 
     if not current_user.credentials_valid(data.old_password):
         raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN, detail="Incorrect password."
+            status_code=HTTP_401_UNAUTHORIZED, detail="Incorrect password."
         )
 
     current_user.update_password(db=db, new_password=data.new_password)

--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -97,7 +97,7 @@ def create_user(
     return user
 
 
-def _validate_current_user(user_id: str, user_from_token: FidesopsUser) -> bool:
+def _validate_current_user(user_id: str, user_from_token: FidesopsUser) -> None:
     if not user_from_token:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,
@@ -109,7 +109,6 @@ def _validate_current_user(user_id: str, user_from_token: FidesopsUser) -> bool:
             status_code=HTTP_401_UNAUTHORIZED,
             detail=f"You are only authorised to update your own user data.",
         )
-    return True
 
 
 @router.put(

--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -96,7 +96,7 @@ def create_user(
     return user
 
 
-def _validate_current_user(user_id, user_from_token):
+def _validate_current_user(user_id: str, user_from_token: FidesopsUser) -> bool:
     if not user_from_token:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,

--- a/src/fidesops/api/v1/scope_registry.py
+++ b/src/fidesops/api/v1/scope_registry.py
@@ -45,6 +45,7 @@ SAAS_CONFIG_READ = "saas_config:read"
 SAAS_CONFIG_DELETE = "saas_config:delete"
 
 USER_CREATE = "user:create"
+USER_UPDATE = "user:update"
 USER_READ = "user:read"
 USER_DELETE = "user:delete"
 
@@ -86,6 +87,7 @@ SCOPE_REGISTRY = [
     SAAS_CONFIG_READ,
     SAAS_CONFIG_DELETE,
     USER_CREATE,
+    USER_UPDATE,
     USER_READ,
     USER_DELETE,
     USER_PERMISSION_CREATE,

--- a/src/fidesops/api/v1/scope_registry.py
+++ b/src/fidesops/api/v1/scope_registry.py
@@ -1,3 +1,6 @@
+from fidesops.api.v1.urn_registry import USER_PASSWORD_RESET
+
+
 CLIENT_CREATE = "client:create"
 CLIENT_UPDATE = "client:update"
 CLIENT_READ = "client:read"
@@ -48,6 +51,7 @@ USER_CREATE = "user:create"
 USER_UPDATE = "user:update"
 USER_READ = "user:read"
 USER_DELETE = "user:delete"
+USER_PASSWORD_RESET = "user:reset-password"
 
 USER_PERMISSION_CREATE = "user-permission:create"
 USER_PERMISSION_UPDATE = "user-permission:update"
@@ -89,6 +93,7 @@ SCOPE_REGISTRY = [
     USER_CREATE,
     USER_UPDATE,
     USER_READ,
+    USER_PASSWORD_RESET,
     USER_DELETE,
     USER_PERMISSION_CREATE,
     USER_PERMISSION_UPDATE,

--- a/src/fidesops/api/v1/scope_registry.py
+++ b/src/fidesops/api/v1/scope_registry.py
@@ -1,6 +1,3 @@
-from fidesops.api.v1.urn_registry import USER_PASSWORD_RESET
-
-
 CLIENT_CREATE = "client:create"
 CLIENT_UPDATE = "client:update"
 CLIENT_READ = "client:read"

--- a/src/fidesops/api/v1/urn_registry.py
+++ b/src/fidesops/api/v1/urn_registry.py
@@ -76,6 +76,7 @@ SAAS_CONFIG = CONNECTION_BY_KEY + "/saas_config"
 # User URLs
 USERS = "/user"
 USER_DETAIL = "/user/{user_id}"
+USER_PASSWORD_RESET = "/user/{user_id}/reset-password"
 
 # User Permission URLs
 USER_PERMISSIONS = "/user/{user_id}/permission"

--- a/src/fidesops/db/base_class.py
+++ b/src/fidesops/db/base_class.py
@@ -234,6 +234,10 @@ class OrmWrappedFidesopsBase(FidesopsBase):
         deleted_count = db.query(cls).delete()
         return deleted_count
 
+    def refresh_from_db(self, db: Session) -> FidesopsBase:
+        """Returns a current version of this object from the database"""
+        return db.query(self.__class__).get(self.id)
+
     def update(self, db: Session, *, data: Dict[str, Any]):
         """Update specific row with supplied values"""
         # Set self.key where applicable

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -6,13 +6,18 @@ from pydantic import validator
 from fidesops.schemas.base_class import BaseSchema
 
 
-class UserCreate(BaseSchema):
+class UserUpdate(BaseSchema):
+    """Data required to update a FidesopsUser"""
+
+    first_name: Optional[str]
+    last_name: Optional[str]
+
+
+class UserCreate(UserUpdate):
     """Data required to create a FidesopsUser"""
 
     username: str
     password: str
-    first_name: Optional[str]
-    last_name: Optional[str]
 
     @validator("username")
     def validate_username(cls, username: str) -> str:

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -52,6 +52,13 @@ class UserLogin(BaseSchema):
     password: str
 
 
+class UserPasswordReset(BaseSchema):
+    """Contains both old and new passwords when resetting a password"""
+
+    old_password: str
+    new_password: str
+
+
 class UserResponse(BaseSchema):
     """Response after requesting a User"""
 

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -32,6 +32,7 @@ from fidesops.api.v1.scope_registry import (
     USER_READ,
     USER_UPDATE,
     USER_DELETE,
+    USER_PASSWORD_RESET,
     SCOPE_REGISTRY,
     PRIVACY_REQUEST_READ,
 )
@@ -504,11 +505,13 @@ class TestUpdateUser:
                 "last_name": NEW_LAST_NAME,
             },
         )
-        assert resp.status_code == HTTP_401_UNAUTHORIZED
-        assert (
-            resp.json()["detail"]
-            == "You are only authorised to update your own user data."
-        )
+        assert resp.status_code == HTTP_200_OK
+        user_data = resp.json()
+        assert user_data["username"] == user.username
+        assert user_data["id"] == user.id
+        assert user_data["created_at"] == user.created_at.isoformat()
+        assert user_data["first_name"] == NEW_FIRST_NAME
+        assert user_data["last_name"] == NEW_LAST_NAME
 
     def test_update_user_names(
         self,
@@ -559,7 +562,7 @@ class TestUpdateUserPassword:
 
         auth_header = generate_auth_header_for_user(
             user=application_user,
-            scopes=[USER_UPDATE],
+            scopes=[USER_PASSWORD_RESET],
         )
         resp = api_client.post(
             f"{url_no_id}/{user.id}/reset-password",
@@ -592,7 +595,7 @@ class TestUpdateUserPassword:
 
         auth_header = generate_auth_header_for_user(
             user=application_user,
-            scopes=[USER_UPDATE],
+            scopes=[USER_PASSWORD_RESET],
         )
         resp = api_client.post(
             f"{url_no_id}/{application_user.id}/reset-password",
@@ -622,7 +625,7 @@ class TestUpdateUserPassword:
 
         auth_header = generate_auth_header_for_user(
             user=application_user,
-            scopes=[USER_UPDATE],
+            scopes=[USER_PASSWORD_RESET],
         )
         resp = api_client.post(
             f"{url_no_id}/{application_user.id}/reset-password",

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -485,6 +485,34 @@ class TestUpdateUser:
     def url_no_id(self) -> str:
         return V1_URL_PREFIX + USERS
 
+    def test_update_different_users_names(
+        self,
+        api_client,
+        url_no_id,
+        user,
+        application_user,
+    ) -> None:
+        NEW_FIRST_NAME = "another"
+        NEW_LAST_NAME = "name"
+
+        auth_header = generate_auth_header_for_user(
+            user=application_user,
+            scopes=[USER_UPDATE],
+        )
+        resp = api_client.put(
+            f"{url_no_id}/{user.id}",
+            headers=auth_header,
+            json={
+                "first_name": NEW_FIRST_NAME,
+                "last_name": NEW_LAST_NAME,
+            },
+        )
+        assert resp.status_code == HTTP_401_UNAUTHORIZED
+        assert (
+            resp.json()["detail"]
+            == "You are only authorised to update your own user data."
+        )
+
     def test_update_user_names(
         self,
         api_client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,8 +115,22 @@ def oauth_client(db: Session) -> Generator:
     client.delete(db)
 
 
+def generate_auth_header_for_user(user, scopes):
+    payload = {
+        JWE_PAYLOAD_SCOPES: scopes,
+        JWE_PAYLOAD_CLIENT_ID: user.client.id,
+        JWE_ISSUED_AT: datetime.now().isoformat(),
+    }
+    jwe = generate_jwe(json.dumps(payload))
+    return {"Authorization": "Bearer " + jwe}
+
+
 @pytest.fixture(scope="function")
 def generate_auth_header(oauth_client):
+    return _generate_auth_header(oauth_client)
+
+
+def _generate_auth_header(oauth_client):
     client_id = oauth_client.id
 
     def _build_jwt(scopes: List[str]):

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -932,7 +932,10 @@ def sample_data():
 
 
 @pytest.fixture(scope="function")
-def application_user(db) -> FidesopsUser:
+def application_user(
+    db,
+    oauth_client,
+) -> FidesopsUser:
     unique_username = f"user-{uuid4()}"
     user = FidesopsUser.create(
         db=db,
@@ -943,5 +946,7 @@ def application_user(db) -> FidesopsUser:
             "last_name": "User",
         },
     )
+    oauth_client.user_id = user.id
+    oauth_client.save(db=db)
     yield user
     user.delete(db=db)


### PR DESCRIPTION
# Purpose

This PR adds an API endpoints to:
- update fields on the user model
- reset users passwords

# Changes

- `/api/v1/user/{user_id}` — updates the currently logged-in user's first and last names.

```
{
  "first_name": "...",
  "last_name": "..."
}
```

- `/api/v1/user/{user_id}/reset-password` — updates the currently logged-in user's password if `old_password` matches the user's current password at the time of the update.

```
{
  "old_password": "...",
  "new_password": "..."
}
```

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
