### PR TITLE
Update datastore connection filters to support clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The types of changes are:
 * Install MSSQL By Default [#664](https://github.com/ethyca/fidesops/pull/664)
 * [Admin UI] Change "Policy Name" to "Request Type" on SR list page.[#546](https://github.com/ethyca/fidesops/pull/696)
 * Queue PrivacyRequests into a Celery queue for execution [#621](https://github.com/ethyca/fidesops/pull/621)
+* Added filtering clearing in datastore connections [#701](https://github.com/ethyca/fidesops/pull/701)
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/auth/auth.slice.ts
+++ b/clients/admin-ui/src/features/auth/auth.slice.ts
@@ -72,13 +72,14 @@ credentialStorage.startListening({
 });
 
 // Auth API
-export const authApi: any = createApi({
+export const authApi = createApi({
   reducerPath: "authApi",
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
       const token: string | null = selectToken(getState() as RootState);
-      return addCommonHeaders(headers, token);
+      addCommonHeaders(headers, token);
+      return headers;
     },
   }),
   tagTypes: ["Auth"],

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionDropdown.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionDropdown.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, IconButton, Spacer, Text } from "@fidesui/react";
+import { Box, Button, Flex, IconButton, Spacer, Text } from "@fidesui/react";
 import React, { useCallback, useState } from "react";
 
 import { useOutsideClick } from "../common/hooks";
@@ -107,6 +107,21 @@ const ConnectionDropdown: React.FC<ConnectionDropdownProps> = ({
           position="absolute"
           zIndex={1}
         >
+          <Flex borderBottom="1px" borderColor="gray.200" padding="8px">
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => {
+                if (value) {
+                  setValue("");
+                }
+                toggleMenu();
+              }}
+            >
+              Clear
+            </Button>
+            <Spacer />
+          </Flex>
           {options}
         </Flex>
       ) : null}

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionStatusMenu.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionStatusMenu.tsx
@@ -86,8 +86,11 @@ const useConnectionStatusMenu = () => {
     setCheckBoxStates(newList);
   };
 
-  const resetCheckboxStates = () => {
-    setCheckBoxStates([...initialCheckListState]);
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+  const closeMenu = () => {
+    setIsOpen(false);
   };
 
   const updateConnectionTypeFilter = () => {
@@ -95,18 +98,20 @@ const useConnectionStatusMenu = () => {
       .filter((d) => d.checked)
       .map((d) => d.type);
     disbatch(setConnectionType(connectionTypes));
+    closeMenu();
   };
 
-  const toggleMenu = () => {
-    setIsOpen(!isOpen);
-  };
-  const closeMenu = () => {
-    setIsOpen(false);
+  const resetCheckboxStates = () => {
+    const falseCheckboxes = checkboxStates.filter((d) => !d.checked);
+    if (falseCheckboxes.length !== checkboxStates.length) {
+      setCheckBoxStates([...initialCheckListState]);
+      disbatch(setConnectionType([]));
+    }
+    closeMenu();
   };
   return {
     isOpen,
     toggleMenu,
-    closeMenu,
     checkboxStates,
     updateCheckBoxStates,
     resetCheckboxStates,
@@ -119,7 +124,6 @@ const ConnectionStatusMenu: React.FC = () => {
   const {
     isOpen,
     toggleMenu,
-    closeMenu,
     checkboxStates,
     updateCheckBoxStates,
     resetCheckboxStates,
@@ -208,7 +212,6 @@ const ConnectionStatusMenu: React.FC = () => {
               color="white"
               onClick={() => {
                 updateConnectionTypeFilter();
-                closeMenu();
               }}
             >
               Done

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -141,7 +141,8 @@ export const datastoreConnectionApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
-      addCommonHeaders(headers, selectToken(getState() as RootState));
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
       return headers;
     },
   }),

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -4,6 +4,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import type { RootState } from "../../app/store";
 import { BASE_URL, CONNECTION_ROUTE } from "../../constants";
 import { selectToken } from "../auth";
+import { addCommonHeaders } from "../common/CommonHeaders";
 import {
   ConnectionType,
   DatastoreConnection,
@@ -140,11 +141,7 @@ export const datastoreConnectionApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
-      const token = selectToken(getState() as RootState);
-      headers.set("Access-Control-Allow-Origin", "*");
-      if (token) {
-        headers.set("authorization", `Bearer ${token}`);
-      }
+      addCommonHeaders(headers, selectToken(getState() as RootState));
       return headers;
     },
   }),

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -48,13 +48,14 @@ export function mapFiltersToSearchParams({
 }
 
 // Subject requests API
-export const privacyRequestApi: any = createApi({
+export const privacyRequestApi = createApi({
   reducerPath: "privacyRequestApi",
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
       const token: string | null = selectToken(getState() as RootState);
-      return addCommonHeaders(headers, token);
+      addCommonHeaders(headers, token);
+      return headers;
     },
   }),
   tagTypes: ["Request"],

--- a/clients/admin-ui/src/features/user-management/user-management.slice.ts
+++ b/clients/admin-ui/src/features/user-management/user-management.slice.ts
@@ -77,13 +77,14 @@ export const mapFiltersToSearchParams = ({
   ...(username ? { username } : {}),
 });
 
-export const userApi: any = createApi({
+export const userApi = createApi({
   reducerPath: "userApi",
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
       const token: string | null = selectToken(getState() as RootState);
-      return addCommonHeaders(headers, token);
+      addCommonHeaders(headers, token);
+      return headers;
     },
   }),
   tagTypes: ["User"],


### PR DESCRIPTION
# Purpose
Update datastore connection filters to support clearing selections.

# Changes
- Update both the `ConnectionDropdown` and `ConnectionStatusMenu` to support clearing selections
- Update `datastore-connection.slice.ts` to use the `addCommonHeaders` for analytics
- Refactor other `prepareHeaders` calls to make the type checker happier. This allows the RTK Query API slices to not be typed as `Any`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #699 
 
