### PR TITLE
660 Add support for multiple statuses to be selected for filtering subject requests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The types of changes are:
 
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.1...main)
+* Add support for multiple statuses to be selected for filtering subject requests [#660](https://github.com/ethyca/fidesops/pull/802)
 
 ## [1.6.1](https://github.com/ethyca/fidesops/compare/1.6.0...1.6.1)
 

--- a/docs/fidesops/docs/guides/reporting.md
+++ b/docs/fidesops/docs/guides/reporting.md
@@ -71,6 +71,11 @@ Use the following query params to further filter your privacy requests.  Filters
 - errored_lt
 - errored_gt
 
+You can filter for multiple statuses by repeating the status query param:
+
+`GET api/v1/privacy-request?status=paused&status=complete`
+
+
 
 ## View All Privacy Request Logs
 

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Security
+from fastapi.params import Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
@@ -290,7 +291,9 @@ def execution_logs_by_dataset_name(
 def _filter_privacy_request_queryset(
     query: Query,
     request_id: Optional[str] = None,
-    status: Optional[PrivacyRequestStatus] = None,
+    status: Optional[List[PrivacyRequestStatus]] = Query(
+        default=None
+    ),  # type:ignore
     created_lt: Optional[datetime] = None,
     created_gt: Optional[datetime] = None,
     started_lt: Optional[datetime] = None,
@@ -302,7 +305,10 @@ def _filter_privacy_request_queryset(
     external_id: Optional[str] = None,
 ) -> Query:
     """
-    Utility method to apply filters to our privacy request query
+    Utility method to apply filters to our privacy request query.
+
+    Status supports "or" filtering:
+    ?status=approved&status=pending will be translated into an "or" query.
     """
     if any([completed_lt, completed_gt]) and any([errored_lt, errored_gt]):
         raise HTTPException(
@@ -336,7 +342,7 @@ def _filter_privacy_request_queryset(
     if external_id:
         query = query.filter(PrivacyRequest.external_id.ilike(f"{external_id}%"))
     if status:
-        query = query.filter(PrivacyRequest.status == status)
+        query = query.filter(PrivacyRequest.status.in_(status))
     if created_lt:
         query = query.filter(PrivacyRequest.created_at < created_lt)
     if created_gt:

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Security
-from fastapi.params import Query
+from fastapi.params import Query as FastAPIQuery
 from fastapi_pagination import Page, Params
 from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
@@ -291,9 +291,7 @@ def execution_logs_by_dataset_name(
 def _filter_privacy_request_queryset(
     query: Query,
     request_id: Optional[str] = None,
-    status: Optional[List[PrivacyRequestStatus]] = Query(
-        default=None
-    ),  # type:ignore
+    status: Optional[List[PrivacyRequestStatus]] = None,
     created_lt: Optional[datetime] = None,
     created_gt: Optional[datetime] = None,
     started_lt: Optional[datetime] = None,
@@ -431,7 +429,9 @@ def get_request_status(
     db: Session = Depends(deps.get_db),
     params: Params = Depends(),
     request_id: Optional[str] = None,
-    status: Optional[PrivacyRequestStatus] = None,
+    status: Optional[List[PrivacyRequestStatus]] = FastAPIQuery(
+        default=None
+    ),  # type:ignore
     created_lt: Optional[datetime] = None,
     created_gt: Optional[datetime] = None,
     started_lt: Optional[datetime] = None,

--- a/tests/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -48,7 +48,6 @@ from fidesops.models.privacy_request import (
     ManualAction,
     PrivacyRequest,
     PrivacyRequestStatus,
-    StoppedCollection,
 )
 from fidesops.schemas.dataset import DryRunDatasetResponse
 from fidesops.schemas.jwt import (
@@ -649,6 +648,25 @@ class TestGetPrivacyRequests:
         resp = response.json()
         assert len(resp["items"]) == 1
         assert resp["items"][0]["id"] == failed_privacy_request.id
+
+    def test_filter_privacy_request_by_multiple_statuses(
+        self,
+        api_client: TestClient,
+        url,
+        generate_auth_header,
+        privacy_request,
+        succeeded_privacy_request,
+        failed_privacy_request,
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        response = api_client.get(
+            url + f"?status=complete&status=error", headers=auth_header
+        )
+        assert 200 == response.status_code
+        resp = response.json()
+        assert len(resp["items"]) == 2
+        assert resp["items"][0]["id"] == failed_privacy_request.id
+        assert resp["items"][1]["id"] == succeeded_privacy_request.id
 
     def test_filter_privacy_requests_by_internal_id(
         self,


### PR DESCRIPTION
# Purpose

# Changes
660 - Add support for multiple statuses to be selected for filtering subject requests (https://github.com/ethyca/fidesops/issues/660)

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 #660 
