### PR TITLE
update tutorial directions to install fidesdemo from the root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.0...main)
 
+### Docs
+* Updated the tutorial installation to use main in fidesdemo [#715](https://github.com/ethyca/fidesops/pull/715)
 
 ## [1.6.0](https://github.com/ethyca/fidesops/compare/1.5.3...1.6.0)
 

--- a/docs/fidesops/docs/tutorial/installation.md
+++ b/docs/fidesops/docs/tutorial/installation.md
@@ -11,13 +11,10 @@ To run this project, ensure you have the following requirements installed and ru
 
 ## Clone the fidesdemo repo
 
-Let's clone [Fides Demo](https://github.com/ethyca/fidesdemo), and rewind to an earlier tag, so we can build out 
-the later commits together. Among other things, this will give us a Flask App to 
-mimic your application and some YAML files that annotate the Flask App's databases. 
+Clone [Fides Demo](https://github.com/ethyca/fidesdemo), and run `make install` to begin setup. Among other things, this will create a [Flask](https://flask.palletsprojects.com/) app to mimic your application, and provide several YAML files that annotate the Flask app's databases. 
 ```bash
 git clone https://github.com/ethyca/fidesdemo
 cd fidesdemo
-git checkout fidesctl-demo
 make install
 source venv/bin/activate
 ```


### PR DESCRIPTION
# Purpose

Quick update to the demo/tutorial instructions, removing the need to check out older branches in fidesdemo.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #682
 
