### PR TITLE
Fix bug in client with no scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
 * Fix issue requiring separate install of snowflake-connector-python [#807](https://github.com/ethyca/fidesops/pull/807)
 * Fix publish_docs CI action [#818](https://github.com/ethyca/fidesops/pull/818)
 * Bump fideslib to handle base64 encoded password [#820](https://github.com/ethyca/fidesops/pull/820)
+* Fix error when there are no scopes in `ClientDetail` [#830](https://github.com/ethyca/fidesops/pull/830)
 
 ## [1.6.1](https://github.com/ethyca/fidesops/compare/1.6.0...1.6.1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.8.3
 fastapi[all]==0.78.0
 fideslang==1.0.0
-fideslib==2.2.1
+fideslib==2.2.2
 fideslog==1.2.1
 multidimensional_urlencode==0.0.4
 pandas==1.3.3

--- a/src/fidesops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/oauth_endpoints.py
@@ -76,7 +76,9 @@ async def acquire_access_token(
     else:
         raise AuthenticationFailure(detail="Authentication Failure")
 
-    client_detail = ClientDetail.get(db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY)
+    client_detail = ClientDetail.get(
+        db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY
+    )
 
     if client_detail is None:
         raise AuthenticationFailure(detail="Authentication Failure")

--- a/src/fidesops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/oauth_endpoints.py
@@ -76,6 +76,7 @@ async def acquire_access_token(
     else:
         raise AuthenticationFailure(detail="Authentication Failure")
 
+    # scopes param is only used if client is root client, otherwise we use the client's associated scopes
     client_detail = ClientDetail.get(
         db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY
     )

--- a/src/fidesops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/oauth_endpoints.py
@@ -76,7 +76,7 @@ async def acquire_access_token(
     else:
         raise AuthenticationFailure(detail="Authentication Failure")
 
-    client_detail = ClientDetail.get(db, object_id=client_id, config=config)
+    client_detail = ClientDetail.get(db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY)
 
     if client_detail is None:
         raise AuthenticationFailure(detail="Authentication Failure")

--- a/src/fidesops/util/oauth_util.py
+++ b/src/fidesops/util/oauth_util.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from starlette.status import HTTP_404_NOT_FOUND
 
 from fidesops.api.deps import get_db
+from fidesops.api.v1.scope_registry import SCOPE_REGISTRY
 from fidesops.api.v1.urn_registry import TOKEN, V1_URL_PREFIX
 from fidesops.core.config import config
 from fidesops.models.policy import PolicyPreWebhook
@@ -139,7 +140,7 @@ async def verify_oauth_client(
         raise AuthorizationError(detail="Not Authorized for this action")
 
     client = ClientDetail.get(
-        db, object_id=client_id, config=config, scopes=security_scopes.scopes
+        db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY
     )
 
     if not client:

--- a/src/fidesops/util/oauth_util.py
+++ b/src/fidesops/util/oauth_util.py
@@ -139,6 +139,7 @@ async def verify_oauth_client(
     if not client_id:
         raise AuthorizationError(detail="Not Authorized for this action")
 
+    # scopes param is only used if client is root client, otherwise we use the client's associated scopes
     client = ClientDetail.get(
         db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY
     )

--- a/tests/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/api/v1/endpoints/test_oauth_endpoints.py
@@ -408,7 +408,8 @@ class TestAcquireAccessToken:
         assert (
             json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
                 JWE_PAYLOAD_SCOPES
-            ] is None
+            ]
+            is None
         )
 
     def test_get_access_token(self, db, url, api_client):

--- a/tests/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/api/v1/endpoints/test_oauth_endpoints.py
@@ -409,7 +409,7 @@ class TestAcquireAccessToken:
             json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
                 JWE_PAYLOAD_SCOPES
             ]
-            is None
+            == SCOPE_REGISTRY
         )
 
     def test_get_access_token(self, db, url, api_client):

--- a/tests/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/api/v1/endpoints/test_oauth_endpoints.py
@@ -437,7 +437,7 @@ class TestAcquireAccessToken:
             json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
                 JWE_PAYLOAD_SCOPES
             ]
-            == []
+            == None
         )
 
         new_client.delete(db)

--- a/tests/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/api/v1/endpoints/test_oauth_endpoints.py
@@ -408,8 +408,7 @@ class TestAcquireAccessToken:
         assert (
             json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
                 JWE_PAYLOAD_SCOPES
-            ]
-            == []
+            ] is None
         )
 
     def test_get_access_token(self, db, url, api_client):
@@ -437,7 +436,7 @@ class TestAcquireAccessToken:
             json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
                 JWE_PAYLOAD_SCOPES
             ]
-            == None
+            == []
         )
 
         new_client.delete(db)

--- a/tests/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/api/v1/endpoints/test_oauth_endpoints.py
@@ -390,6 +390,28 @@ class TestAcquireAccessToken:
 
         new_client.delete(db)
 
+    def test_get_access_token_root_client(self, url, api_client):
+        data = {
+            "client_id": config.security.OAUTH_ROOT_CLIENT_ID,
+            "client_secret": config.security.OAUTH_ROOT_CLIENT_SECRET,
+        }
+
+        response = api_client.post(url, data=data)
+        jwt = json.loads(response.text).get("access_token")
+        assert 200 == response.status_code
+        assert (
+            data["client_id"]
+            == json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
+                JWE_PAYLOAD_CLIENT_ID
+            ]
+        )
+        assert (
+            json.loads(extract_payload(jwt, config.security.APP_ENCRYPTION_KEY))[
+                JWE_PAYLOAD_SCOPES
+            ]
+            == []
+        )
+
     def test_get_access_token(self, db, url, api_client):
         new_client, secret = ClientDetail.create_client_and_secret(
             db,


### PR DESCRIPTION
# Purpose

Bumps fideslib to fix bug when there are no scopes in `ClientDetail`

# Changes
- Bump fideslib to 2.2.2

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #829
 
