### PR TITLE
[Misc] Adds user data to the login response

### DIFF
--- a/src/fidesops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/user_endpoints.py
@@ -35,6 +35,7 @@ from fidesops.schemas.user import (
     UserLogin,
     UserPasswordReset,
     UserResponse,
+    UserLoginResponse,
 )
 
 from fidesops.util.oauth_util import (
@@ -238,11 +239,11 @@ def delete_user(
 @router.post(
     urls.LOGIN,
     status_code=HTTP_200_OK,
-    response_model=AccessToken,
+    response_model=UserLoginResponse,
 )
 def user_login(
     *, db: Session = Depends(deps.get_db), user_data: UserLogin
-) -> AccessToken:
+) -> UserLoginResponse:
     """Login the user by creating a client if it doesn't exist, and have that client generate a token"""
     user: FidesopsUser = FidesopsUser.get_by(
         db, field="username", value=user_data.username
@@ -260,7 +261,10 @@ def user_login(
 
     logger.info("Creating login access token")
     access_code = client.create_access_code_jwe()
-    return AccessToken(access_token=access_code)
+    return UserLoginResponse(
+        user_data=user,
+        token_data=AccessToken(access_token=access_code),
+    )
 
 
 @router.post(

--- a/src/fidesops/schemas/user.py
+++ b/src/fidesops/schemas/user.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pydantic import validator
 from fidesops.schemas.base_class import BaseSchema
+from fidesops.schemas.oauth import AccessToken
 
 
 class UserUpdate(BaseSchema):
@@ -67,6 +68,13 @@ class UserResponse(BaseSchema):
     created_at: datetime
     first_name: Optional[str]
     last_name: Optional[str]
+
+
+class UserLoginResponse(BaseSchema):
+    """Similar to UserResponse except with an access token"""
+
+    user_data: UserResponse
+    token_data: AccessToken
 
 
 class UserCreateResponse(BaseSchema):

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -669,13 +669,16 @@ class TestUserLogin:
 
         db.refresh(user)
         assert user.client is not None
-        assert list(response.json().keys()) == ["access_token"]
-        token = response.json()["access_token"]
-
+        assert "token_data" in list(response.json().keys())
+        token = response.json()["token_data"]["access_token"]
         token_data = json.loads(extract_payload(token))
-
         assert token_data["client-id"] == user.client.id
-        assert token_data["scopes"] == [PRIVACY_REQUEST_READ]
+        assert token_data["scopes"] == [
+            PRIVACY_REQUEST_READ
+        ]  # Uses scopes on existing client
+
+        assert "user_data" in list(response.json().keys())
+        assert response.json()["user_data"]["id"] == user.id
 
         user.client.delete(db)
 
@@ -699,15 +702,16 @@ class TestUserLogin:
 
         db.refresh(user)
         assert user.client is not None
-        assert list(response.json().keys()) == ["access_token"]
-        token = response.json()["access_token"]
-
+        assert "token_data" in list(response.json().keys())
+        token = response.json()["token_data"]["access_token"]
         token_data = json.loads(extract_payload(token))
-
         assert token_data["client-id"] == existing_client_id
         assert token_data["scopes"] == [
             PRIVACY_REQUEST_READ
         ]  # Uses scopes on existing client
+
+        assert "user_data" in list(response.json().keys())
+        assert response.json()["user_data"]["id"] == user.id
 
 
 class TestUserLogout:


### PR DESCRIPTION
# Purpose

The Admin UI needs awareness of the logged in user's ID in order to make certain API requests that require the user's ID.

# Changes

- Adds `user_data` to the `UserLoginResponse`, alongside `token_data`.

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
 
