### PR TITLE
bump to v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The types of changes are:
 * `Security` in case of vulnerabilities.
 
 
-## [Unreleased](https://github.com/ethyca/fidesops/compare/1.5.0...main)
+## [Unreleased](https://github.com/ethyca/fidesops/compare/1.5.1...main)
+
+## [1.5.1](https://github.com/ethyca/fidesops/compare/1.5.0...1.5.1)
 
 ### Added
 * Added `FIDESOPS__DATABASE__ENABLED` and `FIDESOPS__REDIS__ENABLED` configuration variables to allow `fidesops` to run cleanly in a "stateless" mode without any database or redis cache integration [#550](https://github.com/ethyca/fidesops/pull/550)


### PR DESCRIPTION
This PR bumps the changelog to version `1.5.1`, so that we can publish the `1.5.1` release and unblock @PSalant726.
 
