### PR TITLE
Handle hashed password

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.8.3
 fastapi[all]==0.78.0
 fideslang==1.0.0
-fideslib==2.1.1
+fideslib==2.2.1
 fideslog==1.2.1
 multidimensional_urlencode==0.0.4
 pandas==1.3.3

--- a/tests/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/api/v1/endpoints/test_user_endpoints.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytest
 from fastapi_pagination import Params
+from fideslib.cryptography.cryptographic_util import str_to_b64_str
 from fideslib.cryptography.schemas.jwt import (
     JWE_ISSUED_AT,
     JWE_PAYLOAD_CLIENT_ID,
@@ -70,7 +71,10 @@ class TestCreateUser:
         url,
     ) -> None:
         auth_header = generate_auth_header([USER_CREATE])
-        body = {"username": "spaces in name", "password": "TestP@ssword9"}
+        body = {
+            "username": "spaces in name",
+            "password": str_to_b64_str("TestP@ssword9"),
+        }
 
         response = api_client.post(url, headers=auth_header, json=body)
         assert HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
@@ -84,7 +88,7 @@ class TestCreateUser:
     ) -> None:
         auth_header = generate_auth_header([USER_CREATE])
 
-        body = {"username": "test_user", "password": "TestP@ssword9"}
+        body = {"username": "test_user", "password": str_to_b64_str("TestP@ssword9")}
         user = FidesUser.create(db=db, data=body)
 
         response = api_client.post(url, headers=auth_header, json=body)
@@ -103,7 +107,7 @@ class TestCreateUser:
     ) -> None:
         auth_header = generate_auth_header([USER_CREATE])
 
-        body = {"username": "test_user", "password": "short"}
+        body = {"username": "test_user", "password": str_to_b64_str("short")}
         response = api_client.post(url, headers=auth_header, json=body)
         assert HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
         assert (
@@ -111,7 +115,7 @@ class TestCreateUser:
             == "Password must have at least eight characters."
         )
 
-        body = {"username": "test_user", "password": "longerpassword"}
+        body = {"username": "test_user", "password": str_to_b64_str("longerpassword")}
         response = api_client.post(url, headers=auth_header, json=body)
         assert HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
         assert (
@@ -119,7 +123,7 @@ class TestCreateUser:
             == "Password must have at least one number."
         )
 
-        body = {"username": "test_user", "password": "longer55password"}
+        body = {"username": "test_user", "password": str_to_b64_str("longer55password")}
         response = api_client.post(url, headers=auth_header, json=body)
         assert HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
         assert (
@@ -127,7 +131,7 @@ class TestCreateUser:
             == "Password must have at least one capital letter."
         )
 
-        body = {"username": "test_user", "password": "LoNgEr55paSSworD"}
+        body = {"username": "test_user", "password": str_to_b64_str("LoNgEr55paSSworD")}
         response = api_client.post(url, headers=auth_header, json=body)
         assert HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
         assert (
@@ -143,7 +147,7 @@ class TestCreateUser:
         url,
     ) -> None:
         auth_header = generate_auth_header([USER_CREATE])
-        body = {"username": "test_user", "password": "TestP@ssword9"}
+        body = {"username": "test_user", "password": str_to_b64_str("TestP@ssword9")}
 
         response = api_client.post(url, headers=auth_header, json=body)
 
@@ -164,7 +168,7 @@ class TestCreateUser:
         auth_header = generate_auth_header([USER_CREATE])
         body = {
             "username": "test_user",
-            "password": "TestP@ssword9",
+            "password": str_to_b64_str("TestP@ssword9"),
             "first_name": "Test",
             "last_name": "User",
         }
@@ -211,7 +215,7 @@ class TestDeleteUser:
             db=db,
             data={
                 "username": "test_delete_user",
-                "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+                "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
             },
         )
         saved_user_id = user.id
@@ -264,7 +268,7 @@ class TestDeleteUser:
             db=db,
             data={
                 "username": "test_delete_user",
-                "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+                "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
             },
         )
 
@@ -362,7 +366,7 @@ class TestGetUsers:
         for i in range(total_users):
             body = {
                 "username": f"user{i}@example.com",
-                "password": "Password123!",
+                "password": str_to_b64_str("Password123!"),
                 "first_name": "Test",
                 "last_name": "User",
             }
@@ -399,7 +403,7 @@ class TestGetUsers:
         for i in range(total_users):
             body = {
                 "username": f"user{i}@example.com",
-                "password": "Password123!",
+                "password": str_to_b64_str("Password123!"),
             }
             resp = api_client.post(url, headers=create_auth_header, json=body)
             assert resp.status_code == HTTP_201_CREATED
@@ -577,8 +581,8 @@ class TestUpdateUserPassword:
             f"{url_no_id}/{user.id}/reset-password",
             headers=auth_header,
             json={
-                "old_password": OLD_PASSWORD,
-                "new_password": NEW_PASSWORD,
+                "old_password": str_to_b64_str(OLD_PASSWORD),
+                "new_password": str_to_b64_str(NEW_PASSWORD),
             },
         )
         assert resp.status_code == HTTP_401_UNAUTHORIZED
