### PR TITLE
[#587, #607, #608] update config reference and deployment docs

### DIFF
--- a/docs/fidesops/docs/css/fides.css
+++ b/docs/fidesops/docs/css/fides.css
@@ -377,7 +377,7 @@ form.hs-form{
 
 .highlight .filename > code{
     background-color: transparent;
-    color: #2A2F45 ;
+    color: var(--md-typeset-color);
 }
 
 

--- a/docs/fidesops/docs/deployment.md
+++ b/docs/fidesops/docs/deployment.md
@@ -20,7 +20,7 @@ Like most web applications, `fidesops` uses an application database for persiste
 * Self-hosted PostgreSQL Docker container with a persistent volume mount (e.g. on a Kubernetes cluster)
 * Self-hosted PostgreSQL server (e.g. on an EC2 server)
 
-NOTE: there *is no reason to expose this database to the public Internet* as long as it is will be accessible by your `fidesops` web server!
+NOTE: there *is no reason to expose this database to the public Internet* as long as it will be accessible by your `fidesops` web server!
 
 Setting up a production-grade PostgreSQL database is likely something your team is already familiar with, so we won't revisit that here. Once it's up and running, make sure you create a unique user and database to use for `fidesops` (we recommended calling these both `fidesops`) and assign a secure password, then keep track of all those credentials. You'll need those values later to populate these configuration variables for `fidesops`:
 
@@ -108,18 +108,6 @@ docker run \
   --env FIDESOPS__REDIS__PORT=6379 \
   --env FIDESOPS__REDIS__PASSWORD="fidesopssecret" \
   ethyca/fidesops
-
-INFO:fidesops.main:****************fidesops****************
-INFO:fidesops.main:Running any pending DB migrations...
-INFO:alembic.runtime.migration:Context impl PostgresqlImpl.
-INFO:alembic.runtime.migration:Will assume transactional DDL.
-INFO:fidesops.main:Starting scheduled request intake...
-INFO:apscheduler.scheduler:Scheduler started
-INFO:fidesops.main:Starting web server...
-INFO:uvicorn.error:Started server process [1]
-INFO:uvicorn.error:Waiting for application startup.
-INFO:uvicorn.error:Application startup complete.
-INFO:uvicorn.error:Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
 ```
 
 Or if you prefer to create your .env file and pass an `--env-file` variable, you can use the following: 
@@ -131,6 +119,19 @@ docker run \
   ethyca/fidesops
 ```
 
+```env title="<code>config.env</env>"
+FIDESOPS__SECURITY__APP_ENCRYPTION_KEY="averyveryverysecretencryptionkey"
+FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID="fidesopsadmin"
+FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET="fidesopsadminsecret"
+FIDESOPS__DATABASE__SERVER="postgres.internal"
+FIDESOPS__DATABASE__PORT="5432"
+FIDESOPS__DATABASE__USER="fidesops"
+FIDESOPS__DATABASE__PASSWORD="fidesopssecret"
+FIDESOPS__DATABASE__DB="fidesops"
+FIDESOPS__REDIS__HOST="redis.internal"
+FIDESOPS__REDIS__PORT=6379
+FIDESOPS__REDIS__PASSWORD="fidesopssecret"
+```
 
 
 Now, for most Docker hosts, you won't be calling `docker run` directly, and instead will be providing configuration variables to Kubernetes/Swarm/ECS/etc. As you can see in the `docker run` example above, this config is quite minimal and should just involve specifying (1) the image, (2) the port mapping, (3) all the various environment variables for configuration.

--- a/docs/fidesops/docs/guides/configuration_reference.md
+++ b/docs/fidesops/docs/guides/configuration_reference.md
@@ -29,27 +29,29 @@ The `fidesops.toml` file should specify the following variables:
 
 | TOML Variable | ENV Variable | Type | Example | Default | Description |
 |---|---|---|---|---|---|
+| `PORT` | --- | int | 8080 | 8080 | The port at which the webserver will run.|
+| Database Variables |---|---|---|---|---|
 | `SERVER` | `FIDESOPS__DATABASE__SERVER` | string | postgres.internal | N/A | The networking address for the Fideops Postgres database server |
 | `USER` | `FIDESOPS__DATABASE__USER` | string | postgres | N/A | The database user with which to login to the Fidesops application database |
 | `PASSWORD` | `FIDESOPS__DATABASE__PASSWORD` | string | apassword | N/A | The password with which to login to the Fidesops application database |
 | `PORT` | `FIDESOPS__DATABASE__PORT` | int | 5432 | 5432 | The port at which the Fidesops application database will be accessible |
 | `DB` | `FIDESOPS__DATABASE__DB` | string | db | N/A | The name of the database to use in the Fidesops application database |
 | `ENABLED` | `FIDESOPS__DATABASE__ENABLED` | bool | True | True | Whether the application database should be enabled. Only set to false for certain narrow uses of the application that do not require a backing application database. |
-|---|---|---|---|---|---|
+| Redis Variables |---|---|---|---|---|
 | `HOST` | `FIDESOPS__REDIS__HOST` | string | redis.internal | N/A | The networking address for the Fidesops application Redis cache |
 | `PORT` | `FIDESOPS__REDIS__PORT` | int | 6379 | 6379 | The port at which the Fidesops application cache will be accessible |
 | `PASSWORD` | `FIDESOPS__REDIS__PASSWORD` | string | anotherpassword | N/A | The password with which to login to the Fidesops application cache |
 | `DB_INDEX` | `FIDESOPS__REDIS__DB_INDEX` | int | 0 | 0 | The Fidesops application will use this index in the Redis cache to cache data |
 | `DEFAULT_TTL_SECONDS` | `FIDESOPS__REDIS__DEFAULT_TTL_SECONDS` | int | 3600 | 604800 | The number of seconds for which data will live in Redis before automatically expiring |
 | `ENABLED` | `FIDESOPS__REDIS__ENABLED` | bool | True | True | Whether the application's redis cache should be enabled. Only set to false for certain narrow uses of the application that do not require a backing redis cache. |
-|---|---|---|---|---|---|
+| Security Variables |---|---|---|---|---|
 | `APP_ENCRYPTION_KEY` | `FIDESOPS__SECURITY__APP_ENCRYPTION_KEY` | string | OLMkv91j8DHiDAULnK5Lxx3kSCov30b3 | N/A | The key used to sign Fidesops API access tokens |
 | `CORS_ORIGINS` | `FIDESOPS__SECURITY__CORS_ORIGINS` | List[AnyHttpUrl] | ["https://a-client.com/", "https://another-client.com"/] | N/A | A list of pre-approved addresses of clients allowed to communicate with the Fidesops application server |
 | `LOG_LEVEL` | `FIDESOPS__SECURITY__LOG_LEVEL` | string | INFO | N/A | The log level used for Fidesops. Must be one of DEBUG, INFO, WARNING, ERROR, or CRITICAL |
 | `OAUTH_ROOT_CLIENT_ID` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_ID` | string | fidesopsadmin | N/A | The value used to identify the Fidesops application root API client |
 | `OAUTH_ROOT_CLIENT_SECRET` | `FIDESOPS__SECURITY__OAUTH_ROOT_CLIENT_SECRET` | string | fidesopsadminsecret | N/A | The secret value used to authenticate the Fidesops application root API client |
 | `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `FIDESOPS__SECURITY__OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | int | 1 | 11520 | The time period Fidesops API tokens will be valid |
-|---|---|---|---|---|---|
+| Execution Variables |---|---|---|---|---|
 |`PRIVACY_REQUEST_DELAY_TIMEOUT` | `FIDESOPS__EXECUTION__PRIVACY_REQUEST_DELAY_TIMEOUT` | int | 3600 | 3600 | The amount of time to wait for actions delaying privacy requests, for example pre and post processing webhooks.
 |`TASK_RETRY_COUNT` | `FIDESOPS__EXECUTION__TASK_RETRY_COUNT` | int | 5 | 0 | The number of times a failed request will be retried
 |`TASK_RETRY_DELAY` | `FIDESOPS__EXECUTION__TASK_RETRY_DELAY` | int | 20 | 1 | The delays between retries in seconds
@@ -61,6 +63,8 @@ The `fidesops.toml` file should specify the following variables:
 ## An example `fidesops.toml` configuration file
 
 ```
+PORT=8080
+
 [database]
 SERVER="db"
 USER="postgres"
@@ -102,7 +106,8 @@ Please note: The configuration is case-sensitive, so the variables must be speci
 | `FIDESOPS__LOG_PII` | False | If this is set to "True", pii values will display unmasked in log output. This variable should always be set to "False" in production systems.
 | `FIDESOPS__HOT_RELOAD` | False | If "True", the fidesops server will reload code changes without you needing to restart the server. This variable should always be set to "False" in production systems.|
 | `FIDESOPS__DEV_MODE` | False | If "True", the fidesops server will log error tracebacks, and log details of third party requests. This variable should always be set to "False" in production systems.|
-| `FIDESOPS__CONFIG_PATH` | None | If this variable is set to a path, that path will be used to load .toml files first. That is, any .toml files on this path will override any installed .toml files.
+| `FIDESOPS__CONFIG_PATH` | None | If this variable is set to a path, that path will be used to load .toml files first. That is, any .toml files on this path will override any installed .toml files. |
+| `FIDESOPS__DATABASE__SQLALCHEMY_DATABASE_URI` | None | An optional override for the URI used for the database connection. |
 
 ## - Reporting a running application's configuration
 


### PR DESCRIPTION
# Purpose
Catch the docs up on some missed variable additions/updates from recent work. 

# Changes
- removed extra text and added in a sample .env file in the deployment guide for easier copy-pasting
- added in the new `PORT` variable in the config guide and updated sample files
- cleaned up the config guide so it's easier to use

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [X] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).

# Ticket

Fixes #587, #608, #607 
 
