### PR TITLE
Enable/Disable Datastores [Frontend]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
 * Include number of records to be masked in masking endpoint's log message [#692](https://github.com/ethyca/fidesops/pull/692)
 * Datastore Connection Landing Page [#674](https://github.com/ethyca/fidesops/pull/674)
 * Added the ability to delete a datastore from the frontend [#683] https://github.com/ethyca/fidesops/pull/683
+* Added the ability to disable/enable a datastore from the frontend [#693] https://github.com/ethyca/fidesops/pull/693
 
 ### Changed
 

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionGridItem.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionGridItem.tsx
@@ -113,7 +113,13 @@ const ConnectionGridItem: React.FC<ConnectionGridItemProps> = ({
         </Text>
         <Spacer />
         <ConnectionStatusBadge disabled={connectionData.disabled} />
-        <ConnectionMenu connection_key={connectionData.key} />
+        <ConnectionMenu
+          connection_key={connectionData.key}
+          disabled={connectionData.disabled}
+          name={connectionData.name}
+          connection_type={connectionData.connection_type}
+          access_type={connectionData.access}
+        />
       </Flex>
       <Text color="gray.600" fontSize="sm" fontWeight="sm" lineHeight="20px">
         {getConnectorDisplayName(connectionData.connection_type)}

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionMenu.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionMenu.tsx
@@ -11,13 +11,24 @@ import React from "react";
 
 import { MoreIcon } from "../common/Icon";
 import DeleteConnectionModal from "./DeleteConnectionModal";
+import DisableConnectionModal from "./DisableConnectionModal";
+import { AccessLevel, ConnectionType } from "./types";
 
 interface ConnectionMenuProps {
   connection_key: string;
-  // disabled: boolean;
+  disabled: boolean;
+  name: string;
+  connection_type: ConnectionType;
+  access_type: AccessLevel;
 }
 
-const ConnectionMenu: React.FC<ConnectionMenuProps> = ({ connection_key }) => (
+const ConnectionMenu: React.FC<ConnectionMenuProps> = ({
+  connection_key,
+  disabled,
+  connection_type,
+  access_type,
+  name,
+}) => (
   <Menu>
     <MenuButton
       as={Button}
@@ -35,12 +46,13 @@ const ConnectionMenu: React.FC<ConnectionMenuProps> = ({ connection_key }) => (
         >
           <Text fontSize="sm">Edit</Text>
         </MenuItem>
-        <MenuItem
-          _focus={{ color: "complimentary.500", bg: "gray.100" }}
-          // onClick={handleViewDetails}
-        >
-          <Text fontSize="sm">Disable</Text>
-        </MenuItem>
+        <DisableConnectionModal
+          connection_key={connection_key}
+          disabled={disabled}
+          connection_type={connection_type}
+          access_type={access_type}
+          name={name}
+        />
         <DeleteConnectionModal connection_key={connection_key} />
       </MenuList>
     </Portal>

--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  MenuItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@fidesui/react";
+import React from "react";
+
+import { usePatchDatastoreConnectionsMutation } from "./datastore-connection.slice";
+import { AccessLevel, ConnectionType } from "./types";
+
+type DataConnectionProps = {
+  connection_key: string;
+  disabled: boolean;
+  name: string;
+  access_type: AccessLevel;
+  connection_type: ConnectionType;
+};
+
+const DisableConnectionModal: React.FC<DataConnectionProps> = ({
+  connection_key,
+  disabled,
+  name,
+  access_type,
+  connection_type,
+}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [patchConnection, patchConnectionResult] =
+    usePatchDatastoreConnectionsMutation();
+
+  const handleDisableConnection = async () => {
+    const shouldDisable = !disabled;
+    return patchConnection({
+      key: connection_key,
+      name,
+      disabled: shouldDisable,
+      access: access_type,
+      connection_type,
+    })
+      .unwrap()
+      .then(() => onClose());
+  };
+
+  const closeIfComplete = () => {
+    if (!patchConnectionResult.isLoading) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <MenuItem
+        _focus={{ color: "complimentary.500", bg: "gray.100" }}
+        onClick={onOpen}
+      >
+        <Text fontSize="sm">{disabled ? "Enable" : "Disable"}</Text>
+      </MenuItem>
+      <Modal isCentered isOpen={isOpen} onClose={closeIfComplete}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            {disabled ? "Enable" : "Disable"} Connection
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <Stack direction="column" spacing="15px">
+              <Text
+                color="gray.600"
+                fontSize="sm"
+                fontWeight="sm"
+                lineHeight="20px"
+              >
+                {disabled ? "Enabling" : "Disabling"} a datastore connection may
+                impact any subject request that is currently in progress. Do you
+                wish to proceed?
+              </Text>
+            </Stack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              onClick={onClose}
+              marginRight="10px"
+              size="sm"
+              variant="solid"
+              bg="white"
+              width="50%"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDisableConnection}
+              isLoading={patchConnectionResult.isLoading}
+              mr={3}
+              size="sm"
+              variant="solid"
+              bg="primary.800"
+              color="white"
+              width="50%"
+            >
+              {disabled ? "Enable" : "Disable"} Connection
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default DisableConnectionModal;

--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -87,7 +87,7 @@ const DisableConnectionModal: React.FC<DataConnectionProps> = ({
 
           <ModalFooter>
             <Button
-              onClick={onClose}
+              onClick={closeIfComplete}
               marginRight="10px"
               size="sm"
               variant="solid"

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -139,10 +139,10 @@ export const datastoreConnectionApi = createApi({
       },
     }),
     patchDatastoreConnections: build.mutation({
-      query: () => ({
+      query: ({ key, name, disabled, connection_type, access }) => ({
         url: CONNECTION_ROUTE,
         method: "PATCH",
-        body: {},
+        body: [{ key, name, disabled, connection_type, access }],
       }),
       invalidatesTags: () => ["DatastoreConnection"],
     }),
@@ -167,5 +167,6 @@ export const datastoreConnectionApi = createApi({
 export const {
   useGetAllDatastoreConnectionsQuery,
   useLazyGetDatastoreConnectionStatusQuery,
+  usePatchDatastoreConnectionsMutation,
   useDeleteDatastoreConnectionMutation,
 } = datastoreConnectionApi;

--- a/clients/admin-ui/src/features/datastore-connections/types.ts
+++ b/clients/admin-ui/src/features/datastore-connections/types.ts
@@ -66,3 +66,11 @@ export type DatastoreConnectionStatus = {
   test_status?: ConnectionTestStatus;
   failure_reason?: string;
 };
+
+export interface DatastoreConnectionUpdate {
+  name: string;
+  key: string;
+  disabled: boolean;
+  connection_type: ConnectionType;
+  access: AccessLevel;
+}


### PR DESCRIPTION
❗ Dependent on #604: Merge that first

# Purpose

Demonstrate that a user can disable a connected datastore from the Datastore Connection Management UI.
The datastore should remain visible from the UI, but UI should indicate that it is disabled.

# Changes
- Add a disable connection modal. If datastore is already disabled you have the option to enable it instead.


https://user-images.githubusercontent.com/9755598/174901351-2b9f1e76-c541-4a52-a9aa-1ab9cd0e2e42.mov



# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #604
 
