### PR TITLE
Import sorting via eslint

### DIFF
--- a/clients/admin-ui/.eslintignore
+++ b/clients/admin-ui/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/clients/admin-ui/.eslintrc.json
+++ b/clients/admin-ui/.eslintrc.json
@@ -5,21 +5,24 @@
     "prettier",
     "next/core-web-vitals"
   ],
+  "plugins": ["simple-import-sort"],
+  "root": true,
   "parserOptions": {
     "project": "./tsconfig.json"
   },
   "rules": {
-    "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
-    "react/jsx-props-no-spreading": [0],
+    // causes bug in re-exporting default exports, see
+    // https://github.com/eslint/eslint/issues/15617
+    "no-restricted-exports": [0],
     "react/function-component-definition": [
       2,
       {
         "namedComponents": "arrow-function"
       }
     ],
-    // causes bug in re-exporting default exports, see
-    // https://github.com/eslint/eslint/issues/15617
-    "no-restricted-exports": [0]
-  },
-  "plugins": ["simple-import-sort"]
+    "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
+    "react/jsx-props-no-spreading": [0],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
+  }
 }

--- a/clients/admin-ui/.eslintrc.json
+++ b/clients/admin-ui/.eslintrc.json
@@ -20,5 +20,6 @@
     // causes bug in re-exporting default exports, see
     // https://github.com/eslint/eslint/issues/15617
     "no-restricted-exports": [0]
-  }
+  },
+  "plugins": ["simple-import-sort"]
 }

--- a/clients/admin-ui/__tests__/index.test.tsx
+++ b/clients/admin-ui/__tests__/index.test.tsx
@@ -1,7 +1,8 @@
 // __tests__/index.test.tsx
 import { render, screen } from '@testing-library/react';
 import { SessionProvider } from 'next-auth/react';
