### PR TITLE
Accept an arbitrary path to `/migrations` in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The types of changes are:
 * Subject Request Details page [#563](https://github.com/ethyca/fidesops/pull/563)
 * Restart Graph from Failure [#578](https://github.com/ethyca/fidesops/pull/578)
 
+### Changed
+* Specify an arbitrary path to database migrations with the `FIDESOPS__PACKAGE__MIGRATION_PATH` ENV variable, rather than a path to the package source [#613](https://github.com/ethyca/fidesops/pull/613)
+
 
 ## [1.5.2](https://github.com/ethyca/fidesops/compare/1.5.1...1.5.2)
 

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -1,4 +1,4 @@
-PORT=8080
+PORT = 8080
 
 [database]
 SERVER = "db"

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -264,11 +264,11 @@ class FidesopsConfig(FidesSettings):
     class Config:  # pylint: disable=C0115
         case_sensitive = True
 
-    logger.warning(
+    logger.debug(
         f"Startup configuration: reloading = {hot_reloading}, dev_mode = {dev_mode}"
     )
-    logger.warning(
-        f'Startup configuration: pii logging = {os.getenv("FIDESOPS__LOG_PII") == "True"}'
+    logger.debug(
+        f'Startup configuration: pii logging = {getenv("FIDESOPS__LOG_PII") == "True"}'
     )
 
     def log_all_config_values(self) -> None:

--- a/src/fidesops/db/database.py
+++ b/src/fidesops/db/database.py
@@ -16,13 +16,14 @@ from .base import Base
 
 def get_alembic_config(
     database_url: str,
-    package_source_dir: str = config.package.PATH,
+    migrations_dir: str = config.package.MIGRATION_PATH,
 ) -> Config:
     """
     Do lots of magic to make alembic work programmatically.
     """
 
-    migrations_dir = os.path.join(package_source_dir, "migrations/")
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    package_source_dir = os.path.normpath(os.path.join(current_dir, "../../"))
     alembic_config = Config(os.path.join(package_source_dir, "alembic.ini"))
     alembic_config.set_main_option("script_location", migrations_dir.replace("%", "%%"))
     alembic_config.set_main_option("sqlalchemy.url", database_url)
@@ -35,14 +36,11 @@ def upgrade_db(alembic_config: Config, revision: str = "head") -> None:
     command.upgrade(alembic_config, revision)
 
 
-def init_db(
-    database_url: PostgresDsn,
-    package_source_dir: str = config.package.PATH,
-) -> None:
+def init_db(database_url: PostgresDsn) -> None:
     """
     Runs the migrations and creates all of the database objects.
     """
-    alembic_config = get_alembic_config(database_url, package_source_dir)
+    alembic_config = get_alembic_config(database_url)
     upgrade_db(alembic_config)
 
 

--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -56,7 +56,7 @@ def start_webserver() -> None:
 
     if config.database.ENABLED:
         logger.info("Running any pending DB migrations...")
-        init_db(config.database.SQLALCHEMY_DATABASE_URI, config.package.PATH)
+        init_db(config.database.SQLALCHEMY_DATABASE_URI)
 
     scheduler.start()
 


### PR DESCRIPTION
# Purpose

PyPI installs the fidesops `/migrations` directory outside of the package source tree, in a sibling directory of `/fidesops`. This enables a way to specify a path to DB migrations that exists outside of the `/fidesops` package source tree.

# Changes
- `config.package.PATH` --> `config.package.MIGRATION_PATH`
- If provided, fidesops does not prescribe the directory structure within the `MIGRATIONS_PATH`, other than that a `/migrations` directory must exist
- Dramatically reduce the `os` package import volume in `config.py`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #612