### PR TITLE
test fixing publish_docs ci action

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docs/**"
+
 jobs:
   publish_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -3,7 +3,7 @@ name: Publish updated docs to gh-pages
 on:
   push:
     branches:
-      - docs_test_branch
+      - main
     paths:
       - "docs/**"
   

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: "pip"
       - run: pip install -r docs/fidesops/requirements.txt
       - name: Build docs
         run: make docs-build

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -3,7 +3,7 @@ name: Publish updated docs to gh-pages
 on:
   push:
     branches:
-      - main
+      - docs_test_branch
     paths:
       - "docs/**"
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The types of changes are:
 * Resolve issue with MyPy seeing files in fidesops as missing imports [#719](https://github.com/ethyca/fidesops/pull/719)
 * Fixed `check-migrations` Make command [#806](https://github.com/ethyca/fidesops/pull/806)
 * Fix issue requiring separate install of snowflake-connector-python [#807](https://github.com/ethyca/fidesops/pull/807)
-
+* Fix publish_docs CI action [#818](https://github.com/ethyca/fidesops/pull/818)
 
 ## [1.6.1](https://github.com/ethyca/fidesops/compare/1.6.0...1.6.1)
 


### PR DESCRIPTION
# Purpose
Upon merging in https://github.com/ethyca/fidesops/pull/795, we got some failures on the `publish_docs` job:

`The specified python version file at: /home/runner/work/fidesops/fidesops/.python-version does not exist`

This PR should fix this error and result in successful `publish_docs` job.

# Changes
- Updates yaml  to specify python version

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Unticketed
 
