### PR TITLE
Add a gh workflow for frontend tests

### DIFF
--- a/.github/workflows/frontend_pr_checks.yml
+++ b/.github/workflows/frontend_pr_checks.yml
@@ -1,0 +1,64 @@
+name: Frontend PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "clients"
+      - ".github/workflows/frontend_pr_checks.yml"
+
+jobs:
+  Admin-UI-Unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    defaults:
+      run:
+        working-directory: clients/admin-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint 
+
+      - name: Jest test
+        run: npm run test
+
+  Privacy-Center-Unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    defaults:
+      run:
+        working-directory: clients/privacy-center  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint 
+
+      - name: Jest test
+        run: npm run test 
+
+        


### PR DESCRIPTION
# Purpose
To run admin-ui and privacy-center frontend tests in CI 🎉 

# Changes
- Adds a github workflow file to run frontend unit tests
- In the future Cypress tests can go in here too

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes https://github.com/ethyca/fidesops/issues/508
 
