### PR TITLE
Update CHANGELOG.md, bump to `fideslib==2.1.0` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ The types of changes are:
 * `Security` in case of vulnerabilities.
 
 
-## [Unreleased](https://github.com/ethyca/fidesops/compare/1.5.3...main)
+## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.0...main)
+
+
+## [1.6.0](https://github.com/ethyca/fidesops/compare/1.5.3...1.6.0)
 
 ### Added
 * Subject Request Details page [#563](https://github.com/ethyca/fidesops/pull/563)
@@ -59,6 +62,7 @@ The types of changes are:
 ### Developer Experience
 
 * Add celerybeat-schedule file to gitignore [#639](https://github.com/ethyca/fidesops/pull/639)
+* Use `v2.1.0` of `fideslib` [#705](https://github.com/ethyca/fidesops/pull/705)
 
 ### Fixed
 * Fixed error with running mypy on M1 Macs [#630](https://github.com/ethyca/fidesops/pull/630)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.8.3
 fastapi[all]==0.78.0
 fideslang==1.0.0
-fideslib==2.0.4
+fideslib==2.1.0
 fideslog==1.2.1
 multidimensional_urlencode==0.0.4
 pandas==1.3.3


### PR DESCRIPTION
- Bumps to the latest version of `fideslib` to `2.1.0`
- Rounds off the `CHANGELOG.md` for the `1.6.0` release