### PR TITLE
Add `AdminUiSettings` to helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 * Build and deploy Admin UI from webserver [#625](https://github.com/ethyca/fidesops/pull/625)
 * Allow disabling a ConnectionConfig [#637](https://github.com/ethyca/fidesops/pull/637)
 * Erasure support for Outreach connector [#619](https://github.com/ethyca/fidesops/pull/619)
+* Added `AdminUiSettings` to the `log_all_config_values` helper method [#647](https://github.com/ethyca/fidesops/pull/647)
 
 ### Changed
 

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -156,7 +156,7 @@ class FidesopsConfig(FidesSettings):
 
     def log_all_config_values(self) -> None:
         """Output DEBUG logs of all the config values."""
-        for settings in [self.database, self.redis, self.security, self.execution]:
+        for settings in [self.database, self.redis, self.security, self.execution, self.admin_ui]:
             for key, value in settings.dict().items():  # type: ignore
                 logger.debug(
                     "Using config: %s%s = %s",

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -156,7 +156,13 @@ class FidesopsConfig(FidesSettings):
 
     def log_all_config_values(self) -> None:
         """Output DEBUG logs of all the config values."""
-        for settings in [self.database, self.redis, self.security, self.execution, self.admin_ui]:
+        for settings in [
+            self.database,
+            self.redis,
+            self.security,
+            self.execution,
+            self.admin_ui,
+        ]:
             for key, value in settings.dict().items():  # type: ignore
                 logger.debug(
                     "Using config: %s%s = %s",


### PR DESCRIPTION
# Purpose
The `log_all_config_values` method is missing the admin ui settings. It should contain them.
# Changes
- Update `log_all_config_values` to display new admin ui settings

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
