### PR TITLE
Reduce docker image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.0...main)
 
+### Devloper Experience
+* Reduce the size of the docker image [#707](https://github.com/ethyca/fidesops/pull/707)
+
 
 ## [1.6.0](https://github.com/ethyca/fidesops/compare/1.5.3...1.6.0)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG SKIP_MSSQL_INSTALLATION
 
 # Install auxiliary software
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     git \
     make \
     ipython \
@@ -21,22 +21,26 @@ RUN apt-get update && \
     curl \
     g++ \
     gnupg \
-    gcc
+    gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 
 RUN echo "ENVIRONMENT VAR:  SKIP_MSSQL_INSTALLATION $SKIP_MSSQL_INSTALLATION"
 
 # SQL Server (MS SQL)
 # https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15
-RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get install apt-transport-https ; fi
+RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get install -y --no-install-recommends apt-transport-https && apt-get clean && rm -rf /var/lib/apt/lists/* ; fi
 RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - ; fi
 RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then curl https://packages.microsoft.com/config/debian/10/prod.list | tee /etc/apt/sources.list.d/msprod.list ; fi
 RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get update ; fi
 ENV ACCEPT_EULA=y DEBIAN_FRONTEND=noninteractive
-RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get -y install \
+RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get -y --no-install-recommends install \
     unixodbc-dev \
     msodbcsql17 \
-    mssql-tools ; fi
+    mssql-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* ; fi
 
 # Update pip and install requirements
 COPY requirements.txt dev-requirements.txt mssql-requirements.txt ./


### PR DESCRIPTION
# Purpose

Reduces the size of the docker image. It's a small reduction compared to the overall size of the image, but will help a little.

# Changes
- Clean up the apt cache and add `--no-install-recommends` in the apt-get stages of the Dockerfile

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
