### PR TITLE
create basic drp docs [#475]

### DIFF
--- a/docs/fidesops/docs/guides/data_rights_protocol.md
+++ b/docs/fidesops/docs/guides/data_rights_protocol.md
@@ -1,0 +1,73 @@
+# Data Rights Protocol
+
+The [Data Rights Protocol](https://github.com/consumer-reports-digital-lab/data-rights-protocol) (DRP) is a technical standard for exchanging data rights requests under regulations like the California Consumer Privacy Act (CCPA). 
+
+As a Privacy Infrastructure Provider (PIP), fidesops conforms to the DRP standards to receive and process Data Rights Requests. The following endpoints and actions are available in fidesops for working within the DRP specifications.
+
+## DRP Actions
+A [DRP action](https://github.com/consumer-reports-digital-lab/data-rights-protocol#301-supported-rights-actions) may be defined when creating or editing a [policy](policies.md#create-a-policy). These actions associate a fidesops policy with a DRP-standardized protocol for receiving and processing Data Rights Requests. 
+
+A given action may only be associated to a single policy:
+
+```yaml title="<code>PATCH /api/v1/policy</code>"
+[
+    {
+        "name": "User Email Address",
+        "key": "user_email_address_policy",
+        "drp_action": "access"
+    }
+]
+```
+
+### Available actions
+The following actions may be associated to a policy via the `drp_action` attribute, which correspond to the DRP's set of [supported rights](https://github.com/consumer-reports-digital-lab/data-rights-protocol#202-post-exercise-data-rights-exercise-endpoint).
+
+| Action | Use |
+|---|----|
+| `sale:opt_out` | Right to opt out of data sale |
+| `sale:opt_in` | Reconsent, or opt-in to data sale |
+| `deletion` | Right to Delete |
+| `access` | Right to Know |
+| `access:categories` |	Right to Know |
+| `access:specific` | Right to Know |
+
+## Endpoints
+
+Once a policy is associated with an action, the following DRP-standardized endpoints are available.
+
+### Exercise
+The `/exercise` endpoint creates a new DRP privacy request. Fidesops will execute this request based on the policy associated to the DRP action specified in `exercise`.
+
+All identity information should be encapsulated in the provided `identity` field using RFC7515-encoded [JSON Web Tokens](https://datatracker.ietf.org/doc/html/rfc7515). More about identity ecapsulation can be found in the [DRP standard](https://github.com/consumer-reports-digital-lab/data-rights-protocol#304-schema-identity-encapsulation).
+
+```json title="<code>POST /api/v1/drp/exercise</code>"
+{
+  "meta": {
+    "version": "0.5"
+  },
+  "exercise": [
+    "sale:opt-out"
+  ],
+  "identity": "jwt",
+}
+```
+
+```json title="Response"
+{
+    "request_id": "c789ff35-7644-4ceb-9981-4b35c264aac3",
+    "received_at": "20210902T152725.403-0700",
+    "expected_by": "20211015T152725.403-0700",
+    "status": "open",
+}
+```
+
+### Status
+
+The current status of an existing privacy request may be returned via the `/status` endpoint, which must be queried using a privacy request ID.
+
+```json title="<code>GET /api/v1/drp/status?request_id={privacy_request_id}</code>"
+{
+    "request_id": "c789ff35-7644-4ceb-9981-4b35c264aac3",
+    "status": "open",
+}
+```

--- a/docs/fidesops/docs/guides/policies.md
+++ b/docs/fidesops/docs/guides/policies.md
@@ -42,7 +42,7 @@ PATCH /api/v1/policy
 [
   {
     "name": "User Email Address",
-    "key": "user_email_address_polcy",
+    "key": "user_email_address_policy",
     "drp_action": "access" // optional
   }
 ]
@@ -54,7 +54,7 @@ This policy is subtly different from the concept of a Policy in [Fidesctl](https
 |---|---|
 | `Policy.name` | User-friendly name for your Policy. |
 | `Policy.key` | Unique key by which to reference the Policy. |
-| `Policy.drp_action` | <b>Optional.</b> A [Data Rights Protocol](https://github.com/consumer-reports-digital-lab/data-rights-protocol) action to associate to this policy. |
+| `Policy.drp_action` | <b>Optional.</b> A [Data Rights Protocol](./data_rights_protocol.md) action to associate to this policy. |
 | `access` | A data subject access request. Should be used with an `access` Rule. |
 | `deletion` | A data subject erasure request. Should be used with an `erasure` Rule. |
 

--- a/docs/fidesops/mkdocs.yml
+++ b/docs/fidesops/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Configuration Reference: guides/configuration_reference.md
       - Admin UI: guides/admin_ui.md
       - Postman Collection: postman/using_postman.md
+      - Data Rights Protocol: guides/data_rights_protocol.md
   - Deployment Guide: deployment.md
   - Glossary: glossary.md
   - API: api/index.md


### PR DESCRIPTION
# Purpose
Document how Fidesops' implementation of DRP works, why this is important, and what endpoints are currently available.

# Changes
- create a home in the documentation for drp information, which can be easily expanded as we add future endpoints
- small copy fixes 

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file in appropriate sections
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).

# Ticket

Fixes #475 
 
