### PR TITLE
Pause Erasure Execution for Manual Confirmation [#522]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 ### Added
 * Added `FIDESOPS__DATABASE__ENABLED` and `FIDESOPS__REDIS__ENABLED` configuration variables to allow `fidesops` to run cleanly in a "stateless" mode without any database or redis cache integration [#550](https://github.com/ethyca/fidesops/pull/550)
 * Pause Access Request Execution / Resume on Manual Input in [#554](https://github.com/ethyca/fidesops/pull/554)
+* Pause Erasure Request Execution / Resume on Manual Input in [#571](https://github.com/ethyca/fidesops/pull/571/)
 
 ### Changed
 * `MaskingStrategyFactory` and associated `MaskingStrategy` implementations now use a decorator-based registration system, to improve extensibility

--- a/docs/fidesops/docs/guides/manual_data.md
+++ b/docs/fidesops/docs/guides/manual_data.md
@@ -3,7 +3,8 @@
 In this section we'll cover:
 
 - How to describe a manual dataset
-- How to send manual data to resume a privacy request
+- How to send manual data to resume the access portion of a privacy request
+- How to send manual data to resume the erasure portion of a privacy request
 
 ## Overview
 
@@ -37,11 +38,13 @@ dataset:
               data_type: string
 ```
 
-## Resuming a paused privacy request
+## Resuming a paused access privacy request
 
-A privacy request will pause execution when it reaches a manual collection.  An administrator
+A privacy request will pause execution when it reaches a manual collection in an access request.  An administrator
 should manually retrieve the data and send it in a POST request.  The fields 
 should match the fields on the paused collection.  
+
+Erasure requests with manual collections will also need data manually added as well.
 
 ```json title="<code>POST {{host}}/privacy-request/{{privacy_request_id}}/manual_input</code>"
 [{
@@ -54,4 +57,19 @@ If no manual data can be found, simply pass in an empty list to resume the priva
 
 ```json
 []
+```
+
+## Resuming a paused erasure privacy request
+
+A privacy request will pause execution when it reaches a manual collection in an erasure request.  An administrator
+should manually mask the records in question and send confirmation of the rows affected in a POST request.  
+
+```json title="<code>POST {{host}}/privacy-request/{{privacy_request_id}}/erasure_confirm</code>"
+{"row_count": 2}
+```
+
+If no manual data was destroyed, pass in a count of 0 to resume the privacy request:
+
+```json
+{"row_count": 0}
 ```

--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -3697,6 +3697,44 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Resume Erasure Request with Confirmed Masked Row Count",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{client_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"row_count\": 5\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/privacy-request/{{privacy_request_id}}/erasure_confirm",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"privacy-request",
+								"{{privacy_request_id}}",
+								"erasure_confirm"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}

--- a/docs/fidesops/docs/postman/Fidesops.postman_collection.json
+++ b/docs/fidesops/docs/postman/Fidesops.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "336250bf-42b1-49d2-8b9f-d82706f6f4b4",
+		"_postman_id": "9019796e-9107-41a1-a268-4d2cda117e85",
 		"name": "Fidesops",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -3526,7 +3526,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\"name\": \"Manual connector\",\n    \"key\": \"{{manual_connector}}\",\n    \"connection_type\": \"manual\",\n    \"access\": \"read\"\n}]",
+							"raw": "[\n    {\"name\": \"Manual connector\",\n    \"key\": \"{{manual_connector}}\",\n    \"connection_type\": \"manual\",\n    \"access\": \"write\"\n}]",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -593,7 +593,9 @@ def validate_collection(collection: CollectionAddress, db: Session) -> DatasetGr
 
 
 def validate_manual_input(
-    manual_rows: List[Optional[Row]], collection: CollectionAddress, dataset_graph: DatasetGraph
+    manual_rows: List[Optional[Row]],
+    collection: CollectionAddress,
+    dataset_graph: DatasetGraph,
 ) -> None:
     """Validate manually-added data for a collection.
 
@@ -616,7 +618,7 @@ def resume_privacy_request_with_manual_input(
     cache: FidesopsRedis,
     expected_paused_step: ActionType,
     manual_rows: Optional[List[Row]] = None,
-    manual_count: Optional[int] = None
+    manual_count: Optional[int] = None,
 ) -> PrivacyRequest:
     """Resume privacy request after validating and caching manual data for an access or an erasure request."""
     privacy_request: PrivacyRequest = get_privacy_request_or_error(
@@ -667,9 +669,7 @@ def resume_privacy_request_with_manual_input(
         logger.info(
             f"Caching manually erased row count for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
         )
-        privacy_request.cache_manual_erasure_result(
-            paused_collection, manual_count
-        )
+        privacy_request.cache_manual_erasure_result(paused_collection, manual_count)
 
     logger.info(
         f"Resuming privacy request '{privacy_request_id}', {paused_step.value} step, from collection "

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -578,20 +578,6 @@ def resume_privacy_request(
     return privacy_request
 
 
-def validate_collection(collection: CollectionAddress, db: Session) -> DatasetGraph:
-    datasets = DatasetConfig.all(db=db)
-    dataset_graphs = [dataset_config.get_graph() for dataset_config in datasets]
-    dataset_graph = DatasetGraph(*dataset_graphs)
-
-    node: Optional[Node] = dataset_graph.nodes.get(collection)
-    if not node:
-        raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Cannot save manual rows. No collection in graph with name: '{collection.value}'.",
-        )
-    return dataset_graph
-
-
 def validate_manual_input(
     manual_rows: List[Optional[Row]],
     collection: CollectionAddress,
@@ -669,7 +655,7 @@ def resume_privacy_request_with_manual_input(
         logger.info(
             f"Caching manually erased row count for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
         )
-        privacy_request.cache_manual_erasure_result(paused_collection, manual_count)
+        privacy_request.cache_manual_erasure_count(paused_collection, manual_count)
 
     logger.info(
         f"Resuming privacy request '{privacy_request_id}', {paused_step.value} step, from collection "

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -48,7 +48,7 @@ from fidesops.models.audit_log import AuditLog, AuditLogAction
 from fidesops.models.client import ClientDetail
 from fidesops.models.connectionconfig import ConnectionConfig
 from fidesops.models.datasetconfig import DatasetConfig
-from fidesops.models.policy import ActionType, Policy, PolicyPreWebhook
+from fidesops.models.policy import PausedStep, Policy, PolicyPreWebhook
 from fidesops.models.privacy_request import (
     ExecutionLog,
     PrivacyRequest,
@@ -579,7 +579,7 @@ def resume_privacy_request(
 
 
 def validate_manual_input(
-    manual_rows: List[Optional[Row]],
+    manual_rows: List[Row],
     collection: CollectionAddress,
     dataset_graph: DatasetGraph,
 ) -> None:
@@ -588,7 +588,7 @@ def validate_manual_input(
     The specified collection must exist and all fields must be previously defined.
     """
     for row in manual_rows:
-        for field_name in row or {}:
+        for field_name in row:
             if not dataset_graph.nodes[collection].contains_field(
                 lambda f: f.name == field_name  # pylint: disable=W0640
             ):
@@ -602,8 +602,8 @@ def resume_privacy_request_with_manual_input(
     privacy_request_id: str,
     db: Session,
     cache: FidesopsRedis,
-    expected_paused_step: ActionType,
-    manual_rows: Optional[List[Row]] = None,
+    expected_paused_step: PausedStep,
+    manual_rows: List[Row] = [],
     manual_count: Optional[int] = None,
 ) -> PrivacyRequest:
     """Resume privacy request after validating and caching manual data for an access or an erasure request."""
@@ -617,20 +617,20 @@ def resume_privacy_request_with_manual_input(
             f"status = {privacy_request.status.value}. Privacy request is not paused.",
         )
 
-    paused_step: Optional[ActionType]
+    paused_step: Optional[PausedStep]
     paused_collection: Optional[CollectionAddress]
     paused_step, paused_collection = privacy_request.get_paused_step_and_collection()
-    if not paused_collection:
+    if not paused_collection or not paused_step:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Cannot resume privacy request '{privacy_request.id}'; no paused collection.",
+            detail=f"Cannot resume privacy request '{privacy_request.id}'; no paused collection or no paused step.",
         )
 
     if paused_step != expected_paused_step:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Collection '{paused_collection}' is paused at the {paused_step} step. Pass in manual data instead to "
-            f"'{PRIVACY_REQUEST_MANUAL_ERASURE if paused_step == ActionType.erasure else PRIVACY_REQUEST_MANUAL_INPUT}' to resume.",
+            detail=f"Collection '{paused_collection}' is paused at the {paused_step.value} step. Pass in manual data instead to "
+            f"'{PRIVACY_REQUEST_MANUAL_ERASURE if paused_step == PausedStep.erasure else PRIVACY_REQUEST_MANUAL_INPUT}' to resume.",
         )
 
     datasets = DatasetConfig.all(db=db)
@@ -644,14 +644,14 @@ def resume_privacy_request_with_manual_input(
             detail=f"Cannot save manual data. No collection in graph with name: '{paused_collection.value}'.",
         )
 
-    if paused_step == ActionType.access:
-        validate_manual_input(manual_rows or [], paused_collection, dataset_graph)
+    if paused_step == PausedStep.access:
+        validate_manual_input(manual_rows, paused_collection, dataset_graph)
         logger.info(
             f"Caching manual input for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
         )
         privacy_request.cache_manual_input(paused_collection, manual_rows)
 
-    elif paused_step == ActionType.erasure:
+    elif paused_step == PausedStep.erasure:
         logger.info(
             f"Caching manually erased row count for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
         )
@@ -686,7 +686,7 @@ def resume_with_manual_input(
     *,
     db: Session = Depends(deps.get_db),
     cache: FidesopsRedis = Depends(deps.get_cache),
-    manual_rows: List[Optional[Row]],
+    manual_rows: List[Row],
 ) -> PrivacyRequestResponse:
     """Resume a privacy request by passing in manual input for the paused collection.
 
@@ -696,7 +696,7 @@ def resume_with_manual_input(
         privacy_request_id=privacy_request_id,
         db=db,
         cache=cache,
-        expected_paused_step=ActionType.access,
+        expected_paused_step=PausedStep.access,
         manual_rows=manual_rows,
     )
 
@@ -724,7 +724,7 @@ def resume_with_erasure_confirmation(
         privacy_request_id=privacy_request_id,
         db=db,
         cache=cache,
-        expected_paused_step=ActionType.erasure,
+        expected_paused_step=PausedStep.erasure,
         manual_count=manual_count.row_count,
     )
 

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -34,6 +34,7 @@ from fidesops.api.v1.scope_registry import (
 from fidesops.api.v1.urn_registry import (
     PRIVACY_REQUEST_APPROVE,
     PRIVACY_REQUEST_DENY,
+    PRIVACY_REQUEST_MANUAL_ERASURE,
     PRIVACY_REQUEST_MANUAL_INPUT,
     PRIVACY_REQUEST_RESUME,
     REQUEST_PREVIEW,
@@ -64,6 +65,7 @@ from fidesops.schemas.privacy_request import (
     PrivacyRequestResponse,
     PrivacyRequestVerboseResponse,
     ReviewPrivacyRequestIds,
+    RowCountRequest,
 )
 from fidesops.service.privacy_request.request_runner_service import PrivacyRequestRunner
 from fidesops.service.privacy_request.request_service import (
@@ -576,13 +578,7 @@ def resume_privacy_request(
     return privacy_request
 
 
-def validate_manual_input(
-    manual_rows: List[Row], collection: CollectionAddress, db: Session
-) -> None:
-    """Validate manually-added data for a collection.
-
-    The specified collection must exist and all fields must be previously defined.
-    """
+def validate_collection(collection: CollectionAddress, db: Session) -> DatasetGraph:
     datasets = DatasetConfig.all(db=db)
     dataset_graphs = [dataset_config.get_graph() for dataset_config in datasets]
     dataset_graph = DatasetGraph(*dataset_graphs)
@@ -593,6 +589,17 @@ def validate_manual_input(
             status_code=HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Cannot save manual rows. No collection in graph with name: '{collection.value}'.",
         )
+    return dataset_graph
+
+
+def validate_manual_input(
+    manual_rows: List[Row], collection: CollectionAddress, db: Session
+) -> None:
+    """Validate manually-added data for a collection.
+
+    The specified collection must exist and all fields must be previously defined.
+    """
+    dataset_graph = validate_collection(collection, db)
 
     for row in manual_rows:
         for field_name in row:
@@ -603,6 +610,10 @@ def validate_manual_input(
                     status_code=HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Cannot save manual rows. No '{field_name}' field defined on the '{collection.value}' collection.",
                 )
+
+
+def validate_resume_from_graph(privacy_request_id: PrivacyRequest):
+    pass
 
 
 @router.post(
@@ -643,11 +654,85 @@ def resume_with_manual_input(
             detail=f"Cannot resume privacy request '{privacy_request.id}'; no paused collection.",
         )
 
+    if paused_step == ActionType.erasure:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Collection '{paused_collection}' is paused at the erasure step. Pass in manual data to "
+                   f"{PRIVACY_REQUEST_MANUAL_ERASURE} to resume.",
+        )
+
     validate_manual_input(manual_rows, paused_collection, db)
     logger.info(
         f"Caching manual input for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
     )
     privacy_request.cache_manual_input(paused_collection, manual_rows)
+
+    logger.info(
+        f"Resuming privacy request '{privacy_request_id}', {paused_step.value} step, from collection "
+        f"'{paused_collection.value}'"
+    )
+
+    privacy_request.status = PrivacyRequestStatus.in_processing
+    privacy_request.save(db=db)
+
+    PrivacyRequestRunner(
+        cache=cache,
+        privacy_request=privacy_request,
+    ).submit(from_step=paused_step)
+
+    return privacy_request
+
+
+@router.post(
+    PRIVACY_REQUEST_MANUAL_ERASURE,
+    status_code=HTTP_200_OK,
+    response_model=PrivacyRequestResponse,
+    dependencies=[
+        Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
+    ],
+)
+def resume_with_erasure_confirmation(
+    privacy_request_id: str,
+    *,
+    db: Session = Depends(deps.get_db),
+    cache: FidesopsRedis = Depends(deps.get_cache),
+    row_count: RowCountRequest,
+) -> PrivacyRequestResponse:
+    """Resume the erasure portion of privacy request by passing in the number of rows that were manually masked.
+
+    If no rows were masked, pass in a 0 to resume the privacy request.
+    """
+    privacy_request: PrivacyRequest = get_privacy_request_or_error(
+        db, privacy_request_id
+    )
+    if privacy_request.status != PrivacyRequestStatus.paused:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Invalid resume request: privacy request '{privacy_request.id}' status = {privacy_request.status.value}.",
+        )
+
+    paused_step: Optional[ActionType]
+    paused_collection: Optional[CollectionAddress]
+    paused_step, paused_collection = privacy_request.get_paused_step_and_collection()
+    if not paused_collection:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Cannot resume privacy request '{privacy_request.id}'; no paused collection.",
+        )
+
+    if paused_step == ActionType.access:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Collection '{paused_collection}' is paused at the access step. "
+                   f"Pass in manual data to {PRIVACY_REQUEST_MANUAL_INPUT} to resume.",
+        )
+
+    validate_collection(paused_collection, db)
+
+    logger.info(
+        f"Caching manually erased row count for privacy request '{privacy_request_id}', collection: '{paused_collection}'"
+    )
+    privacy_request.cache_manual_erasure_result(paused_collection, row_count)
 
     logger.info(
         f"Resuming privacy request '{privacy_request_id}', {paused_step.value} step, from collection '{paused_collection.value}'"

--- a/src/fidesops/api/v1/urn_registry.py
+++ b/src/fidesops/api/v1/urn_registry.py
@@ -38,6 +38,7 @@ PRIVACY_REQUEST_DENY = "/privacy-request/administrate/deny"
 REQUEST_STATUS_LOGS = "/privacy-request/{privacy_request_id}/log"
 PRIVACY_REQUEST_RESUME = "/privacy-request/{privacy_request_id}/resume"
 PRIVACY_REQUEST_MANUAL_INPUT = "/privacy-request/{privacy_request_id}/manual_input"
+PRIVACY_REQUEST_MANUAL_ERASURE = "/privacy-request/{privacy_request_id}/erasure_confirm"
 REQUEST_PREVIEW = "/privacy-request/preview"
 
 # Rule URLs

--- a/src/fidesops/models/policy.py
+++ b/src/fidesops/models/policy.py
@@ -25,6 +25,11 @@ from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.util.data_category import _validate_data_category
 
 
+class PausedStep(EnumType):
+    access = "access"
+    erasure = "erasure"
+
+
 class ActionType(str, EnumType):
     """The purpose of a particular privacy request"""
 

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -21,6 +21,7 @@ from fidesops.models.client import ClientDetail
 from fidesops.models.fidesops_user import FidesopsUser
 from fidesops.models.policy import (
     ActionType,
+    PausedStep,
     Policy,
     PolicyPreWebhook,
     WebhookDirection,
@@ -232,7 +233,7 @@ class PrivacyRequest(Base):
 
     def cache_paused_step_and_collection(
         self,
-        paused_step: Optional[ActionType] = None,
+        paused_step: Optional[PausedStep] = None,
         paused_collection: Optional[CollectionAddress] = None,
     ) -> None:
         """
@@ -257,7 +258,7 @@ class PrivacyRequest(Base):
 
     def get_paused_step_and_collection(
         self,
-    ) -> Tuple[Optional[ActionType], Optional[CollectionAddress]]:
+    ) -> Tuple[Optional[PausedStep], Optional[CollectionAddress]]:
         """Get both the paused step (access or erasure) and collection awaiting manual input for the given privacy request.
 
         The paused step lets us know if we should resume privacy request execution from the "access" or the "erasure"
@@ -269,7 +270,7 @@ class PrivacyRequest(Base):
 
         if node_addr:
             split_addr = node_addr.split(self.PAUSED_SEPARATOR)
-            return ActionType(split_addr[0]), CollectionAddress.from_string(
+            return PausedStep(split_addr[0]), CollectionAddress.from_string(
                 split_addr[1]
             )
         return None, None  # If no cached data, return a tuple of Nones
@@ -309,8 +310,7 @@ class PrivacyRequest(Base):
     def get_manual_erasure_count(self, collection: CollectionAddress) -> Optional[int]:
         """Retrieve number of rows manually masked for this collection from the cache.
 
-        The count isn't actually used, we mainly care that data exists for this
-        collection at all. If there's no data, we return None.
+        Cached as an integer to mimic what we return from erasures in an automated way.
         """
         cache: FidesopsRedis = get_cache()
         prefix = f"MANUAL_MASK__{self.id}__{collection.value}"

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -295,6 +295,23 @@ class PrivacyRequest(Base):
             f"MANUAL_INPUT__{self.id}__{collection.value}"
         )
 
+    def cache_manual_erasure_result(
+        self, collection: CollectionAddress, count: int
+    ) -> None:
+        """Cache the number of rows updated for a given collection"""
+        cache: FidesopsRedis = get_cache()
+        cache.set_encoded_object(
+            f"MANUAL_MASK__{self.id}__{collection.value}",
+            count,
+        )
+
+    def get_manual_erasure_count(self, collection: CollectionAddress) -> Dict[str, int]:
+        """Retrieve number of rows manually masked for this collection."""
+        cache: FidesopsRedis = get_cache()
+        prefix = f"MANUAL_MASK__{self.id}__{collection.value}"
+        value_dict = cache.get_encoded_objects_by_prefix(prefix)
+        return value_dict
+
     def trigger_policy_webhook(self, webhook: WebhookTypes) -> None:
         """Trigger a request to a single customer-defined policy webhook. Raises an exception if webhook response
         should cause privacy request execution to stop.

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -299,7 +299,7 @@ class PrivacyRequest(Base):
     def cache_manual_erasure_count(
         self, collection: CollectionAddress, count: int
     ) -> None:
-        """Cache the number of rows manually updated for a given collection."""
+        """Cache the number of rows manually masked for a given collection."""
         cache: FidesopsRedis = get_cache()
         cache.set_encoded_object(
             f"MANUAL_MASK__{self.id}__{collection.value}",
@@ -307,14 +307,16 @@ class PrivacyRequest(Base):
         )
 
     def get_manual_erasure_count(self, collection: CollectionAddress) -> Optional[int]:
-        """Retrieve number of rows manually masked for this collection.
+        """Retrieve number of rows manually masked for this collection from the cache.
 
         The count isn't actually used, we mainly care that data exists for this
         collection at all. If there's no data, we return None.
         """
         cache: FidesopsRedis = get_cache()
         prefix = f"MANUAL_MASK__{self.id}__{collection.value}"
-        value_dict = cache.get_encoded_objects_by_prefix(prefix)
+        value_dict: Optional[Dict[str, int]] = cache.get_encoded_objects_by_prefix(
+            prefix
+        )
         return list(value_dict.values())[0] if value_dict else None
 
     def trigger_policy_webhook(self, webhook: WebhookTypes) -> None:

--- a/src/fidesops/models/privacy_request.py
+++ b/src/fidesops/models/privacy_request.py
@@ -295,10 +295,11 @@ class PrivacyRequest(Base):
             f"MANUAL_INPUT__{self.id}__{collection.value}"
         )
 
-    def cache_manual_erasure_result(
+    def cache_manual_erasure_count(
         self, collection: CollectionAddress, count: int
     ) -> None:
-        """Cache the number of rows updated for a given collection"""
+        """Cache the number of rows manually updated for a given collection.
+        """
         cache: FidesopsRedis = get_cache()
         cache.set_encoded_object(
             f"MANUAL_MASK__{self.id}__{collection.value}",
@@ -306,7 +307,9 @@ class PrivacyRequest(Base):
         )
 
     def get_manual_erasure_count(self, collection: CollectionAddress) -> Dict[str, int]:
-        """Retrieve number of rows manually masked for this collection."""
+        """Retrieve number of rows manually masked for this collection.
+        The count isn't as important as whether or not the collection has been cached.
+        """
         cache: FidesopsRedis = get_cache()
         prefix = f"MANUAL_MASK__{self.id}__{collection.value}"
         value_dict = cache.get_encoded_objects_by_prefix(prefix)

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -104,6 +104,8 @@ class ExecutionLogDetailResponse(ExecutionLogResponse):
 
 
 class RowCountRequest(BaseSchema):
+    """Schema for a user to manually confirm data erased for a collection"""
+
     row_count: int
 
 

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -103,6 +103,10 @@ class ExecutionLogDetailResponse(ExecutionLogResponse):
     dataset_name: Optional[str]
 
 
+class RowCountRequest(BaseSchema):
+    row_count: int
+
+
 class PrivacyRequestResponse(BaseSchema):
     """Schema to check the status of a PrivacyRequest"""
 

--- a/src/fidesops/service/connectors/manual_connector.py
+++ b/src/fidesops/service/connectors/manual_connector.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from fidesops.common_exceptions import PrivacyRequestPaused
 from fidesops.graph.traversal import TraversalNode
-from fidesops.models.policy import ActionType, Policy
+from fidesops.models.policy import PausedStep, Policy
 from fidesops.models.privacy_request import PrivacyRequest
 from fidesops.service.connectors.base_connector import BaseConnector
 from fidesops.util.collection_util import Row
@@ -45,7 +45,7 @@ class ManualConnector(BaseConnector[None]):
 
         # Save the step (access) and collection where we're paused.
         privacy_request.cache_paused_step_and_collection(
-            ActionType.access, node.address
+            PausedStep.access, node.address
         )
         raise PrivacyRequestPaused(
             f"Collection '{node.address.value}' waiting on manual data for privacy request '{privacy_request.id}'"
@@ -69,7 +69,7 @@ class ManualConnector(BaseConnector[None]):
             return manual_cached_count
 
         privacy_request.cache_paused_step_and_collection(
-            ActionType.erasure, node.address
+            PausedStep.erasure, node.address
         )
         raise PrivacyRequestPaused(
             f"Collection '{node.address.value}' waiting on manual erasure confirmation for privacy request '{privacy_request.id}'"

--- a/src/fidesops/service/connectors/manual_connector.py
+++ b/src/fidesops/service/connectors/manual_connector.py
@@ -35,13 +35,13 @@ class ManualConnector(BaseConnector[None]):
         """
         Returns manually added data for the given collection if it exists, otherwise pauses the Privacy Request.
         """
-        cached_results: Optional[
-            Dict[str, Optional[List[Row]]]
-        ] = privacy_request.get_manual_input(node.address)
+        cached_results: Optional[List[Row]] = privacy_request.get_manual_input(
+            node.address
+        )
 
-        if cached_results:
+        if cached_results is not None:  # None check intentional
             privacy_request.cache_paused_step_and_collection()  # Caches paused location as None
-            return list(cached_results.values())[0]
+            return cached_results
 
         # Save the step (access) and collection where we're paused.
         privacy_request.cache_paused_step_and_collection(
@@ -58,16 +58,18 @@ class ManualConnector(BaseConnector[None]):
         privacy_request: PrivacyRequest,
         rows: List[Row],
     ) -> Optional[int]:
-        """Pause to have the user manually perform an erasure of data at the given node."""
-        cached_count: Dict[
-            Optional[str], Optional[int]
-        ] = privacy_request.get_manual_erasure_count(node.address)
+        """If erasure confirmation has been added to the manual cache, continue, otherwise,
+        pause and wait for manual input."""
+        manual_cached_count: Optional[int] = privacy_request.get_manual_erasure_count(
+            node.address
+        )
 
-        if cached_count:
+        if (
+            manual_cached_count is not None
+        ):  # Checking for None because it is possible the count is 0
             privacy_request.cache_paused_step_and_collection()  # Caches paused location as None
-            return list(cached_count.values())[0]
+            return manual_cached_count
 
-        # Save the step (erasure) and collection where we're paused.
         privacy_request.cache_paused_step_and_collection(
             ActionType.erasure, node.address
         )

--- a/src/fidesops/service/connectors/manual_connector.py
+++ b/src/fidesops/service/connectors/manual_connector.py
@@ -59,4 +59,18 @@ class ManualConnector(BaseConnector[None]):
         rows: List[Row],
     ) -> int:
         """Pause to have the user manually perform an erasure of data at the given node."""
-        # TODO implement in follow-up ticket
+        cached_count: Dict[
+            Optional[str], Optional[int]
+        ] = privacy_request.get_manual_erasure_count(node.address)
+
+        if cached_count:
+            privacy_request.cache_paused_step_and_collection()  # Caches paused location as None
+            return list(cached_count.values())[0]
+
+        # Save the step (erasure) and collection where we're paused.
+        privacy_request.cache_paused_step_and_collection(
+            ActionType.erasure, node.address
+        )
+        raise PrivacyRequestPaused(
+            f"Collection '{node.address.value}' waiting on manual erasure confirmation for privacy request '{privacy_request.id}'"
+        )

--- a/src/fidesops/service/connectors/manual_connector.py
+++ b/src/fidesops/service/connectors/manual_connector.py
@@ -39,7 +39,7 @@ class ManualConnector(BaseConnector[None]):
             node.address
         )
 
-        if cached_results is not None:  # None check intentional
+        if cached_results is not None:  # None comparison intentional
             privacy_request.cache_paused_step_and_collection()  # Caches paused location as None
             return cached_results
 
@@ -64,9 +64,7 @@ class ManualConnector(BaseConnector[None]):
             node.address
         )
 
-        if (
-            manual_cached_count is not None
-        ):  # Checking for None because it is possible the count is 0
+        if manual_cached_count is not None:  # None comparison intentional
             privacy_request.cache_paused_step_and_collection()  # Caches paused location as None
             return manual_cached_count
 

--- a/src/fidesops/service/connectors/manual_connector.py
+++ b/src/fidesops/service/connectors/manual_connector.py
@@ -57,7 +57,7 @@ class ManualConnector(BaseConnector[None]):
         policy: Policy,
         privacy_request: PrivacyRequest,
         rows: List[Row],
-    ) -> int:
+    ) -> Optional[int]:
         """Pause to have the user manually perform an erasure of data at the given node."""
         cached_count: Dict[
             Optional[str], Optional[int]

--- a/src/fidesops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/service/privacy_request/request_runner_service.py
@@ -14,6 +14,7 @@ from fidesops.models.connectionconfig import ConnectionConfig
 from fidesops.models.datasetconfig import DatasetConfig
 from fidesops.models.policy import (
     ActionType,
+    PausedStep,
     Policy,
     PolicyPostWebhook,
     PolicyPreWebhook,
@@ -98,7 +99,7 @@ class PrivacyRequestRunner:
     def submit(
         self,
         from_webhook: Optional[PolicyPreWebhook] = None,
-        from_step: Optional[ActionType] = None,
+        from_step: Optional[PausedStep] = None,
     ) -> Awaitable[None]:
         """Run this privacy request in a separate thread."""
         from_webhook_id = from_webhook.id if from_webhook else None
@@ -108,7 +109,7 @@ class PrivacyRequestRunner:
         self,
         privacy_request_id: str,
         from_webhook_id: Optional[str] = None,
-        from_step: Optional[ActionType] = None,
+        from_step: Optional[PausedStep] = None,
     ) -> None:
         # pylint: disable=too-many-locals
         """
@@ -155,7 +156,7 @@ class PrivacyRequestRunner:
                 connection_configs = ConnectionConfig.all(db=session)
 
                 if (
-                    not from_step == ActionType.erasure
+                    not from_step == PausedStep.erasure
                 ):  # Skip if we're resuming from erasure step
                     access_result: Dict[str, List[Row]] = run_access_request(
                         privacy_request=privacy_request,

--- a/src/fidesops/task/graph_task.py
+++ b/src/fidesops/task/graph_task.py
@@ -36,7 +36,7 @@ from fidesops.util.saas_util import FIDESOPS_GROUPED_INPUTS
 
 logger = logging.getLogger(__name__)
 
-dask.config.set(scheduler="synchronous")
+dask.config.set(scheduler="threads")
 
 EMPTY_REQUEST = PrivacyRequest()
 COLLECTION_FIELD_PATH_MAP = Dict[CollectionAddress, List[Tuple[FieldPath, FieldPath]]]
@@ -599,8 +599,7 @@ def update_erasure_mapping_from_cache(
 
     If there's no cached data, the dsk dictionary won't change.
     """
-
-    cached_erasures: Dict[str, List[Row]] = resources.get_all_cached_erasures()
+    cached_erasures: Dict[str, int] = resources.get_all_cached_erasures()
 
     for collection_name in cached_erasures:
         dsk[CollectionAddress.from_string(collection_name)] = (

--- a/src/fidesops/task/task_resources.py
+++ b/src/fidesops/task/task_resources.py
@@ -130,6 +130,21 @@ class TaskResources:
         # extract request id to return a map of address:value
         return {k.split("__")[-1]: v for k, v in value_dict.items()}
 
+    def cache_erasure(self, key: str, value: Any) -> None:
+        """Cache that a node's erasure is complete. Object will be stored in redis under
+        'REQUEST_ID__erasure_request__ADDRESS'"""
+        self.cache.set_encoded_object(
+            f"{self.request.id}__erasure_request__{key}", value
+        )
+
+    def get_all_cached_erasures(self) -> Dict[str, Optional[Any]]:
+        """Retrieve the results of all steps (cache_erasure)"""
+        value_dict = self.cache.get_encoded_objects_by_prefix(
+            f"{self.request.id}__erasure_request"
+        )
+        # extract request id to return a map of address:value
+        return {k.split("__")[-1]: v for k, v in value_dict.items()}
+
     def write_execution_log(  # pylint: disable=too-many-arguments
         self,
         collection_address: CollectionAddress,

--- a/src/fidesops/task/task_resources.py
+++ b/src/fidesops/task/task_resources.py
@@ -130,15 +130,16 @@ class TaskResources:
         # extract request id to return a map of address:value
         return {k.split("__")[-1]: v for k, v in value_dict.items()}
 
-    def cache_erasure(self, key: str, value: Any) -> None:
-        """Cache that a node's erasure is complete. Object will be stored in redis under
-        'REQUEST_ID__erasure_request__ADDRESS'"""
+    def cache_erasure(self, key: str, value: int) -> None:
+        """Cache that a node's masking is complete. Object will be stored in redis under
+        'REQUEST_ID__erasure_request__ADDRESS
+        '"""
         self.cache.set_encoded_object(
             f"{self.request.id}__erasure_request__{key}", value
         )
 
-    def get_all_cached_erasures(self) -> Dict[str, Optional[Any]]:
-        """Retrieve the results of all steps (cache_erasure)"""
+    def get_all_cached_erasures(self) -> Dict[str, int]:
+        """Retrieve which collections have been masked and their row counts(cache_erasure)"""
         value_dict = self.cache.get_encoded_objects_by_prefix(
             f"{self.request.id}__erasure_request"
         )

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1811,7 +1811,7 @@ class TestResumeErasureRequestWithManualConfirmation:
         assert response.status_code == 400
         assert (
             response.json()["detail"]
-            == f"Invalid resume request: privacy request '{privacy_request.id}' status = in_processing."
+            == f"Invalid resume request: privacy request '{privacy_request.id}' status = in_processing. Privacy request is not paused."
         )
 
     def test_manual_resume_privacy_request_no_paused_location(
@@ -1859,15 +1859,13 @@ class TestResumeErasureRequestWithManualConfirmation:
         )
         response = api_client.post(url, headers=auth_header, json={"row_count": 0})
         assert response.status_code == 400
-        import pdb
 
-        pdb.set_trace()
         assert (
             response.json()["detail"]
             == "Collection 'manual_example:filing_cabinet' is paused at the access step. Pass in manual data instead to '/privacy-request/{privacy_request_id}/manual_input' to resume."
         )
 
-    def test_resume_with_manual_input(
+    def test_resume_with_manual_count(
         self,
         db,
         api_client,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1865,6 +1865,9 @@ class TestResumeErasureRequestWithManualConfirmation:
             == "Collection 'manual_example:filing_cabinet' is paused at the access step. Pass in manual data instead to '/privacy-request/{privacy_request_id}/manual_input' to resume."
         )
 
+    @mock.patch(
+        "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.submit"
+    )
     def test_resume_with_manual_count(
         self,
         db,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1870,6 +1870,7 @@ class TestResumeErasureRequestWithManualConfirmation:
     )
     def test_resume_with_manual_count(
         self,
+        submit_mock,
         db,
         api_client,
         url,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1657,7 +1657,7 @@ class TestResumeAccessRequestWithManualInput:
         assert response.status_code == 400
         assert (
             response.json()["detail"]
-            == f"Cannot resume privacy request '{privacy_request.id}'; no paused collection."
+            == f"Cannot resume privacy request '{privacy_request.id}'; no paused collection or no paused step."
         )
 
     def test_resume_with_manual_input_collection_has_changed(
@@ -1788,7 +1788,7 @@ class TestValidateManualInput:
 
 class TestResumeErasureRequestWithManualConfirmation:
     @pytest.fixture(scope="function")
-    def url(self, db, privacy_request):
+    def url(self, privacy_request):
         return V1_URL_PREFIX + PRIVACY_REQUEST_MANUAL_ERASURE.format(
             privacy_request_id=privacy_request.id
         )
@@ -1825,7 +1825,7 @@ class TestResumeErasureRequestWithManualConfirmation:
         assert response.status_code == 400
         assert (
             response.json()["detail"]
-            == f"Cannot resume privacy request '{privacy_request.id}'; no paused collection."
+            == f"Cannot resume privacy request '{privacy_request.id}'; no paused collection or no paused step."
         )
 
     def test_resume_with_manual_erasure_confirmation_collection_has_changed(
@@ -1865,19 +1865,20 @@ class TestResumeErasureRequestWithManualConfirmation:
             == "Collection 'manual_example:filing_cabinet' is paused at the access step. Pass in manual data instead to '/privacy-request/{privacy_request_id}/manual_input' to resume."
         )
 
+    @pytest.mark.usefixtures(
+        "postgres_example_test_dataset_config", "manual_dataset_config"
+    )
     @mock.patch(
         "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.submit"
     )
     def test_resume_with_manual_count(
         self,
-        submit_mock,
+        _,
         db,
         api_client,
         url,
         generate_auth_header,
         privacy_request,
-        postgres_example_test_dataset_config,
-        manual_dataset_config,
     ):
         auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
         privacy_request.status = PrivacyRequestStatus.paused

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -564,10 +564,7 @@ def policy_drp_action(
 
 
 @pytest.fixture(scope="function")
-def policy_drp_action_erasure(
-    db: Session,
-    oauth_client: ClientDetail
-) -> Generator:
+def policy_drp_action_erasure(db: Session, oauth_client: ClientDetail) -> Generator:
     erasure_request_policy = Policy.create(
         db=db,
         data={

--- a/tests/fixtures/manual_fixtures.py
+++ b/tests/fixtures/manual_fixtures.py
@@ -20,7 +20,7 @@ def integration_manual_config(db) -> ConnectionConfig:
             "name": str(uuid4()),
             "key": "manual_example",
             "connection_type": ConnectionType.manual,
-            "access": AccessLevel.read,
+            "access": AccessLevel.write
         },
     )
     yield connection_config

--- a/tests/fixtures/manual_fixtures.py
+++ b/tests/fixtures/manual_fixtures.py
@@ -20,7 +20,7 @@ def integration_manual_config(db) -> ConnectionConfig:
             "name": str(uuid4()),
             "key": "manual_example",
             "connection_type": ConnectionType.manual,
-            "access": AccessLevel.write
+            "access": AccessLevel.write,
         },
     )
     yield connection_config

--- a/tests/integration_tests/test_manual_task.py
+++ b/tests/integration_tests/test_manual_task.py
@@ -1,4 +1,5 @@
 import uuid
+
 import pytest
 
 from fidesops.common_exceptions import PrivacyRequestPaused

--- a/tests/integration_tests/test_manual_task.py
+++ b/tests/integration_tests/test_manual_task.py
@@ -4,7 +4,7 @@ import pytest
 
 from fidesops.common_exceptions import PrivacyRequestPaused
 from fidesops.graph.config import CollectionAddress
-from fidesops.models.policy import ActionType
+from fidesops.models.policy import PausedStep
 from fidesops.models.privacy_request import (
     ExecutionLog,
     ExecutionLogStatus,
@@ -42,7 +42,7 @@ def test_postgres_with_manual_input_access_request_task(
 
     request_type, paused_node = privacy_request.get_paused_step_and_collection()
     assert paused_node.value == "manual_example:storage_unit"
-    assert request_type == ActionType.access
+    assert request_type == PausedStep.access
 
     # Mock user retrieving storage unit data by adding manual data to cache
     privacy_request.cache_manual_input(
@@ -209,7 +209,7 @@ def test_no_manual_input_found(
         )
 
     request_type, paused_node = privacy_request.get_paused_step_and_collection()
-    assert request_type == ActionType.access
+    assert request_type == PausedStep.access
     assert paused_node.value == "manual_example:storage_unit"
 
     # Mock user retrieving storage unit data by adding manual data to cache,
@@ -271,12 +271,9 @@ def test_no_manual_input_found(
 @pytest.mark.integration_postgres
 @pytest.mark.integration
 def test_collections_with_manual_erasure_confirmation(
-    db,
     policy,
     integration_postgres_config,
     integration_manual_config,
-    postgres_integration_db,
-    cache,
 ) -> None:
     """Run an erasure privacy request with two manual nodes"""
     privacy_request = PrivacyRequest(
@@ -365,7 +362,7 @@ def test_collections_with_manual_erasure_confirmation(
 
     request_type, paused_node = privacy_request.get_paused_step_and_collection()
     assert paused_node.value == "manual_example:filing_cabinet"
-    assert request_type == ActionType.erasure
+    assert request_type == PausedStep.erasure
 
     # Mock confirming from user that there was no data in the filing cabinet
     privacy_request.cache_manual_erasure_count(
@@ -386,7 +383,7 @@ def test_collections_with_manual_erasure_confirmation(
 
     request_type, paused_node = privacy_request.get_paused_step_and_collection()
     assert paused_node.value == "manual_example:storage_unit"
-    assert request_type == ActionType.erasure
+    assert request_type == PausedStep.erasure
 
     # Mock confirming from user that storage unit erasure is complete
     privacy_request.cache_manual_erasure_count(

--- a/tests/integration_tests/test_manual_task.py
+++ b/tests/integration_tests/test_manual_task.py
@@ -11,7 +11,6 @@ from fidesops.models.privacy_request import (
     PrivacyRequest,
 )
 from fidesops.task import graph_task
-from fidesops.task.graph_task import get_cached_data_for_erasures
 
 from ..graph.graph_test_util import assert_rows_match
 from ..task.traversal_data import postgres_and_manual_nodes
@@ -369,7 +368,7 @@ def test_collections_with_manual_erasure_confirmation(
     assert request_type == ActionType.erasure
 
     # Mock confirming from user that there was no data in the filing cabinet
-    privacy_request.cache_manual_erasure_result(
+    privacy_request.cache_manual_erasure_count(
         CollectionAddress.from_string("manual_example:filing_cabinet"),
         0,
     )
@@ -390,7 +389,7 @@ def test_collections_with_manual_erasure_confirmation(
     assert request_type == ActionType.erasure
 
     # Mock confirming from user that storage unit erasure is complete
-    privacy_request.cache_manual_erasure_result(
+    privacy_request.cache_manual_erasure_count(
         CollectionAddress.from_string("manual_example:storage_unit"), 1
     )
 

--- a/tests/integration_tests/test_manual_task.py
+++ b/tests/integration_tests/test_manual_task.py
@@ -1,5 +1,4 @@
 import uuid
-
 import pytest
 
 from fidesops.common_exceptions import PrivacyRequestPaused
@@ -11,6 +10,7 @@ from fidesops.models.privacy_request import (
     PrivacyRequest,
 )
 from fidesops.task import graph_task
+from fidesops.task.graph_task import get_cached_data_for_erasures
 
 from ..graph.graph_test_util import assert_rows_match
 from ..task.traversal_data import postgres_and_manual_nodes
@@ -266,3 +266,148 @@ def test_no_manual_input_found(
     request_type, paused_node = privacy_request.get_paused_step_and_collection()
     assert request_type is None
     assert paused_node is None
+
+
+@pytest.mark.integration_postgres
+@pytest.mark.integration
+def test_collections_with_manual_erasure_confirmation(
+    db,
+    policy,
+    integration_postgres_config,
+    integration_manual_config,
+    postgres_integration_db,
+    cache,
+) -> None:
+    """Run an erasure privacy request with two manual nodes"""
+    privacy_request = PrivacyRequest(
+        id=f"test_postgres_access_request_task_{uuid.uuid4()}"
+    )
+
+    cached_data_for_erasures = {
+        "postgres_example:payment_card": [
+            {
+                "id": "pay_aaa-aaa",
+                "name": "Example Card 1",
+                "ccn": 123456789,
+                "customer_id": 1,
+                "billing_address_id": 1,
+            },
+            {
+                "id": "pay_bbb-bbb",
+                "name": "Example Card 2",
+                "ccn": 987654321,
+                "customer_id": 2,
+                "billing_address_id": 1,
+            },
+        ],
+        "postgres_example:address": [
+            {
+                "id": 1,
+                "street": "Example Street",
+                "city": "Exampletown",
+                "state": "NY",
+                "zip": "12345",
+            },
+            {
+                "id": 2,
+                "street": "Example Lane",
+                "city": "Exampletown",
+                "state": "NY",
+                "zip": "12321",
+            },
+        ],
+        "postgres_example:customer": [
+            {
+                "id": 1,
+                "name": "John Customer",
+                "email": "customer-1@example.com",
+                "address_id": 1,
+            }
+        ],
+        "manual_example:filing_cabinet": [
+            {"id": 1, "authorized_user": "Jane Doe", "payment_card_id": "pay_bbb-bbb"}
+        ],
+        "manual_example:storage_unit": [
+            {"box_id": 5, "email": "customer-1@example.com"}
+        ],
+        "postgres_example:orders": [
+            {
+                "id": "ord_aaa-aaa",
+                "customer_id": 1,
+                "shipping_address_id": 2,
+                "payment_card_id": "pay_aaa-aaa",
+            },
+            {
+                "id": "ord_ccc-ccc",
+                "customer_id": 1,
+                "shipping_address_id": 1,
+                "payment_card_id": "pay_aaa-aaa",
+            },
+            {
+                "id": "ord_ddd-ddd",
+                "customer_id": 1,
+                "shipping_address_id": 1,
+                "payment_card_id": "pay_bbb-bbb",
+            },
+        ],
+    }
+
+    # ATTEMPT 1 - erasure request will pause to wait for confirmation that data has been destroyed from the filing cabinet
+    with pytest.raises(PrivacyRequestPaused):
+        graph_task.run_erasure(
+            privacy_request,
+            policy,
+            postgres_and_manual_nodes("postgres_example", "manual_example"),
+            [integration_postgres_config, integration_manual_config],
+            {"email": "customer-1@example.com"},
+            cached_data_for_erasures,
+        )
+
+    request_type, paused_node = privacy_request.get_paused_step_and_collection()
+    assert paused_node.value == "manual_example:filing_cabinet"
+    assert request_type == ActionType.erasure
+
+    # Mock confirming from user that there was no data in the filing cabinet
+    privacy_request.cache_manual_erasure_result(
+        CollectionAddress.from_string("manual_example:filing_cabinet"),
+        0,
+    )
+
+    # Attempt 2 - erasure request will pause, waiting for confirmation that the box in the storage unit is destroyed.
+    with pytest.raises(PrivacyRequestPaused):
+        graph_task.run_erasure(
+            privacy_request,
+            policy,
+            postgres_and_manual_nodes("postgres_example", "manual_example"),
+            [integration_postgres_config, integration_manual_config],
+            {"email": "customer-1@example.com"},
+            cached_data_for_erasures,
+        )
+
+    request_type, paused_node = privacy_request.get_paused_step_and_collection()
+    assert paused_node.value == "manual_example:storage_unit"
+    assert request_type == ActionType.erasure
+
+    # Mock confirming from user that storage unit erasure is complete
+    privacy_request.cache_manual_erasure_result(
+        CollectionAddress.from_string("manual_example:storage_unit"), 1
+    )
+
+    # Attempt 3 - We've confirmed data has been removed for manual nodes so we can proceed with the rest of the erasure
+    v = graph_task.run_erasure(
+        privacy_request,
+        policy,
+        postgres_and_manual_nodes("postgres_example", "manual_example"),
+        [integration_postgres_config, integration_manual_config],
+        {"email": "customer-1@example.com"},
+        cached_data_for_erasures,
+    )
+
+    assert v == {
+        "postgres_example:customer": 0,
+        "manual_example:storage_unit": 1,
+        "postgres_example:payment_card": 0,
+        "postgres_example:orders": 0,
+        "postgres_example:address": 0,
+        "manual_example:filing_cabinet": 0,
+    }

--- a/tests/models/test_privacy_request.py
+++ b/tests/models/test_privacy_request.py
@@ -14,7 +14,6 @@ from fidesops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
 from fidesops.util.cache import FidesopsRedis, get_identity_cache_key
 
-
 paused_location = CollectionAddress("test_dataset", "test_collection")
 
 
@@ -386,30 +385,25 @@ class TestCacheManualInput:
         manual_data = [{"id": 1, "name": "Jane"}, {"id": 2, "name": "Hank"}]
 
         privacy_request.cache_manual_input(paused_location, manual_data)
-
-        assert privacy_request.get_manual_input(paused_location,) == {
-            f"EN_MANUAL_INPUT__{privacy_request.id}__{paused_location.value}": manual_data
-        }
+        assert privacy_request.get_manual_input(paused_location,) == manual_data
 
     def test_cache_empty_manual_input(self, privacy_request):
         manual_data = []
-
         privacy_request.cache_manual_input(paused_location, manual_data)
 
         assert (
             privacy_request.get_manual_input(
                 paused_location,
             )
-            == {f"EN_MANUAL_INPUT__{privacy_request.id}__{paused_location.value}": []}
+            == []
         )
 
     def test_no_manual_data_in_cache(self, privacy_request):
-
         assert (
             privacy_request.get_manual_input(
                 paused_location,
             )
-            == {}
+            is None
         )
 
 
@@ -419,9 +413,13 @@ class TestCacheManualErasureCount:
         privacy_request.cache_manual_erasure_count(paused_location, 5)
 
         cached_data = privacy_request.get_manual_erasure_count(paused_location)
-        assert len(cached_data.keys()) == 1
-        assert list(cached_data.values())[0] == 5
+        assert cached_data == 5
 
     def test_no_erasure_data_cached(self, privacy_request):
         cached_data = privacy_request.get_manual_erasure_count(paused_location)
-        assert cached_data == {}
+        assert cached_data is None
+
+    def test_zero_cached(self, privacy_request):
+        privacy_request.cache_manual_erasure_count(paused_location, 0)
+        cached_data = privacy_request.get_manual_erasure_count(paused_location)
+        assert cached_data == 0

--- a/tests/models/test_privacy_request.py
+++ b/tests/models/test_privacy_request.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from fidesops.common_exceptions import ClientUnsuccessfulException, PrivacyRequestPaused
 from fidesops.graph.config import CollectionAddress
-from fidesops.models.policy import ActionType, Policy
+from fidesops.models.policy import PausedStep, Policy
 from fidesops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
 from fidesops.util.cache import FidesopsRedis, get_identity_cache_key
@@ -366,7 +366,7 @@ class TestCachePausedLocation:
     def test_privacy_request_cache_paused_location(self, privacy_request):
         assert privacy_request.get_paused_step_and_collection() == (None, None)
 
-        paused_step = ActionType.erasure
+        paused_step = PausedStep.erasure
         privacy_request.cache_paused_step_and_collection(paused_step, paused_location)
 
         assert privacy_request.get_paused_step_and_collection() == (

--- a/tests/models/test_privacy_request.py
+++ b/tests/models/test_privacy_request.py
@@ -385,7 +385,12 @@ class TestCacheManualInput:
         manual_data = [{"id": 1, "name": "Jane"}, {"id": 2, "name": "Hank"}]
 
         privacy_request.cache_manual_input(paused_location, manual_data)
-        assert privacy_request.get_manual_input(paused_location,) == manual_data
+        assert (
+            privacy_request.get_manual_input(
+                paused_location,
+            )
+            == manual_data
+        )
 
     def test_cache_empty_manual_input(self, privacy_request):
         manual_data = []
@@ -408,7 +413,6 @@ class TestCacheManualInput:
 
 
 class TestCacheManualErasureCount:
-
     def test_cache_manual_erasure_count(self, privacy_request):
         privacy_request.cache_manual_erasure_count(paused_location, 5)
 

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from fidesops.common_exceptions import ClientUnsuccessfulException, PrivacyRequestPaused
 from fidesops.core.config import config
 from fidesops.db.session import get_db_session
-from fidesops.models.policy import PolicyPostWebhook
+from fidesops.models.policy import PausedStep, PolicyPostWebhook
 from fidesops.models.privacy_request import (
     ActionType,
     ExecutionLog,
@@ -100,7 +100,7 @@ def test_from_graph_resume_does_not_run_pre_webhooks(
     privacy_request.save(db)
 
     privacy_request.started_processing_at = None
-    wait_for(privacy_request_runner.submit(from_step=ActionType.access))
+    wait_for(privacy_request_runner.submit(from_step=PausedStep.access))
 
     _sessionmaker = get_db_session()
     db = _sessionmaker()
@@ -136,7 +136,7 @@ def test_resume_privacy_request_from_erasure(
     privacy_request.policy = erasure_policy
     privacy_request.save(db)
 
-    wait_for(privacy_request_runner.submit(from_step=ActionType.erasure))
+    wait_for(privacy_request_runner.submit(from_step=PausedStep.erasure))
 
     _sessionmaker = get_db_session()
     db = _sessionmaker()

--- a/tests/service/privacy_request/request_runner_service_test.py
+++ b/tests/service/privacy_request/request_runner_service_test.py
@@ -80,14 +80,25 @@ def test_start_processing_doesnt_overwrite_started_processing_at(
 
 
 @mock.patch(
-    "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.run_webhooks_and_report_status"
+    "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.run_webhooks_and_report_status",
 )
+@mock.patch(
+    "fidesops.service.privacy_request.request_runner_service.run_access_request"
+)
+@mock.patch("fidesops.service.privacy_request.request_runner_service.run_erasure")
 def test_from_graph_resume_does_not_run_pre_webhooks(
+    run_erasure,
+    run_access,
     run_webhooks,
     db: Session,
     privacy_request: PrivacyRequest,
     privacy_request_runner: PrivacyRequestRunner,
+    erasure_policy,
 ) -> None:
+    privacy_request.started_processing_at = None
+    privacy_request.policy = erasure_policy
+    privacy_request.save(db)
+
     privacy_request.started_processing_at = None
     wait_for(privacy_request_runner.submit(from_step=ActionType.access))
 
@@ -100,6 +111,45 @@ def test_from_graph_resume_does_not_run_pre_webhooks(
     # Starting privacy request in the middle of the graph means we don't run pre-webhooks again
     assert run_webhooks.call_count == 1
     assert run_webhooks.call_args[1]["webhook_cls"] == PolicyPostWebhook
+
+    assert run_access.call_count == 1  # Access request runs
+    assert run_erasure.call_count == 1  # Erasure request runs
+
+
+@mock.patch(
+    "fidesops.service.privacy_request.request_runner_service.PrivacyRequestRunner.run_webhooks_and_report_status",
+)
+@mock.patch(
+    "fidesops.service.privacy_request.request_runner_service.run_access_request"
+)
+@mock.patch("fidesops.service.privacy_request.request_runner_service.run_erasure")
+def test_resume_privacy_request_from_erasure(
+    run_erasure,
+    run_access,
+    run_webhooks,
+    db: Session,
+    privacy_request: PrivacyRequest,
+    privacy_request_runner: PrivacyRequestRunner,
+    erasure_policy,
+) -> None:
+    privacy_request.started_processing_at = None
+    privacy_request.policy = erasure_policy
+    privacy_request.save(db)
+
+    wait_for(privacy_request_runner.submit(from_step=ActionType.erasure))
+
+    _sessionmaker = get_db_session()
+    db = _sessionmaker()
+
+    privacy_request = PrivacyRequest.get(db=db, id=privacy_request.id)
+    assert privacy_request.started_processing_at is not None
+
+    # Starting privacy request in the middle of the graph means we don't run pre-webhooks again
+    assert run_webhooks.call_count == 1
+    assert run_webhooks.call_args[1]["webhook_cls"] == PolicyPostWebhook
+
+    assert run_access.call_count == 0  # Access request skipped
+    assert run_erasure.call_count == 1  # Erasure request runs
 
 
 def get_privacy_request_results(

--- a/tests/task/test_task_resources.py
+++ b/tests/task/test_task_resources.py
@@ -1,0 +1,16 @@
+from fidesops.task.task_resources import TaskResources
+
+
+class TestTaskResources:
+    def test_cache_erasure(self, privacy_request, policy, integration_manual_config):
+        resources = TaskResources(privacy_request, policy, [integration_manual_config])
+
+        assert resources.get_all_cached_erasures() == {}
+
+        resources.cache_erasure("manual_example:filing-cabinet", 2)
+        resources.cache_erasure("manual_example:storage-unit", 3)
+
+        assert resources.get_all_cached_erasures() == {
+            "manual_example:filing-cabinet": 2,
+            "manual_example:storage-unit": 3
+        }

--- a/tests/task/test_task_resources.py
+++ b/tests/task/test_task_resources.py
@@ -12,5 +12,5 @@ class TestTaskResources:
 
         assert resources.get_all_cached_erasures() == {
             "manual_example:filing-cabinet": 2,
-            "manual_example:storage-unit": 3
+            "manual_example:storage-unit": 3,
         }


### PR DESCRIPTION
➡️  Follow-up to #554. Follows same pattern, but for an erasure.

# Purpose

Some data cannot be automatically masked or destroyed.  During execution of a privacy request with configured erasures, pause on collections marked as manual and wait for the user to confirm that data has been removed or manually masked before proceeding.  

Resume a paused erasure request by passing in the masked count for the paused collection: 
`POST {{host}}/privacy-request/{{privacy_request_id}}/erasure_confirm`
```json
{
    "row_count": 5
}
```
This mirrors what we return in an automated way when masking collections.

# Changes
Big picture, changes added to store which nodes we've run erasures on as we run them, and separately to store which node we're currently paused on, as well as store manually-confirmed erasure counts. Finally, an endpoint is added to resume the privacy request from an erasure stage, more details below:

- Add an API endpoint to resume a privacy request that is paused at the _erasure_ stage
  - Dry up the logic to share between this and an endpoint that is paused at the _access_ stage.  These are separate endpoints because a single privacy request can run both access and erasures
- Update `graph_task.erasure_request` to cache the row count erased for each collection (similar to how we currently cache data retrieved for access requests).  The primary purpose of this is to track which collections we've already erased so the new graph doesn't visit them when we resume. 
- Add `update_erasure_mapping_from_cache` which modifies the graph if we need to restart to avoid running erasures on the collections we've already visited.  This is how "pausing" is effectively handled - we don't actually pause, but we force execution to stop when we hit a paused node, and then rebuild a different graph that just runs the remaining nodes on resume.
- Like access requests, force erasure tasks to run sequentially. With #554, A "Pause" now throws an exception and cancels all other tasks in the graph.   Running one at a time makes sure we don't close the session prematurely and affect other tasks in flight, potentially preventing execution logs from getting persisted for each collection.  There are other ways to do this, but we decided in #554 that this was a good path forward for now, seeing as we're already using `Dask Delayed` to execute the graph - its side effect is that an exception cancels all other tasks in the graph.
- Separately add methods to the PrivacyRequest to both cache manual erasure confirmations and retrieve them. These are used both when we resume a privacy request manually to see if we have the information needed to proceed.
- Add `ManualConnector.mask_data` which looks to see if a manual erasure confirmation has been added to the cache. Otherwise, it Pauses the graph.  When we rerun after the user adds the manual confirmation via the API, it finds that and proceeds with execution. 


# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Worth noting
- We have a separate ticket to surface to the user _how_ to perform this manual request, for both access and erasure.  For both access and erasure requests, the user needs to know the paused collection, and how to locate the record in question (this would be whatever data is passed to the manual node from upstream collections).  In addition, they might need to be given how to mask the record in question.  https://github.com/ethyca/fidesops/issues/570
- The current design makes erasures with manual data a two-step process (as erasures actually run both an access and an erasure).  First, the user will need to retrieve the record in question and enter in specific fields. Second, the user will need to manually mask or destroy that data and send in a confirmation.  If the data in question is something like a folder in a filing cabinet that needs to be destroyed, this feels like overkill.  On the other hand, the file in the filing cabinet might be needed to find data in some other collection, so the user needs to pass in its contents.  Additionally, the data may have more specific masking requirements beyond just destruction, hence the two-step process.   Further product refinement may be needed here.
  - This ticket doesn't surface to the user how to manually mask the data, that will be included in #570 

# Ticket

Fixes #522 
 
