### PR TITLE
Add fixture to clear tables between test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,12 @@ from typing import Any, Callable, Dict, Generator, List, MutableMapping
 import pytest
 from fastapi.testclient import TestClient
 from fideslib.core.config import load_toml
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
 from fidesops.api.v1.scope_registry import SCOPE_REGISTRY
 from fidesops.core.config import config
+from fidesops.db.base_class import Base
 from fidesops.db.database import init_db
 from fidesops.db.session import Session, get_db_engine, get_db_session
 from fidesops.main import app
@@ -87,6 +89,34 @@ def db() -> Generator:
     logger.debug(f"Database at: {engine.url} successfully dropped")
 
 
+@pytest.fixture(autouse=True)
+def clear_db_tables(db):
+    """Clear data from tables between tests.
+
+    If relationships are not set to cascade on delete they will fail with an
+    IntegrityError if there are relationsips present. This function stores tables
+    that fail with this error then recursively deletes until no more IntegrityErrors
+    are present.
+    """
+    yield
+
+    def delete_data(tables):
+        redo = []
+        for table in tables:
+            try:
+                db.execute(table.delete())
+            except IntegrityError:
+                redo.append(table)
+            finally:
+                db.commit()
+
+        if redo:
+            delete_data(redo)
+
+    db.commit()  # make sure all transactions are closed before starting deletes
+    delete_data(Base.metadata.sorted_tables)
+
+
 @pytest.fixture(scope="session")
 def cache() -> Generator:
     yield get_cache()
@@ -111,7 +141,6 @@ def oauth_client(db: Session) -> Generator:
     db.commit()
     db.refresh(client)
     yield client
-    client.delete(db)
 
 
 def generate_auth_header_for_user(user, scopes) -> Dict[str, str]:


### PR DESCRIPTION
# Purpose

Clears the database tables between each test even if the test fails.

# Changes
- Added `clear_db_tables` as an `autouse` fixture.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #678 and #679
 
