### PR TITLE
fix auditlog refs

### DIFF
--- a/src/fidesops/models/fidesops_user.py
+++ b/src/fidesops/models/fidesops_user.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, relationship
 
 from fidesops.core.config import config
 from fidesops.db.base_class import Base
+from fidesops.models.audit_log import AuditLog
 from fidesops.util.cryptographic_util import generate_salt, hash_with_salt
 
 
@@ -19,6 +20,16 @@ class FidesopsUser(Base):
     salt = Column(String, nullable=False)
     last_login_at = Column(DateTime(timezone=True), nullable=True)
     password_reset_at = Column(DateTime(timezone=True), nullable=True)
+
+    # passive_deletes="all" prevents audit logs from having their privacy_request_id set to null when
+    # a privacy_request is deleted.  We want to retain for record-keeping.
+    audit_logs = relationship(
+        AuditLog,
+        backref="fidesops_user",
+        lazy="dynamic",
+        passive_deletes="all",
+        primaryjoin="foreign(AuditLog.user_id)==FidesopsUser.id",
+    )
 
     client = relationship(
         "ClientDetail", backref="user", cascade="all, delete", uselist=False

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -25,6 +25,7 @@ from fidesops.db.base_class import (
     Base,
     FidesopsBase,
 )
+from fidesops.models.audit_log import AuditLog
 from fidesops.models.client import ClientDetail
 from fidesops.models.fidesops_user import FidesopsUser
 from fidesops.models.policy import (
@@ -134,7 +135,7 @@ class PrivacyRequest(Base):
     # passive_deletes="all" prevents audit logs from having their privacy_request_id set to null when
     # a privacy_request is deleted.  We want to retain for record-keeping.
     audit_logs = relationship(
-        "AuditLog",
+        AuditLog,
         backref="privacy_request",
         lazy="dynamic",
         passive_deletes="all",


### PR DESCRIPTION
```
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from fidesops.db.session import get_db_session
In [2]: from fidesops.models.privacy_request import PrivacyRequest
In [3]: db = get_db_session()()
In [4]: PrivacyRequest.all(db)
```

The above results in the following error:

```
NameError: name 'AuditLog' is not defined
...
InvalidRequestError: When initializing mapper mapped class PrivacyRequest->privacyrequest, expression 'foreign(AuditLog.privacy_request_id)==PrivacyRequest.id' failed to locate a name ("name 'AuditLog' is not defined"). If this is a class name, consider adding this relationship() to the <class 'fidesops.models.privacy_request.PrivacyRequest'> class after both dependent classes have been defined.
```

because we're referring to `AuditLog` on the `PrivacyRequest` model via `"AuditLog"`, which requires the class to be present in local scope, instead of using the imported class.

This PR also adds `FidesopsUser.audit_logs` to link `FidesopsUser` instances in the same way as `PrivacyRequest`s.