### PR TITLE
[Misc] Adds a script to seed initial privacy requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,15 @@ docs-serve: docs-build
 
 
 ####################
-# User Creation
+# Test Data Creation
 ####################
 
 user:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
 		python run_infrastructure.py --datastores postgres --run_create_superuser
+
+test-data:
+	@virtualenv -p python3 fidesops_test_dispatch; \
+		source fidesops_test_dispatch/bin/activate; \
+		python run_infrastructure.py --datastores postgres --run_create_test_data

--- a/create_test_data.py
+++ b/create_test_data.py
@@ -11,6 +11,12 @@ from fidesops.models.client import ClientDetail
 from fidesops.models.fidesops_user import FidesopsUser
 from fidesops.models.policy import ActionType, Policy, Rule, RuleTarget
 from fidesops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
+from fidesops.models.storage import StorageConfig, ResponseFormat
+from fidesops.schemas.storage.storage import (
+    FileNaming,
+    StorageDetails,
+    StorageType,
+)
 from fidesops.util.data_category import DataCategory
 
 
@@ -21,21 +27,29 @@ def _create_policy(
     db: orm.Session,
     action_type: str,
     client_id: str,
+    policy_key: str,
 ) -> Policy:
-    rand = string.ascii_lowercase[:5]
-    policy = Policy.create(
+    """
+    Util method to create policies
+    """
+    created, policy = Policy.get_or_create(
         db=db,
         data={
-            "name": f"example {action_type} policy {rand}",
-            "key": f"example_{action_type}_policy_{rand}",
+            "name": policy_key,
+            "key": policy_key,
             "client_id": client_id,
         },
     )
 
-    rule = Rule.create(
-        db=db,
-        data={
-            "action_type": ActionType.erasure.value,
+    if not created:
+        # If the Policy is already created, don't create it again
+        return policy
+
+    rand = string.ascii_lowercase[:5]
+    data = {}
+    if action_type == ActionType.erasure.value:
+        data = {
+            "action_type": action_type,
             "name": f"{action_type} Rule {rand}",
             "policy_id": policy.id,
             "masking_strategy": {
@@ -43,7 +57,32 @@ def _create_policy(
                 "configuration": {},
             },
             "client_id": client_id,
-        },
+        }
+    elif action_type == ActionType.access.value:
+        _, storage_config = StorageConfig.get_or_create(
+            db=db,
+            data={
+                "name": "test storage config",
+                "type": StorageType.s3,
+                "details": {
+                    StorageDetails.NAMING.value: FileNaming.request_id.value,
+                    StorageDetails.BUCKET.value: "test_bucket",
+                },
+                "key": f"storage_config_for_{policy_key}",
+                "format": ResponseFormat.json,
+            },
+        )
+        data = {
+            "action_type": action_type,
+            "name": f"{action_type} Rule {rand}",
+            "policy_id": policy.id,
+            "storage_destination_id": storage_config.id,
+            "client_id": client_id,
+        }
+
+    rule = Rule.create(
+        db=db,
+        data=data,
     )
 
     RuleTarget.create(
@@ -60,7 +99,7 @@ def _create_policy(
 def create_test_data(db: orm.Session) -> FidesopsUser:
     """Script to create test data for the Admin UI"""
     print(f"Seeding database with privacy requests")
-    client = ClientDetail.create(
+    _, client = ClientDetail.get_or_create(
         db=db,
         data={
             "fides_key": "ci_create_test_data",
@@ -70,9 +109,25 @@ def create_test_data(db: orm.Session) -> FidesopsUser:
         },
     )
 
-    for action in ActionType.__members__.values():
-        policy = _create_policy(db, action.value, client.id)
+    policies = []
+    policies.append(
+        _create_policy(
+            db=db,
+            action_type=ActionType.erasure.value,
+            client_id=client.id,
+            policy_key="delete",
+        )
+    )
+    policies.append(
+        _create_policy(
+            db=db,
+            action_type=ActionType.access.value,
+            client_id=client.id,
+            policy_key="download",
+        )
+    )
 
+    for policy in policies:
         for status in PrivacyRequestStatus.__members__.values():
             PrivacyRequest.create(
                 db=db,

--- a/create_test_data.py
+++ b/create_test_data.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import orm
+import string
+
+from fidesops.core.config import config
+from fidesops.db.database import init_db
+from fidesops.db.session import get_db_session
+from fidesops.models.client import ClientDetail
+from fidesops.models.fidesops_user import FidesopsUser
+from fidesops.models.policy import ActionType, Policy, Rule, RuleTarget
+from fidesops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
+from fidesops.util.data_category import DataCategory
+
+
+"""Script to create test data for the Admin UI"""
+
+
+def _create_policy(
+    db: orm.Session,
+    action_type: str,
+    client_id: str,
+) -> Policy:
+    rand = string.ascii_lowercase[:5]
+    policy = Policy.create(
+        db=db,
+        data={
+            "name": f"example {action_type} policy {rand}",
+            "key": f"example_{action_type}_policy_{rand}",
+            "client_id": client_id,
+        },
+    )
+
+    rule = Rule.create(
+        db=db,
+        data={
+            "action_type": ActionType.erasure.value,
+            "name": f"{action_type} Rule {rand}",
+            "policy_id": policy.id,
+            "masking_strategy": {
+                "strategy": "null_rewrite",
+                "configuration": {},
+            },
+            "client_id": client_id,
+        },
+    )
+
+    RuleTarget.create(
+        db=db,
+        data={
+            "data_category": DataCategory("user.provided.identifiable.name").value,
+            "rule_id": rule.id,
+            "client_id": client_id,
+        },
+    )
+    return policy
+
+
+def create_test_data(db: orm.Session) -> FidesopsUser:
+    """Script to create test data for the Admin UI"""
+    print(f"Seeding database with privacy requests")
+    client = ClientDetail.create(
+        db=db,
+        data={
+            "fides_key": "ci_create_test_data",
+            "hashed_secret": "autoseededdata",
+            "salt": "autoseededdata",
+            "scopes": [],
+        },
+    )
+
+    for action in ActionType.__members__.values():
+        policy = _create_policy(db, action.value, client.id)
+
+        for status in PrivacyRequestStatus.__members__.values():
+            PrivacyRequest.create(
+                db=db,
+                data={
+                    "external_id": f"ext-{uuid4()}",
+                    "started_processing_at": datetime.utcnow(),
+                    "requested_at": datetime.utcnow() - timedelta(days=1),
+                    "status": status,
+                    "origin": f"https://example.com/{status.value}/",
+                    "policy_id": policy.id,
+                    "client_id": policy.client_id,
+                },
+            )
+
+    print(f"Data seeding complete!")
+
+
+if __name__ == "__main__":
+    init_db(config.database.SQLALCHEMY_DATABASE_URI)
+    session_local = get_db_session()
+    with session_local() as session:
+        create_test_data(session)

--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -35,6 +35,7 @@ def run_infrastructure(
     run_quickstart: bool = False,  # Should we run the quickstart command?
     run_tests: bool = False,  # Should we run the tests after creating the infra?
     run_create_superuser: bool = False,  # Should we run the create_superuser command?
+    run_create_test_data: bool = False,  # Should we run the create_test_data command?
 ) -> None:
     """
     - Create a Docker Compose file path for all datastores specified in `datastores`.
@@ -94,6 +95,9 @@ def run_infrastructure(
 
     elif run_create_superuser:
         return _run_create_superuser(path, IMAGE_NAME)
+
+    elif run_create_test_data:
+        return _run_create_test_data(path, IMAGE_NAME)
 
 
 def seed_initial_data(
@@ -164,6 +168,18 @@ def _run_create_superuser(
     _run_cmd_or_err(f'echo "Running create superuser..."')
     _run_cmd_or_err(f"docker-compose {path} up -d")
     _run_cmd_or_err(f"docker exec -it {image_name} python create_superuser.py")
+
+
+def _run_create_test_data(
+    path: str,
+    image_name: str,
+) -> None:
+    """
+    Invokes the Fidesops create_user_and_client command
+    """
+    _run_cmd_or_err(f'echo "Running create superuser..."')
+    _run_cmd_or_err(f"docker-compose {path} up -d")
+    _run_cmd_or_err(f"docker exec -it {image_name} python create_test_data.py")
 
 
 def _open_shell(
@@ -274,6 +290,12 @@ if __name__ == "__main__":
         action="store_true",
     )
 
+    parser.add_argument(
+        "-td",
+        "--run_create_test_data",
+        action="store_true",
+    )
+
     config_args = parser.parse_args()
 
     run_infrastructure(
@@ -283,5 +305,6 @@ if __name__ == "__main__":
         run_application=config_args.run_application,
         run_quickstart=config_args.run_quickstart,
         run_tests=config_args.run_tests,
-        run_create_superuser=config_args.run_create_superuser
+        run_create_superuser=config_args.run_create_superuser,
+        run_create_test_data=config_args.run_create_test_data,
     )


### PR DESCRIPTION
# Purpose

This PR adds a new `make test-data` command to seed our application database with some initial privacy requests, based on the data migration we originally tested the Fidesops Admin UI with (https://github.com/ethyca/fidesops/pull/364/commits/fc4ac38e43f8db1b4d02c7fc954eaa487cb842d0)

 