-import Home from '../pages/index';
+
+import Home from '../src/pages/index';
 
 describe('Home', () => {
   it('renders a logged out notification when no session is present', () => {

--- a/clients/admin-ui/package-lock.json
+++ b/clients/admin-ui/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "typescript": "4.5.5"
@@ -6717,6 +6718,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -16879,6 +16889,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
       "dev": true,
       "requires": {}
     },

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -6,7 +6,7 @@
     "dev:mock": "echo '🚨 Running with mock API'; NEXT_PUBLIC_MOCK_API=true next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint . --ext .ts,.tsx",
     "test": "jest --watch",
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
     "typescript": "4.5.5"

--- a/clients/admin-ui/src/app/hooks.ts
+++ b/clients/admin-ui/src/app/hooks.ts
@@ -1,4 +1,5 @@
 import { TypedUseSelectorHook, useSelector } from 'react-redux';
+
 import type { AppState } from './store';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -1,10 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { setupListeners } from '@reduxjs/toolkit/query/react';
 import { createWrapper } from 'next-redux-wrapper';
 
-import { setupListeners } from '@reduxjs/toolkit/query/react';
 import {
-  reducer as privacyRequestsReducer,
   privacyRequestApi,
+  reducer as privacyRequestsReducer,
 } from '../features/privacy-requests';
 import { reducer as userReducer } from '../features/user';
 

--- a/clients/admin-ui/src/features/common/Header.tsx
+++ b/clients/admin-ui/src/features/common/Header.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
 import {
+  Button,
   Flex,
   Link,
-  Button,
   Menu,
   MenuButton,
-  MenuList,
-  MenuItem,
-  Text,
   MenuDivider,
+  MenuItem,
+  MenuList,
   Stack,
+  Text,
 } from '@fidesui/react';
-import { signOut } from 'next-auth/react';
-import NextLink from 'next/link';
 import Image from 'next/image';
+import NextLink from 'next/link';
+import { signOut } from 'next-auth/react';
+import React from 'react';
 
 import { UserIcon } from './Icon';
 

--- a/clients/admin-ui/src/features/common/Icon/index.tsx
+++ b/clients/admin-ui/src/features/common/Icon/index.tsx
@@ -2,6 +2,6 @@ export { default as ArrowDownLineIcon } from './ArrowDownLine';
 export { default as CloseSolidIcon } from './CloseSolid';
 export { default as DownloadSolidIcon } from './DownloadSolid';
 export { default as GearIcon } from './Gear';
-export { default as UserIcon } from './User';
 export { default as MoreIcon } from './More';
 export { default as SearchLineIcon } from './SearchLine';
+export { default as UserIcon } from './User';

--- a/clients/admin-ui/src/features/privacy-requests/PIIToggle.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/PIIToggle.tsx
@@ -1,7 +1,7 @@
-import React, { ChangeEvent } from 'react';
-
-import { useDispatch } from 'react-redux';
 import { Switch } from '@fidesui/react';
+import React, { ChangeEvent } from 'react';
+import { useDispatch } from 'react-redux';
+
 import { setRevealPII } from './privacy-requests.slice';
 
 const PIIToggle: React.FC = () => {

--- a/clients/admin-ui/src/features/privacy-requests/RequestBadge.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestBadge.tsx
@@ -1,5 +1,6 @@
-import { ComponentProps } from 'react';
 import { Badge } from '@fidesui/react';
+import { ComponentProps } from 'react';
+
 import { PrivacyRequestStatus } from './types';
 
 export const statusPropMap: {

--- a/clients/admin-ui/src/features/privacy-requests/RequestFilters.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestFilters.tsx
@@ -1,37 +1,36 @@
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import {
-  Flex,
-  Text,
   Button,
-  Select,
+  Flex,
   Input,
   InputGroup,
-  InputLeftElement,
   InputLeftAddon,
+  InputLeftElement,
+  Select,
   Stack,
+  Text,
   useToast,
 } from '@fidesui/react';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-import PIIToggle from './PIIToggle';
 import {
-  DownloadSolidIcon,
   CloseSolidIcon,
+  DownloadSolidIcon,
   SearchLineIcon,
 } from '../common/Icon';
-import { statusPropMap } from './RequestBadge';
-
-import { PrivacyRequestStatus } from './types';
-import {
-  setRequestStatus,
-  setRequestId,
-  setRequestFrom,
-  setRequestTo,
-  clearAllFilters,
-  selectPrivacyRequestFilters,
-  requestCSVDownload,
-} from './privacy-requests.slice';
 import { selectUserToken } from '../user/user.slice';
+import PIIToggle from './PIIToggle';
+import {
+  clearAllFilters,
+  requestCSVDownload,
+  selectPrivacyRequestFilters,
+  setRequestFrom,
+  setRequestId,
+  setRequestStatus,
+  setRequestTo,
+} from './privacy-requests.slice';
+import { statusPropMap } from './RequestBadge';
+import { PrivacyRequestStatus } from './types';
 
 const useRequestFilters = () => {
   const filters = useSelector(selectPrivacyRequestFilters);

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -1,33 +1,32 @@
-import React, { useRef, useState } from 'react';
 import {
-  Tag,
-  Text,
-  Tr,
-  Td,
+  Alert,
+  AlertTitle,
   Button,
   ButtonGroup,
   Menu,
   MenuButton,
-  MenuList,
   MenuItem,
+  MenuList,
   Portal,
-  Alert,
-  AlertTitle,
+  Tag,
+  Td,
+  Text,
+  Tr,
   useClipboard,
   useToast,
 } from '@fidesui/react';
 import { format } from 'date-fns-tz';
+import React, { useRef, useState } from 'react';
 
 import { MoreIcon } from '../common/Icon';
-import RequestBadge from './RequestBadge';
-
-import { PrivacyRequest } from './types';
+import DenyPrivacyRequestModal from './DenyPrivacyRequestModal';
 import { useObscuredPII } from './helpers';
 import {
   useApproveRequestMutation,
   useDenyRequestMutation,
 } from './privacy-requests.slice';
-import DenyPrivacyRequestModal from './DenyPrivacyRequestModal';
+import RequestBadge from './RequestBadge';
+import { PrivacyRequest } from './types';
 
 const PII: React.FC<{ data: string }> = ({ data }) => (
   <>{useObscuredPII(data)}</>
@@ -75,8 +74,8 @@ const useRequestRow = (request: PrivacyRequest) => {
         title: 'Request ID copied',
         duration: 5000,
         render: () => (
-          <Alert bg='gray.600' borderRadius='6px' display='flex'>
-            <AlertTitle color='white'>Request ID copied</AlertTitle>
+          <Alert bg="gray.600" borderRadius="6px" display="flex">
+            <AlertTitle color="white">Request ID copied</AlertTitle>
           </Alert>
         ),
         containerStyle: {
@@ -143,25 +142,25 @@ const RequestRow: React.FC<{ request: PrivacyRequest }> = ({ request }) => {
       bg={showMenu ? 'gray.50' : 'white'}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      height='36px'
+      height="36px"
     >
       <Td pl={0} py={1}>
         <RequestBadge status={request.status} />
       </Td>
       <Td py={1}>
         <Tag
-          color='white'
-          bg='primary.400'
+          color="white"
+          bg="primary.400"
           px={2}
           py={0.5}
-          size='sm'
-          fontWeight='medium'
+          size="sm"
+          fontWeight="medium"
         >
           {request.policy.name}
         </Tag>
       </Td>
       <Td py={1}>
-        <Text fontSize='xs'>
+        <Text fontSize="xs">
           <PII
             data={
               request.identity
@@ -172,50 +171,50 @@ const RequestRow: React.FC<{ request: PrivacyRequest }> = ({ request }) => {
         </Text>
       </Td>
       <Td py={1}>
-        <Text fontSize='xs'>
+        <Text fontSize="xs">
           {format(new Date(request.created_at), 'MMMM d, Y, KK:mm:ss z')}
         </Text>
       </Td>
       <Td py={1}>
-        <Text fontSize='xs'>
+        <Text fontSize="xs">
           <PII data={request.reviewer ? request.reviewer.username : ''} />
         </Text>
       </Td>
       <Td py={1}>
-        <Text isTruncated fontSize='xs' maxWidth='87px'>
+        <Text isTruncated fontSize="xs" maxWidth="87px">
           {request.id}
         </Text>
       </Td>
-      <Td pr={0} py={1} textAlign='end' position='relative'>
+      <Td pr={0} py={1} textAlign="end" position="relative">
         <Button
-          size='xs'
-          variant='ghost'
+          size="xs"
+          variant="ghost"
           mr={2.5}
           onFocus={shiftFocusToHoverMenu}
           tabIndex={showMenu ? -1 : 0}
         >
-          <MoreIcon color='gray.700' w={18} h={18} />
+          <MoreIcon color="gray.700" w={18} h={18} />
         </Button>
         <ButtonGroup
           isAttached
-          variant='outline'
-          position='absolute'
+          variant="outline"
+          position="absolute"
           right={2.5}
-          top='50%'
-          transform='translate(1px, -50%)'
+          top="50%"
+          transform="translate(1px, -50%)"
           opacity={showMenu ? 1 : 0}
           pointerEvents={showMenu ? 'auto' : 'none'}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          shadow='base'
-          borderRadius='md'
+          shadow="base"
+          borderRadius="md"
         >
           {request.status === 'pending' ? (
             <>
               <Button
-                size='xs'
-                mr='-px'
-                bg='white'
+                size="xs"
+                mr="-px"
+                bg="white"
                 onClick={handleApproveRequest}
                 isLoading={approveRequestResult.isLoading}
                 _loading={{
@@ -230,9 +229,9 @@ const RequestRow: React.FC<{ request: PrivacyRequest }> = ({ request }) => {
                 Approve
               </Button>
               <Button
-                size='xs'
-                mr='-px'
-                bg='white'
+                size="xs"
+                mr="-px"
+                bg="white"
                 onClick={handleModalOpen}
                 _loading={{
                   opacity: 1,
@@ -260,19 +259,19 @@ const RequestRow: React.FC<{ request: PrivacyRequest }> = ({ request }) => {
           <Menu onOpen={handleMenuOpen} onClose={handleMenuClose}>
             <MenuButton
               as={Button}
-              size='xs'
-              bg='white'
+              size="xs"
+              bg="white"
               ref={request.status !== 'pending' ? hoverButtonRef : null}
             >
-              <MoreIcon color='gray.700' w={18} h={18} />
+              <MoreIcon color="gray.700" w={18} h={18} />
             </MenuButton>
             <Portal>
-              <MenuList shadow='xl'>
+              <MenuList shadow="xl">
                 <MenuItem
                   _focus={{ color: 'complimentary.500', bg: 'gray.100' }}
                   onClick={handleIdCopy}
                 >
-                  <Text fontSize='sm'>Copy Request ID</Text>
+                  <Text fontSize="sm">Copy Request ID</Text>
                 </MenuItem>
               </MenuList>
             </Portal>

--- a/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
@@ -1,26 +1,24 @@
-import React, { useEffect, useRef, useState } from 'react';
 import {
-  Table,
-  Text,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
   Button,
   Flex,
+  Table,
+  Tbody,
+  Text,
+  Th,
+  Thead,
+  Tr,
 } from '@fidesui/react';
+import debounce from 'lodash.debounce';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import debounce from 'lodash.debounce';
-
-import { PrivacyRequest } from './types';
 import {
   selectPrivacyRequestFilters,
-  useGetAllPrivacyRequestsQuery,
   setPage,
+  useGetAllPrivacyRequestsQuery,
 } from './privacy-requests.slice';
-
 import RequestRow from './RequestRow';
+import { PrivacyRequest } from './types';
 
 interface RequestTableProps {
   requests?: PrivacyRequest[];

--- a/clients/admin-ui/src/features/privacy-requests/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-requests/helpers.ts
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+
 import { selectRevealPII } from './privacy-requests.slice';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -1,8 +1,8 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { HYDRATE } from 'next-redux-wrapper';
-import type { AppState } from '../../app/store';
 
+import type { AppState } from '../../app/store';
 import {
   PrivacyRequest,
   PrivacyRequestParams,

--- a/clients/admin-ui/src/features/user/user.slice.ts
+++ b/clients/admin-ui/src/features/user/user.slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { HYDRATE } from 'next-redux-wrapper';
+
 import type { AppState } from '../../app/store';
 
 export interface State {

--- a/clients/admin-ui/src/mocks/browser.ts
+++ b/clients/admin-ui/src/mocks/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw';
+
 import { handlers } from './handlers';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/clients/admin-ui/src/mocks/server.ts
+++ b/clients/admin-ui/src/mocks/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
+
 import { handlers } from './handlers';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/clients/admin-ui/src/pages/404.tsx
+++ b/clients/admin-ui/src/pages/404.tsx
@@ -1,7 +1,7 @@
+import { Box, Button, Heading, Stack, Text } from '@fidesui/react';
 import Head from 'next/head';
 import Image from 'next/image';
 import NextLink from 'next/link';
-import { Stack, Heading, Box, Text, Button } from '@fidesui/react';
 
 const Custom404 = () => (
   <div>

--- a/clients/admin-ui/src/pages/_app.tsx
+++ b/clients/admin-ui/src/pages/_app.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import type { AppProps } from 'next/app';
-import { SessionProvider } from 'next-auth/react';
-import { ChakraProvider } from '@chakra-ui/react';
-import theme from '../theme';
-import { wrapper } from '../app/store';
-
 import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
 import '@fontsource/inter/700.css';
+
+import { ChakraProvider } from '@chakra-ui/react';
+import type { AppProps } from 'next/app';
+import { SessionProvider } from 'next-auth/react';
+import React from 'react';
+
+import { wrapper } from '../app/store';
+import theme from '../theme';
 
 if (process.env.NEXT_PUBLIC_MOCK_API) {
   // eslint-disable-next-line global-require

--- a/clients/admin-ui/src/pages/index.tsx
+++ b/clients/admin-ui/src/pages/index.tsx
@@ -1,17 +1,14 @@
-import React from 'react';
+import { Box, Button, Flex, Heading } from '@fidesui/react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { getSession } from 'next-auth/react';
-import { Flex, Heading, Button, Box } from '@fidesui/react';
+import React from 'react';
+
 import { wrapper } from '../app/store';
-
 import Header from '../features/common/Header';
-
 import { ArrowDownLineIcon } from '../features/common/Icon';
-
-import RequestTable from '../features/privacy-requests/RequestTable';
 import RequestFilters from '../features/privacy-requests/RequestFilters';
-
+import RequestTable from '../features/privacy-requests/RequestTable';
 import { assignToken } from '../features/user/user.slice';
 
 const Home: NextPage<{ session: { username: string } }> = ({ session }) => (

--- a/clients/admin-ui/src/pages/login.tsx
+++ b/clients/admin-ui/src/pages/login.tsx
@@ -1,24 +1,23 @@
-import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  chakra,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Heading,
+  Input,
+  Stack,
+  useToast,
+} from '@fidesui/react';
+import { useFormik } from 'formik';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
-import { useFormik } from 'formik';
-import { signIn } from 'next-auth/react';
-
-import {
-  Flex,
-  Stack,
-  Heading,
-  Box,
-  FormControl,
-  FormLabel,
-  Input,
-  Button,
-  FormErrorMessage,
-  chakra,
-  useToast,
-} from '@fidesui/react';
 import { useRouter } from 'next/router';
+import { signIn } from 'next-auth/react';
+import React, { useState } from 'react';
 
 const useLogin = () => {
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
# Purpose

Implements import sorting via eslint to keep our imports tidy and consistent. Inspired by [this conversation](https://elliotbonnevi-e4q9263.slack.com/archives/C02U22GBDRU/p1652370522897329?thread_ts=1652365727.442189&cid=C02U22GBDRU).

Note: there's a little bit of eslint noise because I ran `eslint . --fix` to update all the imports. Can be safely ignored.

# Changes

- Adds eslintignore file
- Switches package.json `lint` script from using `next lint` to `eslint`
- Adds the simple-import-sort eslint plugin and configures it

# Checklist

- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
