### PR TITLE
Parallelize CI safe checks

### DIFF
--- a/.github/workflows/safe_pr_checks.yml
+++ b/.github/workflows/safe_pr_checks.yml
@@ -20,7 +20,7 @@ jobs:
         pip install -U pip
         pip install -r dev-requirements.txt
         pip install -e .
-    - name: run iort
+    - name: run isort
       run: isort --check-only src tests
 
   Black:

--- a/.github/workflows/safe_pr_checks.yml
+++ b/.github/workflows/safe_pr_checks.yml
@@ -6,26 +6,88 @@ on:
   pull_request:
 
 jobs:
-  Check-All:
+  Import-Sorting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: "pip"
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -r dev-requirements.txt
+        pip install -e .
+    - name: run iort
+      run: isort --check-only src tests
+
+  Black:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: "pip"
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -r dev-requirements.txt
+        pip install -e .
+    - name: run black
+      run: black --check src tests
+
+  Pylint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: "pip"
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -r dev-requirements.txt
+        pip install -e .
+    - name: run pylint
+      run: pylint src tests
+
+  MyPy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: "pip"
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -r dev-requirements.txt
+        pip install -e .
+    - name: run pylint
+      run: mypy src
+
+  Docker-Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker Compose Build
         run: make compose-build
 
-      - name: Format
-        run: make black-ci
-
-      - name: Import Sorting
-        run: make isort-ci
-
-      - name: Lint
-        run: make pylint
-
-      - name: Check Types
-        run: make mypy
+  Migration-Check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Init DB
         run: make init-db
@@ -33,9 +95,27 @@ jobs:
       - name: Check Migrations
         run: make check-migrations
 
+  Unit-Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Init DB
+        run: make init-db
+
       - name: Unit Tests
         run: make pytest
         timeout-minutes: 20
+
+  Integration-Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Init DB
+        run: make init-db
 
       - name: Integration Tests
         run: make pytest-integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.0...main)
 ### Developer Experience
 * Reduce the size of the docker image [#707](https://github.com/ethyca/fidesops/pull/707)
-  
+* Parallelize CI safe checks to reduce run time [#717](https://github.com/ethyca/fidesops/pull/717)
+
 * ### Docs
 * Updated the tutorial installation to use main in fidesdemo [#715](https://github.com/ethyca/fidesops/pull/715)
 


### PR DESCRIPTION
# Purpose

Parallelize the safe CI checks to reduce run times.

Currently the safe CI checks take an average of around 13 minutes to run. I did some testing on a private fork and was getting an average run time of around 8:45 running the jobs in parallel, which is about a 33% reduction in time.

# Changes
- Modify the tests in `safe_pr_checks.yml` to run in parallel rather than serially.
- Run linting outside of docker. Doing this further reduces run times. Pylint is the longest running job in this section at about 2 minutes.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
