### PR TITLE
[#417] DRP status endpoint

### DIFF
--- a/src/fidesops/api/v1/urn_registry.py
+++ b/src/fidesops/api/v1/urn_registry.py
@@ -37,6 +37,7 @@ PRIVACY_REQUEST_DENY = "/privacy-request/administrate/deny"
 REQUEST_STATUS_LOGS = "/privacy-request/{privacy_request_id}/log"
 PRIVACY_REQUEST_RESUME = "/privacy-request/{privacy_request_id}/resume"
 REQUEST_PREVIEW = "/privacy-request/preview"
+REQUEST_STATUS_DRP = "/privacy-request/{privacy_request_id}/drp"
 
 # Rule URLs
 RULE_LIST = "/policy/{policy_key}/rule"

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -18,7 +18,7 @@ from fidesops.util.encryption.aes_gcm_encryption_scheme import verify_encryption
 
 
 class PrivacyRequestDRPStatus(EnumType):
-    """"""
+    """A list of privacy request statuses specified by the Data Rights Protocol."""
 
     open = "open"
     in_progress = "in_progress"
@@ -29,7 +29,7 @@ class PrivacyRequestDRPStatus(EnumType):
 
 
 class PrivacyRequestDRPStatusResponse(BaseSchema):
-    """"""
+    """A Fidesops PrivacyRequest updated to fit the Data Rights Protocol specification."""
 
     request_id: str
     received_at: datetime

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from enum import Enum as EnumType
+from optparse import Option
 from typing import List, Optional, Dict
 
 from pydantic import Field, validator
@@ -13,6 +15,29 @@ from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.schemas.user import PrivacyRequestReviewer
 from fidesops.models.privacy_request import PrivacyRequestStatus, ExecutionLogStatus
 from fidesops.util.encryption.aes_gcm_encryption_scheme import verify_encryption_key
+
+
+class PrivacyRequestDRPStatus(EnumType):
+    """"""
+
+    open = "open"
+    in_progress = "in_progress"
+    fulfilled = "fulfilled"
+    revoked = "revoked"
+    denied = "denied"
+    expired = "expired"
+
+
+class PrivacyRequestDRPStatusResponse(BaseSchema):
+    """"""
+
+    request_id: str
+    received_at: datetime
+    expected_by: Optional[datetime]
+    processing_details: Optional[str]
+    status: PrivacyRequestDRPStatus
+    reason: Optional[str]
+    user_verification_url: Optional[str]
 
 
 class PrivacyRequestCreate(BaseSchema):

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -39,6 +39,12 @@ class PrivacyRequestDRPStatusResponse(BaseSchema):
     reason: Optional[str]
     user_verification_url: Optional[str]
 
+    class Config:
+        """Set orm_mode and use_enum_values"""
+
+        orm_mode = True
+        use_enum_values = True
+
 
 class PrivacyRequestCreate(BaseSchema):
     """Data required to create a PrivacyRequest"""

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from enum import Enum as EnumType
-from optparse import Option
 from typing import List, Optional, Dict
 
 from pydantic import Field, validator

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -515,9 +515,9 @@ def policy(
 
 @pytest.fixture(scope="function")
 def policy_drp_action(
-        db: Session,
-        oauth_client: ClientDetail,
-        storage_config: StorageConfig,
+    db: Session,
+    oauth_client: ClientDetail,
+    storage_config: StorageConfig,
 ) -> Generator:
     access_request_policy = Policy.create(
         db=db,
@@ -692,9 +692,11 @@ def privacy_requests(db: Session, policy: Policy) -> Generator:
         pr.delete(db)
 
 
-@pytest.fixture(scope="function")
-def privacy_request(db: Session, policy: Policy) -> PrivacyRequest:
-    privacy_request = PrivacyRequest.create(
+def _create_privacy_request_for_policy(
+    db: Session,
+    policy: Policy,
+) -> PrivacyRequest:
+    return PrivacyRequest.create(
         db=db,
         data={
             "external_id": f"ext-{str(uuid4())}",
@@ -723,6 +725,23 @@ def privacy_request(db: Session, policy: Policy) -> PrivacyRequest:
             "policy_id": policy.id,
             "client_id": policy.client_id,
         },
+    )
+
+
+@pytest.fixture(scope="function")
+def privacy_request(db: Session, policy: Policy) -> PrivacyRequest:
+    privacy_request = _create_privacy_request_for_policy(db, policy)
+    yield privacy_request
+    privacy_request.delete(db)
+
+
+@pytest.fixture(scope="function")
+def privacy_request_with_drp_action(
+    db: Session, policy_drp_action: Policy
+) -> PrivacyRequest:
+    privacy_request = _create_privacy_request_for_policy(
+        db,
+        policy_drp_action,
     )
     yield privacy_request
     privacy_request.delete(db)


### PR DESCRIPTION
# Purpose

This PR adds an endpoint to:
- return a privacy request's data in the specified DRP format
- if and only if the privacy request corresponding to the given ID has been assigned to a Policy with an associated DRP action

# Changes

- Adds a mapping between our own `PrivacyRequestStatus` and the DRP spec `PrivacyRequestDRPStatus`
- Maps `PrivacyRequest.requested_at` to `PrivacyRequestDRPStatusResponse.received_at`
- Maps `PrivacyRequest.id` to `PrivacyRequestDRPStatusResponse.request_id`

NB. This PR does not contain docs for DRP as we've agreed to waylay those to expedite testing.

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #417 
 
