### PR TITLE
Fix no such container error with docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,6 @@ The types of changes are:
 * Make reading of environment variables case insensitive [712](https://github.com/ethyca/fidesops/pull/712)
 * Fix console warning in disable connection modal [750](https://github.com/ethyca/fidesops/pull/750)
 * Fix no such container error with docker-compose [758](https://github.com/ethyca/fidesops/pull/758)
-
-### Fixed
 * Fixed issue with extending the configuration [#721](https://github.com/ethyca/fidesops/pull/721)
 
 ## [1.6.0](https://github.com/ethyca/fidesops/compare/1.5.3...1.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 ### Fixed
 * Make reading of environment variables case insensitive [712](https://github.com/ethyca/fidesops/pull/712)
 * Fix console warning in disable connection modal [750](https://github.com/ethyca/fidesops/pull/750)
+* Fix no such container error with docker-compose [758](https://github.com/ethyca/fidesops/pull/758)
 
 ### Fixed
 * Fixed issue with extending the configuration [#721](https://github.com/ethyca/fidesops/pull/721)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@
 REGISTRY := ethyca
 IMAGE_TAG := $(shell git fetch --force --tags && git describe --tags --dirty --always)
 
+# IMAGE_NAME is webserver rather than fidesops_webserver because commands that don't
+# use docker-compose fail with fidesops_webserver. When left as webserver here both
+# sets of commands work.
 IMAGE_NAME := webserver
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 IMAGE_LATEST := $(REGISTRY)/$(IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 REGISTRY := ethyca
 IMAGE_TAG := $(shell git fetch --force --tags && git describe --tags --dirty --always)
 
-IMAGE_NAME := fidesops_webserver
+IMAGE_NAME := webserver
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 IMAGE_LATEST := $(REGISTRY)/$(IMAGE_NAME):latest
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 REGISTRY := ethyca
 IMAGE_TAG := $(shell git fetch --force --tags && git describe --tags --dirty --always)
 
-IMAGE_NAME := webserver
+IMAGE_NAME := fidesops_webserver
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 IMAGE_LATEST := $(REGISTRY)/$(IMAGE_NAME):latest
 

--- a/docker-compose.no-db.yml
+++ b/docker-compose.no-db.yml
@@ -1,5 +1,6 @@
 services:
   webserver:
+    container_name: fidesops_webserver
     build:
       context: .
       dockerfile: Dockerfile.app

--- a/docker-compose.no-db.yml
+++ b/docker-compose.no-db.yml
@@ -1,6 +1,6 @@
 services:
   webserver:
-    container_name: fidesops_webserver
+    container_name: webserver
     build:
       context: .
       dockerfile: Dockerfile.app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   webserver:
-    container_name: fidesops_webserver
+    container_name: webserver
     build:
       context: .
       dockerfile: Dockerfile.app
@@ -60,7 +60,7 @@ services:
       - "0.0.0.0:6379:6379"
 
   worker:
-    container_name: fidesops_worker
+    container_name: worker
     build:
       context: .
       dockerfile: Dockerfile.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   webserver:
+    container_name: fidesops_webserver
     build:
       context: .
       dockerfile: Dockerfile.app
@@ -59,6 +60,7 @@ services:
       - "0.0.0.0:6379:6379"
 
   worker:
+    container_name: fidesops_worker
     build:
       context: .
       dockerfile: Dockerfile.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - "0.0.0.0:6379:6379"
 
   worker:
-    container_name: worker
     build:
       context: .
       dockerfile: Dockerfile.worker

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -37,7 +37,6 @@ TASK_RETRY_BACKOFF = 1
 
 [root_user]
 ANALYTICS_OPT_OUT = false
-ANALYTICS_ID = "91fbafc8ef088428337922c03f97e4ad"
 
 [admin_ui]
 ENABLED = true

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -37,6 +37,7 @@ TASK_RETRY_BACKOFF = 1
 
 [root_user]
 ANALYTICS_OPT_OUT = false
+ANALYTICS_ID = "91fbafc8ef088428337922c03f97e4ad"
 
 [admin_ui]
 ENABLED = true

--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -5,10 +5,7 @@ and related workflows.
 import argparse
 import subprocess
 import sys
-from typing import (
-    List,
-)
-
+from typing import List
 
 DOCKER_WAIT = 5
 DOCKERFILE_DATASTORES = [
@@ -24,7 +21,7 @@ EXTERNAL_DATASTORE_CONFIG = {
     "bigquery": ["BIGQUERY_KEYFILE_CREDS", "BIGQUERY_DATASET"],
 }
 EXTERNAL_DATASTORES = list(EXTERNAL_DATASTORE_CONFIG.keys())
-IMAGE_NAME = "webserver"
+IMAGE_NAME = "fidesops_webserver"
 
 
 def run_infrastructure(

--- a/run_infrastructure.py
+++ b/run_infrastructure.py
@@ -21,7 +21,7 @@ EXTERNAL_DATASTORE_CONFIG = {
     "bigquery": ["BIGQUERY_KEYFILE_CREDS", "BIGQUERY_DATASET"],
 }
 EXTERNAL_DATASTORES = list(EXTERNAL_DATASTORE_CONFIG.keys())
-IMAGE_NAME = "fidesops_webserver"
+IMAGE_NAME = "webserver"
 
 
 def run_infrastructure(


### PR DESCRIPTION
# Purpose

Fix the error when running `run_infrastructure.py`

# Changes
- Set `IMAGE_NAME` to `fidesops_webserver`
- Add `container_name` to docker-compose files

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #756
 
