### PR TITLE
Sort ConnectionConfig Name Ascending [#668]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The types of changes are:
 * Bumped mypy to version 0.961 [#630](https://github.com/ethyca/fidesops/pull/630)
 * Bumped Python to version 3.9.13 in the `Dockerfile` [#630](https://github.com/ethyca/fidesops/pull/630)
 * Matched the path to the migrations in the mypy settings with the new location [#634](https://github.com/ethyca/fidesops/pull/634)
+* Sort ConnectionConfig by name ascending [#668](https://github.com/ethyca/fidesops/pull/672)
 
 ### Developer Experience
 

--- a/src/fidesops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_endpoints.py
@@ -103,7 +103,7 @@ def get_connections(
             )
         )
     return paginate(
-        query.order_by(ConnectionConfig.created_at.desc()),
+        query.order_by(ConnectionConfig.name.asc()),
         params=params,
     )
 

--- a/tests/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_config_endpoints.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi import HTTPException
 from fastapi_pagination import Params
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import db
 from starlette.testclient import TestClient
 
 from fidesops.api.v1.scope_registry import (
@@ -470,7 +469,7 @@ class TestGetConnections:
                     [read_connection_config.key, connection_config.key]
                 )
             )
-            .order_by(ConnectionConfig.created_at.desc())
+            .order_by(ConnectionConfig.name.asc())
             .all()
         )
         assert len(ordered) == 2


### PR DESCRIPTION
# Purpose
Support ordering datastores in the frontend.

# Changes
- Change sort order of GET /connection to be name ascending instead of created_at descending.  


# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #668 
 
