### PR TITLE
Return rules in privacy request response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.5.1...main)
 
+### Changed
+* Use the `RuleResponse` schema within the `PrivacyRequestReposnse` schema [#580](https://github.com/ethyca/fidesops/pull/580)
+
 ## [1.5.1](https://github.com/ethyca/fidesops/compare/1.5.0...1.5.1) - 2022-05-27
 
 ### Added

--- a/src/fidesops/schemas/privacy_request.py
+++ b/src/fidesops/schemas/privacy_request.py
@@ -9,7 +9,7 @@ from fidesops.models.policy import ActionType
 from fidesops.models.privacy_request import ExecutionLogStatus, PrivacyRequestStatus
 from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
 from fidesops.schemas.base_class import BaseSchema
-from fidesops.schemas.policy import Policy as PolicySchema
+from fidesops.schemas.policy import PolicyResponse as PolicySchema
 from fidesops.schemas.redis_cache import PrivacyRequestIdentity
 from fidesops.schemas.shared_schemas import FidesOpsKey
 from fidesops.schemas.user import PrivacyRequestReviewer

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -50,6 +50,7 @@ from fidesops.schemas.jwt import (
     JWE_PAYLOAD_CLIENT_ID,
     JWE_PAYLOAD_SCOPES,
 )
+from fidesops.schemas.policy import PolicyResponse
 from fidesops.schemas.masking.masking_secrets import SecretType
 from fidesops.util.cache import (
     get_encryption_cache_key,
@@ -484,6 +485,7 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
+                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
                     },
                 }
             ],
@@ -529,6 +531,7 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
+                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
                     },
                 }
             ],
@@ -826,6 +829,7 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
+                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
                     },
                     "results": {
                         "my-mongo-db": [
@@ -1611,6 +1615,7 @@ class TestResumePrivacyRequest:
                 "drp_action": None,
                 "key": privacy_request.policy.key,
                 "name": privacy_request.policy.name,
+                "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
             },
         }
 

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -50,8 +50,8 @@ from fidesops.schemas.jwt import (
     JWE_PAYLOAD_CLIENT_ID,
     JWE_PAYLOAD_SCOPES,
 )
-from fidesops.schemas.policy import PolicyResponse
 from fidesops.schemas.masking.masking_secrets import SecretType
+from fidesops.schemas.policy import PolicyResponse
 from fidesops.util.cache import (
     get_encryption_cache_key,
     get_identity_cache_key,
@@ -485,7 +485,12 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
-                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
+                        "rules": [
+                            rule.dict()
+                            for rule in PolicyResponse.from_orm(
+                                privacy_request.policy
+                            ).rules
+                        ],
                     },
                 }
             ],
@@ -531,7 +536,12 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
-                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
+                        "rules": [
+                            rule.dict()
+                            for rule in PolicyResponse.from_orm(
+                                privacy_request.policy
+                            ).rules
+                        ],
                     },
                 }
             ],
@@ -829,7 +839,12 @@ class TestGetPrivacyRequests:
                         "drp_action": None,
                         "name": privacy_request.policy.name,
                         "key": privacy_request.policy.key,
-                        "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
+                        "rules": [
+                            rule.dict()
+                            for rule in PolicyResponse.from_orm(
+                                privacy_request.policy
+                            ).rules
+                        ],
                     },
                     "results": {
                         "my-mongo-db": [
@@ -1615,7 +1630,10 @@ class TestResumePrivacyRequest:
                 "drp_action": None,
                 "key": privacy_request.policy.key,
                 "name": privacy_request.policy.name,
-                "rules": [rule.dict() for rule in PolicyResponse.from_orm(privacy_request.policy).rules],
+                "rules": [
+                    rule.dict()
+                    for rule in PolicyResponse.from_orm(privacy_request.policy).rules
+                ],
             },
         }
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -564,10 +564,7 @@ def policy_drp_action(
 
 
 @pytest.fixture(scope="function")
-def policy_drp_action_erasure(
-    db: Session,
-    oauth_client: ClientDetail
-) -> Generator:
+def policy_drp_action_erasure(db: Session, oauth_client: ClientDetail) -> Generator:
     erasure_request_policy = Policy.create(
         db=db,
         data={


### PR DESCRIPTION
# Purpose
Update the `PrivacyRequestResponse` schema to return `PolicyResponse` the schema instead of the `Policy` schema. This is so `RuleReponse` schema is returned. The admin ui needs `Rule` data to be surfaced in order to display the `action_types` of a given `PrivacyRequest`

# Changes
- Update the `PolicySchema` import to use `PolicyResponse`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #575 
 
