### PR TITLE
Make reading of environment variables case insensitive

### DIFF
--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -140,9 +140,9 @@ class FidesopsConfig(FidesSettings):
     admin_ui: AdminUiSettings
 
     PORT: int
-    is_test_mode: bool = os.getenv("TESTING") == "True"
-    hot_reloading: bool = os.getenv("FIDESOPS__HOT_RELOAD") == "True"
-    dev_mode: bool = os.getenv("FIDESOPS__DEV_MODE") == "True"
+    is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"
+    hot_reloading: bool = os.getenv("FIDESOPS__HOT_RELOAD", "").lower() == "true"
+    dev_mode: bool = os.getenv("FIDESOPS__DEV_MODE", "").lower() == "true"
 
     class Config:  # pylint: disable=C0115
         case_sensitive = True
@@ -151,7 +151,7 @@ class FidesopsConfig(FidesSettings):
         f"Startup configuration: reloading = {hot_reloading}, dev_mode = {dev_mode}"
     )
     logger.warning(
-        f'Startup configuration: pii logging = {os.getenv("FIDESOPS__LOG_PII") == "True"}'
+        f'Startup configuration: pii logging = {os.getenv("FIDESOPS__LOG_PII", "").lower() == "true"}'
     )
 
     def log_all_config_values(self) -> None:

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -26,7 +26,7 @@ def get_fides_log_record_factory() -> Any:
         func: str = None,
         sinfo: str = None,
     ) -> logging.LogRecord:
-        env_log_pii: bool = os.getenv("FIDESOPS__LOG_PII") == "True"
+        env_log_pii: bool = os.getenv("FIDESOPS__LOG_PII", "").lower() == "true"
         new_args = args
         if not env_log_pii:
             new_args = tuple(_mask_pii_for_logs(arg) for arg in args)


### PR DESCRIPTION
# Purpose

Makes the reading of the boolean environment variables case insensitive

# Changes
- Convert the reading of the boolean environment in config.py to lower
- Convert the reading of the boolean environment variable in logger.py to lower

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #710
 
