### PR TITLE
Fix issue requiring separate install of snowflake-connector-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The types of changes are:
 ### Fixed
 * Resolve issue with MyPy seeing files in fidesops as missing imports [#719](https://github.com/ethyca/fidesops/pull/719)
 * Fixed `check-migrations` Make command [#806](https://github.com/ethyca/fidesops/pull/806)
+* Fix issue requiring separate install of snowflake-connector-python [#807](https://github.com/ethyca/fidesops/pull/807)
+
 ## [1.6.1](https://github.com/ethyca/fidesops/compare/1.6.0...1.6.1)
 
 ### Added

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -22,6 +22,7 @@ RUN apt-get update && \
     g++ \
     gnupg \
     gcc \
+    python3-wheel \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -45,8 +46,6 @@ RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get -y --no-install-r
 # Update pip and install requirements
 COPY requirements.txt dev-requirements.txt mssql-requirements.txt ./
 RUN pip install -U pip  \
-    && pip install 'cryptography~=3.4.8' \
-    && pip install snowflake-connector-python --no-use-pep517  \
     && pip install -r requirements.txt -r dev-requirements.txt
 
 RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then pip install -U pip -r mssql-requirements.txt ; fi

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -15,6 +15,7 @@ RUN apt-get update && \
     g++ \
     gnupg \
     gcc \
+    python3-wheel \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,8 +38,6 @@ RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then apt-get -y install \
 # Update pip and install requirements
 COPY requirements.txt dev-requirements.txt mssql-requirements.txt ./
 RUN pip install -U pip  \
-    && pip install 'cryptography~=3.4.8' \
-    && pip install snowflake-connector-python --no-use-pep517  \
     && pip install -r requirements.txt -r dev-requirements.txt
 
 RUN if [ "$SKIP_MSSQL_INSTALLATION" != "true" ] ; then pip install -U pip -r mssql-requirements.txt ; fi


### PR DESCRIPTION
# Purpose

Fixes the issue requiring `snowflake-connector-python` to be installed in docker with `--no-use-pep517`, also removing the need to install `cryptography` separately in the Dockerfile.

# Changes
- Install `python3-wheel` in the Dockerfile
- Remove the step to install `cryptography` in the Dockerfile
- Remove the step to install `snowflake-connector-python` in the Dockerfile

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #744
 
