### PR TITLE
Delete Datastore [Frontend]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The types of changes are:
 * Sample dataset and access configuration for Zendesk (ticket endpoints) [#677](https://github.com/ethyca/fidesops/pull/677)
 * Include number of records to be masked in masking endpoint's log message [#692](https://github.com/ethyca/fidesops/pull/692)
 * Datastore Connection Landing Page [#674](https://github.com/ethyca/fidesops/pull/674)
+* Added the ability to delete a datastore from the frontend [#683] https://github.com/ethyca/fidesops/pull/683
 
 ### Changed
 

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionGridItem.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionGridItem.tsx
@@ -113,7 +113,7 @@ const ConnectionGridItem: React.FC<ConnectionGridItemProps> = ({
         </Text>
         <Spacer />
         <ConnectionStatusBadge disabled={connectionData.disabled} />
-        <ConnectionMenu />
+        <ConnectionMenu connection_key={connectionData.key} />
       </Flex>
       <Text color="gray.600" fontSize="sm" fontWeight="sm" lineHeight="20px">
         {getConnectorDisplayName(connectionData.connection_type)}

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionMenu.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionMenu.tsx
@@ -10,12 +10,14 @@ import {
 import React from "react";
 
 import { MoreIcon } from "../common/Icon";
+import DeleteConnectionModal from "./DeleteConnectionModal";
 
 interface ConnectionMenuProps {
+  connection_key: string;
   // disabled: boolean;
 }
 
-const ConnectionMenu: React.FC<ConnectionMenuProps> = () => (
+const ConnectionMenu: React.FC<ConnectionMenuProps> = ({ connection_key }) => (
   <Menu>
     <MenuButton
       as={Button}
@@ -39,12 +41,7 @@ const ConnectionMenu: React.FC<ConnectionMenuProps> = () => (
         >
           <Text fontSize="sm">Disable</Text>
         </MenuItem>
-        <MenuItem
-          _focus={{ color: "complimentary.500", bg: "gray.100" }}
-          // onClick={handleViewDetails}
-        >
-          <Text fontSize="sm">Delete</Text>
-        </MenuItem>
+        <DeleteConnectionModal connection_key={connection_key} />
       </MenuList>
     </Portal>
   </Menu>

--- a/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
@@ -41,7 +41,7 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
       >
         <Text fontSize="sm">Delete</Text>
       </MenuItem>
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Delete Connection</ModalHeader>

--- a/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
@@ -1,0 +1,92 @@
+import {
+  Button,
+  MenuItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@fidesui/react";
+import React from "react";
+
+import { useDeleteDatastoreConnectionMutation } from "./datastore-connection.slice";
+
+type DataConnectionProps = {
+  connection_key: string;
+};
+
+const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
+  connection_key,
+}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [deleteConnection] = useDeleteDatastoreConnectionMutation();
+
+  const handleDeleteConnection = () => {
+    if (connection_key) {
+      deleteConnection(connection_key);
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <MenuItem
+        _focus={{ color: "complimentary.500", bg: "gray.100" }}
+        onClick={onOpen}
+      >
+        <Text fontSize="sm">Delete</Text>
+      </MenuItem>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Delete Connection</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <Stack direction="column" spacing="15px">
+              <Text
+                color="gray.600"
+                fontSize="sm"
+                fontWeight="sm"
+                lineHeight="20px"
+              >
+                Deleting a datastore connection may impact any subject request
+                that is currently in progress. Do you wish to proceed?
+              </Text>
+            </Stack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              onClick={onClose}
+              marginRight="10px"
+              size="sm"
+              variant="solid"
+              bg="white"
+              width="50%"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDeleteConnection}
+              mr={3}
+              size="sm"
+              variant="solid"
+              bg="primary.800"
+              color="white"
+              width="50%"
+            >
+              Delete Connection
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default DeleteConnectionModal;

--- a/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
@@ -33,6 +33,12 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
     }
   };
 
+  const closeIfComplete = () => {
+    if (!deleteConnectionResult.isLoading) {
+      onClose();
+    }
+  };
+
   return (
     <>
       <MenuItem
@@ -41,7 +47,7 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
       >
         <Text fontSize="sm">Delete</Text>
       </MenuItem>
-      <Modal isCentered isOpen={isOpen} onClose={onClose}>
+      <Modal isCentered isOpen={isOpen} onClose={closeIfComplete}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Delete Connection</ModalHeader>
@@ -62,7 +68,7 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
 
           <ModalFooter>
             <Button
-              onClick={onClose}
+              onClick={closeIfComplete}
               marginRight="10px"
               size="sm"
               variant="solid"

--- a/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DeleteConnectionModal.tsx
@@ -24,12 +24,12 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
   connection_key,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [deleteConnection] = useDeleteDatastoreConnectionMutation();
+  const [deleteConnection, deleteConnectionResult] =
+    useDeleteDatastoreConnectionMutation();
 
   const handleDeleteConnection = () => {
     if (connection_key) {
       deleteConnection(connection_key);
-      onClose();
     }
   };
 
@@ -73,12 +73,21 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
             </Button>
             <Button
               onClick={handleDeleteConnection}
+              isLoading={deleteConnectionResult.isLoading}
               mr={3}
               size="sm"
               variant="solid"
               bg="primary.800"
               color="white"
               width="50%"
+              _loading={{
+                opacity: 1,
+                div: { opacity: 0.4 },
+              }}
+              _hover={{
+                bg: "gray.100",
+                color: "gray.600",
+              }}
             >
               Delete Connection
             </Button>

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -167,4 +167,5 @@ export const datastoreConnectionApi = createApi({
 export const {
   useGetAllDatastoreConnectionsQuery,
   useLazyGetDatastoreConnectionStatusQuery,
+  useDeleteDatastoreConnectionMutation,
 } = datastoreConnectionApi;

--- a/clients/admin-ui/src/features/user-management/DeleteUserModal.tsx
+++ b/clients/admin-ui/src/features/user-management/DeleteUserModal.tsx
@@ -56,7 +56,7 @@ const DeleteUserModal: React.FC<User> = ({ id, username }) => {
       >
         <Text fontSize="sm">Delete</Text>
       </MenuItem>
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Delete User</ModalHeader>

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -89,7 +89,7 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
       >
         Update Password
       </Button>
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Update Password</ModalHeader>


### PR DESCRIPTION
❗ Dependent on https://github.com/ethyca/fidesops/pull/674, merge that first.

# Purpose
Demonstrate that a user can delete a connected datastore from the Datastore Connection Management UI.
-- The datastore should be removed from the UI
-- When attempting to delete the connection, the user must be presented with a modal saying "Deleting a datastore connection may impact any subject request that is currently in progress. Do you wish to proceed?" (similar flow to deleting a user)

# Changes
- Add a delete connection modal file which has the menu item "delete" and the modal which asks for confirmation before sending a request to DELETE ${CONNECTION_ROUTE}/{connection_key}


Delete intentionally slowed down to take 5 seconds here:
https://user-images.githubusercontent.com/9755598/174892119-5f50f174-c94b-4ce0-a5e9-0eb347a1b152.mov




# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #604
 
