### PR TITLE
Fix error when editing user permissions

### DIFF
--- a/src/fidesops/api/v1/endpoints/user_permission_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_permission_endpoints.py
@@ -74,7 +74,7 @@ def update_user_permissions(
     logger.info("Updated FidesopsUserPermission record")
     if user.client:
         user.client.update(db=db, data={"scopes": permissions.scopes})
-    return FidesopsUserPermissions.create_or_update(
+    return user.permissions.update(
         db=db,
         data={"id": user.permissions.id, "user_id": user_id, **permissions.dict()},
     )


### PR DESCRIPTION
# Purpose
A 500 error is thrown when trying to edit a users permissions. This updates the backend to use the correct method so updates don't trigger the following error:
```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "fidesopsuserpermissions_user_id_key"
```
# Changes
- update method from `create_or_update` to `update`

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #499 
 
