### PR TITLE
update celery config defaults, set to redis settings if none provided

### DIFF
--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -39,8 +39,8 @@ class ExecutionSettings(FidesSettings):
     TASK_RETRY_BACKOFF: int
     REQUIRE_MANUAL_REQUEST_APPROVAL: bool = False
     MASKING_STRICT: bool = True
-    CELERY_BROKER_URL: str = "redis://:testpassword@redis:6379/1"
-    CELERY_RESULT_BACKEND: str = "redis://:testpassword@redis:6379/1"
+    CELERY_BROKER_URL: Optional[str] = None
+    CELERY_RESULT_BACKEND: Optional[str] = None
 
     class Config:
         env_prefix = "FIDESOPS__EXECUTION__"
@@ -59,6 +59,26 @@ class RedisSettings(FidesSettings):
     ENABLED: bool = True
     SSL: bool = False
     SSL_CERT_REQS: Optional[str] = "required"
+    REDIS_CONNECTION_URL: Optional[str] = None
+
+    @validator("REDIS_CONNECTION_URL", pre=True)
+    @classmethod
+    def assemble_redis_connection_url(
+        cls,
+        v: Optional[str],
+        values: Dict[str, str],
+    ) -> str:
+        """Join Redis connection credentials into a connection string"""
+        if isinstance(v, str):
+            # If the whole URL is provided via the config, preference that
+            return v
+
+        return "redis://:{password}@{host}:{port}/{db_index}".format(
+            password=values["PASSWORD"],
+            host=values["HOST"],
+            port=values["PORT"],
+            db_index=values.get("DB_INDEX"),
+        )
 
     class Config:
         env_prefix = "FIDESOPS__REDIS__"

--- a/src/fidesops/tasks/__init__.py
+++ b/src/fidesops/tasks/__init__.py
@@ -12,8 +12,14 @@ def _create_celery() -> Celery:
     """
     logger.info("Creating Celery app...")
     app = Celery(__name__)
-    app.conf.update(broker_url=config.execution.CELERY_BROKER_URL)
-    app.conf.update(result_backend=config.execution.CELERY_RESULT_BACKEND)
+
+    broker_url = config.execution.CELERY_BROKER_URL or config.redis.REDIS_CONNECTION_URL
+    app.conf.update(broker_url=broker_url)
+
+    result_backend = (
+        config.execution.CELERY_RESULT_BACKEND or config.redis.REDIS_CONNECTION_URL
+    )
+    app.conf.update(result_backend=result_backend)
     logger.info("Autodiscovering tasks...")
     app.autodiscover_tasks(
         [


### PR DESCRIPTION
# Purpose

Changes the default Celery implementation settings to default to the Redis cache.

# Changes
- Adds a `redis_connection_url` that can be manually specified
- Set `result_backend` to `redis_connection_url` if no `celery_result_backend` is supplied
- Set `broker_url` to `redis_connection_url` if no `celery_broker_url` is supplied

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #771 
 
