### PR TITLE
[#681] add documentation on fideslog use

### DIFF
--- a/docs/fidesops/docs/development/fideslog.md
+++ b/docs/fidesops/docs/development/fideslog.md
@@ -1,0 +1,30 @@
+# Fideslog Analytics
+
+Fidesops includes an implementation of [fideslog](https://github.com/ethyca/fideslog) to provide Ethyca with an understanding of user interactions with fides tooling. 
+
+All collected analytics are anonymized, and only used in either product roadmap determination, or as insight into product adoption. Information collected by fideslog is received via HTTPs request, stored in a secure database, and never shared with third parties unless required by law.
+
+More information on use, implementation, and configuration can be found in the [fideslog repository](https://github.com/ethyca/fideslog#readme).
+
+## Collected Data
+Fideslog collects information on instances of fidesops by recording internal events. Starting the server and calling an endpoint will result in sending any or all of the following analytics data to Ethyca:  
+
+| Parameter | Description |
+|----|----|
+| `docker` | If fidesops is run in a docker container. |
+| `event` | The type of analytics event - currently, either a **server start** or **endpoint call**.
+| `event_created` | The time of the event. |
+| `endpoint` | The endpoint accessed. |
+| `status_code` | The status result of the request. |
+| `error` | Error information, if any. |
+
+## Disabling Fideslog
+
+To opt out of analytics, set either the following fidesops environment variable or `.toml` configuration variable to `True`. 
+
+| Variable | Default | Use | 
+|---|---|---|
+| `ANALYTICS_OPT_OUT` | False | Include in your `fidesops.toml` file. | 
+| `FIDESOPS__USER__ANALYTICS_OPT_OUT` | False | Include in your environment variables. |
+
+For more information, see the fidesops [configuration guide](../guides/configuration_reference.md).

--- a/docs/fidesops/mkdocs.yml
+++ b/docs/fidesops/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Contributing Details: development/contributing_details.md
       - Code Style: development/code_style.md
       - Documentation: development/documentation.md
+      - Fideslog Analytics: development/fideslog.md
       - Testing: development/testing.md
       - Pull Requests: development/pull_requests.md
       - Releases: development/releases.md


### PR DESCRIPTION
# Purpose

Add a new page on how fideslog is used, and how to opt out of analytics, to the fidesops documentation.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [X] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)

# Ticket

Fixes #681 
 