@@ -610,8 +614,8 @@ class TestUpdateUserPassword:
             f"{url_no_id}/{application_user.id}/reset-password",
             headers=auth_header,
             json={
-                "old_password": "mismatching password",
-                "new_password": NEW_PASSWORD,
+                "old_password": str_to_b64_str("mismatching password"),
+                "new_password": str_to_b64_str(NEW_PASSWORD),
             },
         )
         assert resp.status_code == HTTP_401_UNAUTHORIZED
@@ -631,7 +635,6 @@ class TestUpdateUserPassword:
         OLD_PASSWORD = "oldpassword"
         NEW_PASSWORD = "newpassword"
         application_user.update_password(db=db, new_password=OLD_PASSWORD)
-
         auth_header = generate_auth_header_for_user(
             user=application_user,
             scopes=[USER_PASSWORD_RESET],
@@ -640,12 +643,11 @@ class TestUpdateUserPassword:
             f"{url_no_id}/{application_user.id}/reset-password",
             headers=auth_header,
             json={
-                "old_password": OLD_PASSWORD,
-                "new_password": NEW_PASSWORD,
+                "old_password": str_to_b64_str(OLD_PASSWORD),
+                "new_password": str_to_b64_str(NEW_PASSWORD),
             },
         )
         assert resp.status_code == HTTP_200_OK
-
         db.expunge(application_user)
         application_user = application_user.refresh_from_db(db=db)
         assert application_user.credentials_valid(password=NEW_PASSWORD)
@@ -659,7 +661,7 @@ class TestUserLogin:
     def test_user_does_not_exist(self, db, url, api_client):
         body = {
             "username": "does not exist",
-            "password": "idonotknowmypassword",
+            "password": str_to_b64_str("idonotknowmypassword"),
         }
         response = api_client.post(url, headers={}, json=body)
         assert response.status_code == HTTP_404_NOT_FOUND
@@ -667,7 +669,7 @@ class TestUserLogin:
     def test_bad_login(self, db, url, user, api_client):
         body = {
             "username": user.username,
-            "password": "idonotknowmypassword",
+            "password": str_to_b64_str("idonotknowmypassword"),
         }
         response = api_client.post(url, headers={}, json=body)
         assert response.status_code == HTTP_403_FORBIDDEN
@@ -677,7 +679,7 @@ class TestUserLogin:
         user.client.delete(db)
         body = {
             "username": user.username,
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+            "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
         }
 
         assert user.client is None  # client does not exist
@@ -705,7 +707,7 @@ class TestUserLogin:
     def test_login_updates_last_login_date(self, db, url, user, api_client):
         body = {
             "username": user.username,
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+            "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
         }
 
         response = api_client.post(url, headers={}, json=body)
@@ -717,7 +719,7 @@ class TestUserLogin:
     def test_login_uses_existing_client(self, db, url, user, api_client):
         body = {
             "username": user.username,
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
+            "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
         }
 
         existing_client_id = user.client.id

--- a/tests/models/test_client.py
+++ b/tests/models/test_client.py
@@ -1,9 +1,9 @@
+from fideslib.cryptography.cryptographic_util import hash_with_salt
 from fideslib.models.client import ClientDetail
 from sqlalchemy.orm import Session
 
 from fidesops.api.v1.scope_registry import SCOPE_REGISTRY
 from fidesops.core.config import config
-from fidesops.util.cryptographic_util import hash_with_salt
 
 
 class TestClientModel:

--- a/tests/scripts/test_create_superuser.py
+++ b/tests/scripts/test_create_superuser.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from create_superuser import collect_username_and_password, create_user_and_client
+from fideslib.cryptography.cryptographic_util import str_to_b64_str
 from fideslib.exceptions import KeyOrNameAlreadyExists
 from fideslib.models.client import ADMIN_UI_ROOT, ClientDetail
 from fideslib.models.fides_user import FidesUser
@@ -23,7 +24,7 @@ class TestCreateSuperuserScript:
         db,
     ):
         GENERIC_INPUT = "some_input"
-        mock_pass.return_value = "TESTP@ssword9"
+        mock_pass.return_value = str_to_b64_str("TESTP@ssword9")
         mock_user.return_value = "test_user"
         mock_input.return_value = GENERIC_INPUT
         user: UserCreate = collect_username_and_password(db)
@@ -47,7 +48,7 @@ class TestCreateSuperuserScript:
             db=db,
             data={"username": "test_user", "password": "test_password"},
         )
-        mock_pass.return_value = "TESTP@ssword9"
+        mock_pass.return_value = str_to_b64_str("TESTP@ssword9")
         mock_user.return_value = "test_user"
         mock_input.return_value = "some_input"
 
@@ -66,7 +67,7 @@ class TestCreateSuperuserScript:
         mock_user,
         db,
     ):
-        mock_pass.return_value = "bad_password"
+        mock_pass.return_value = str_to_b64_str("bad_password")
         mock_user.return_value = "test_user"
         mock_input.return_value = "some_input"
 
@@ -83,7 +84,7 @@ class TestCreateSuperuserScript:
         mock_user,
         db,
     ):
-        mock_pass.return_value = "TESTP@ssword9"
+        mock_pass.return_value = str_to_b64_str("TESTP@ssword9")
         mock_user.return_value = "test_user"
         mock_input.return_value = "some_input"
 


### PR DESCRIPTION
# Purpose

Bumps fideslib to 2.2.1 in order to handle base64 encoded passwords.

# Changes
- Bump fideslib to 2.2.1
- Update tests to encode password.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #809
 
