### PR TITLE
use `from __future__ import annotations` to maintain backward compatibility with python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ The types of changes are:
 * Added `FIDESOPS__DATABASE__ENABLED` and `FIDESOPS__REDIS__ENABLED` configuration variables to allow `fidesops` to run cleanly in a "stateless" mode without any database or redis cache integration [#550](https://github.com/ethyca/fidesops/pull/550)
 
 ### Changed
-* `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility
-* Changed `tuple` type hint reference to `typing.Tuple` to maintain backward compatibility with Python < 3.9
+* `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility [#560](https://github.com/ethyca/fidesops/pull/560)
+* Changed `tuple` type hint reference to `typing.Tuple` to maintain backward compatibility with Python < 3.9 [#569](https://github.com/ethyca/fidesops/pull/569)
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Changed
 * `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility
+* Changed `tuple` type hint reference to `typing.Tuple` to maintain backward compatibility with Python < 3.9
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The types of changes are:
 
 ### Changed
 * `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility [#560](https://github.com/ethyca/fidesops/pull/560)
-* Changed `tuple` type hint reference to `typing.Tuple` to maintain backward compatibility with Python < 3.9 [#569](https://github.com/ethyca/fidesops/pull/569)
+* Added from `__future__ import annotations` to `src/fidesops/util/logger.py` to maintain backward compatibility with Python < 3.9 [#569](https://github.com/ethyca/fidesops/pull/569)
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The types of changes are:
 
 ### Changed
 * `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility [#560](https://github.com/ethyca/fidesops/pull/560)
-* Added from `__future__ import annotations` to `src/fidesops/util/logger.py` to maintain backward compatibility with Python < 3.9 [#569](https://github.com/ethyca/fidesops/pull/569)
+* Added `from __future__ import annotations` to `src/fidesops/util/logger.py` to maintain backward compatibility with Python < 3.9 [#569](https://github.com/ethyca/fidesops/pull/569)
 
 ### Developer Experience
 

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from numbers import Number
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Tuple, Union
 
 MASKED = "MASKED"
 
@@ -19,7 +19,8 @@ def get_fides_log_record_factory() -> Any:
         fn: str,
         lno: int,
         msg: str,
-        args: Union[tuple[Any, ...], Mapping[str, Any]],
+        # DEFER: Update this to use tuple (lowercase "t") when Python 3.9 is required as a minimum version (see issue link: https://github.com/ethyca/fidesops/issues/568.)
+        args: Union[Tuple[Any, ...], Mapping[str, Any]],
         exc_info: Any,
         func: str = None,
         sinfo: str = None,

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 from numbers import Number
-from typing import Any, Mapping, Tuple, Union
+from typing import Any, Mapping, Union
 
 MASKED = "MASKED"
 
@@ -19,8 +21,7 @@ def get_fides_log_record_factory() -> Any:
         fn: str,
         lno: int,
         msg: str,
-        # DEFER: Update this to use tuple (lowercase "t") when Python 3.9 is required as a minimum version (see issue link: https://github.com/ethyca/fidesops/issues/568.)
-        args: Union[Tuple[Any, ...], Mapping[str, Any]],
+        args: Union[tuple[Any, ...], Mapping[str, Any]],
         exc_info: Any,
         func: str = None,
         sinfo: str = None,


### PR DESCRIPTION
# Purpose
Maintain backward compatibility with Python < 3.9

# Changes
Change type hint reference from `tuple` to `typing.Tuple` in `src/fidesops/util/logger.py`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes https://github.com/ethyca/fidesops/issues/567
 
