### PR TITLE
Check `tests/` directory in `black-ci` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 ### Changed
 * Use the `RuleResponse` schema within the `PrivacyRequestReposnse` schema [#580](https://github.com/ethyca/fidesops/pull/580)
 * Updated the webserver to use `PORT` config variable from the `fidesops.toml` file [#586](https://github.com/ethyca/fidesops/pull/586)
+* Updated `black-ci` makefile command to also check `tests/` directory [#594](https://github.com/ethyca/fidesops/pull/594)
 
 ### Developer Experience
 * Adds a script for MSSQL schema exploration [#557](https://github.com/ethyca/fidesops/pull/581)

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ check-all: isort-ci black-ci pylint mypy check-migrations pytest pytest-integrat
 black-ci: compose-build
 	@echo "Running black checks..."
 	@docker-compose run $(IMAGE_NAME) \
-		black --check src/ && black --check tests/ \
-		|| (echo "Error running 'black --check', please run 'make black' to format your code!"; exit 1)
+		black --check src/ tests/ \
+		|| (echo "Error running 'black --check src/ tests/', please run 'make black' to format your code!"; exit 1)
 	@make teardown
 
 check-migrations: compose-build
@@ -156,7 +156,7 @@ pytest-saas: compose-build
 .PHONY: black
 black: compose-build
 	@echo "Running black formatting against the src/ and tests/ directories..."
-	@docker-compose run $(IMAGE_NAME) black tests/ && black src/
+	@docker-compose run $(IMAGE_NAME) black src/ tests/
 	@make teardown
 	@echo "Fin"
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ check-all: isort-ci black-ci pylint mypy check-migrations pytest pytest-integrat
 black-ci: compose-build
 	@echo "Running black checks..."
 	@docker-compose run $(IMAGE_NAME) \
-		black --check src/ \
+		black --check src/ && black --check tests/ \
 		|| (echo "Error running 'black --check', please run 'make black' to format your code!"; exit 1)
 	@make teardown
 


### PR DESCRIPTION
# Purpose
Update `black-ci` command to also check `tests/` directory. This will align it with the `black` command that formats both `src/` and `tests/`

# Changes
- Update `black-ci` to also check `tests/`
- Simplify both black commands

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #593 
 
