### PR TITLE
Only push to Dockerhub on releases

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -2,8 +2,6 @@ name: Publish to DockerHub
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "*"
 


### PR DESCRIPTION
# Purpose

Match `fidesctl` in only pushing releases to dockerhub when there is a release

[Example here](https://github.com/ethyca/fides/blob/main/.github/workflows/docker.yaml)

# Changes
-

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
