### PR TITLE
Skip Masking of Uvicorn Logs [#766]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
 * Fix issue requiring separate install of snowflake-connector-python [#807](https://github.com/ethyca/fidesops/pull/807)
 * Fix publish_docs CI action [#818](https://github.com/ethyca/fidesops/pull/818)
 * Bump fideslib to handle base64 encoded password [#820](https://github.com/ethyca/fidesops/pull/820)
+* Stop masking uvicorn logs by default [#831](https://github.com/ethyca/fidesops/pull/831)
 
 ## [1.6.1](https://github.com/ethyca/fidesops/compare/1.6.0...1.6.1)
 

--- a/src/fidesops/util/logger.py
+++ b/src/fidesops/util/logger.py
@@ -28,7 +28,7 @@ def get_fides_log_record_factory() -> Any:
     ) -> logging.LogRecord:
         env_log_pii: bool = os.getenv("FIDESOPS__LOG_PII", "").lower() == "true"
         new_args = args
-        if not env_log_pii:
+        if not env_log_pii and not name.startswith("uvicorn"):
             new_args = tuple(_mask_pii_for_logs(arg) for arg in args)
         return logging.LogRecord(
             name=name,


### PR DESCRIPTION
# Purpose

Masking uvicorn logs is tricky to debug.  Exclude these logs from being replaced with `MASKED`.

# Changes
- This proposes a quick one-line fix to exclude masking uvicorn logs, and then I recommend we reticket a follow-up to improve _how we log_, details in the #766 issue.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #766
 
