### PR TITLE
660 Add support for multiple statuses to be selected for filtering subject requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
 ### Docs
 * Updated the tutorial installation to use main in fidesdemo [#715](https://github.com/ethyca/fidesops/pull/715)
 * Added a page on how to use the datastore UI [#742](https://github.com/ethyca/fidesops/pull/742)
+* Added a page on implementing and opting out of fideslog analytics [#751](https://github.com/ethyca/fidesops/pull/751)
 
 ### Fixed
 * Make reading of environment variables case insensitive [712](https://github.com/ethyca/fidesops/pull/712)

--- a/docs/fidesops/docs/development/fideslog.md
+++ b/docs/fidesops/docs/development/fideslog.md
@@ -1,0 +1,30 @@
+# Fideslog Analytics
+
+Fidesops includes an implementation of [fideslog](https://github.com/ethyca/fideslog) to provide Ethyca with an understanding of user interactions with fides tooling. 
+
+All collected analytics are anonymized, and only used in either product roadmap determination, or as insight into product adoption. Information collected by fideslog is received via HTTPs request, stored in a secure database, and never shared with third parties unless required by law.
+
+More information on use, implementation, and configuration can be found in the [fideslog repository](https://github.com/ethyca/fideslog#readme).
+
+## Collected Data
+Fideslog collects information on instances of fidesops by recording internal events. Using fidesops may result in sending any or all of the following analytics data to Ethyca:  
+
+| Parameter | Description |
+|----|----|
+| `docker` | If fidesops is run in a docker container. |
+| `event` | The type of analytics event - currently, either a **server start** or **endpoint call**.
+| `event_created` | The time of the event. |
+| `endpoint` | The endpoint accessed. |
+| `status_code` | The status result of the request. |
+| `error` | Error information, if any. |
+
+## Disabling Fideslog
+
+To opt out of analytics, set either the following fidesops environment variable or `.toml` configuration variable to `True`. 
+
+| Variable | Default | Use | 
+|---|---|---|
+| `ANALYTICS_OPT_OUT` | False | Include in your `fidesops.toml` file. | 
+| `FIDESOPS__USER__ANALYTICS_OPT_OUT` | False | Include in your environment variables. |
+
+For more information, see the fidesops [configuration guide](../guides/configuration_reference.md).

--- a/docs/fidesops/mkdocs.yml
+++ b/docs/fidesops/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Contributing Details: development/contributing_details.md
       - Code Style: development/code_style.md
       - Documentation: development/documentation.md
+      - Fideslog Analytics: development/fideslog.md
       - Testing: development/testing.md
       - Pull Requests: development/pull_requests.md
       - Releases: development/releases.md

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Security
+from fastapi.params import Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.bases import AbstractPage
 from fastapi_pagination.ext.sqlalchemy import paginate
@@ -290,7 +291,9 @@ def execution_logs_by_dataset_name(
 def _filter_privacy_request_queryset(
     query: Query,
     request_id: Optional[str] = None,
-    status: Optional[PrivacyRequestStatus] = None,
+    status: Optional[List[PrivacyRequestStatus]] = Query(
+        default=None
+    ),  # type:ignore
     created_lt: Optional[datetime] = None,
     created_gt: Optional[datetime] = None,
     started_lt: Optional[datetime] = None,
@@ -302,7 +305,10 @@ def _filter_privacy_request_queryset(
     external_id: Optional[str] = None,
 ) -> Query:
     """
-    Utility method to apply filters to our privacy request query
+    Utility method to apply filters to our privacy request query.
+
+    Status supports "or" filtering:
+    ?status=approved&status=pending will be translated into an "or" query.
     """
     if any([completed_lt, completed_gt]) and any([errored_lt, errored_gt]):
         raise HTTPException(
@@ -336,7 +342,7 @@ def _filter_privacy_request_queryset(
     if external_id:
         query = query.filter(PrivacyRequest.external_id.ilike(f"{external_id}%"))
     if status:
-        query = query.filter(PrivacyRequest.status == status)
+        query = query.filter(PrivacyRequest.status.in_(status))
     if created_lt:
         query = query.filter(PrivacyRequest.created_at < created_lt)
     if created_gt:


### PR DESCRIPTION
# Purpose

# Changes
- Add support for multiple statuses to be selected for filtering subject requests (https://github.com/ethyca/fidesops/issues/660)

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 #660 
