### PR TITLE
708 - fix console warning in disable connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 
 ### Fixed
 * Make reading of environment variables case insensitive [712](https://github.com/ethyca/fidesops/pull/712)
+* Fix console warning in disable connection modal [750](https://github.com/ethyca/fidesops/pull/750)
 
 
 ## [1.6.0](https://github.com/ethyca/fidesops/compare/1.5.3...1.6.0)

--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -38,15 +38,13 @@ const DisableConnectionModal: React.FC<DataConnectionProps> = ({
 
   const handleDisableConnection = async () => {
     const shouldDisable = !disabled;
-    return patchConnection({
+    patchConnection({
       key: connection_key,
       name,
       disabled: shouldDisable,
       access: access_type,
       connection_type,
     })
-      .unwrap()
-      .then(() => onClose());
   };
 
   const closeIfComplete = () => {

--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -44,7 +44,7 @@ const DisableConnectionModal: React.FC<DataConnectionProps> = ({
       disabled: shouldDisable,
       access: access_type,
       connection_type,
-    })
+    });
   };
 
   const closeIfComplete = () => {


### PR DESCRIPTION
# Purpose
Fix console warning in disable connections

# Changes
- Removes unneeded code in disable connection

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #708 
 
