### PR TITLE
832 - Create new user gives HTTP 422 Unprocessable Entity exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 * Resolve issue with MyPy seeing files in fidesops as missing imports [#719](https://github.com/ethyca/fidesops/pull/719)
 * Fixed `check-migrations` Make command [#806](https://github.com/ethyca/fidesops/pull/806)
 * Fix issue requiring separate install of snowflake-connector-python [#807](https://github.com/ethyca/fidesops/pull/807)
+* [User Management] Create new user gives HTTP 422 Unprocessable Entity exception [#832] (https://github.com/ethyca/fidesops/pull/833)
 
 ### Docs
 * Backend UI deployment [#827](https://github.com/ethyca/fidesops/pull/827)

--- a/clients/admin-ui/src/features/user-management/NewUserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/NewUserForm.tsx
@@ -20,6 +20,7 @@ import React from "react";
 
 import { USER_MANAGEMENT_ROUTE, USER_PRIVILEGES } from "../../constants";
 import { isErrorWithDetail, isErrorWithDetailArray } from "../common/helpers";
+import { utf8ToB64 } from "../common/utils";
 import {
   useCreateUserMutation,
   useUpdateUserPermissionsMutation,
@@ -44,7 +45,7 @@ const useUserForm = () => {
         username: values.username,
         first_name: values.first_name,
         last_name: values.last_name,
-        password: values.password,
+        password: utf8ToB64(values.password),
       };
 
       const createUserResult = await createUser(userBody);


### PR DESCRIPTION
# Purpose
When a FidesOps user is creating a new user and clicks the "Save" button, the following toast error message is displayed:

utf-8' codec can't decode byte 0xd8 in position 4: invalid continuation byte

Via Chrome DevTools, you can see the API endpoint (http://0.0.0.0:8080/api/v1/user) POST is invoked resulting in a HTTP 422 Unprocessable Entity exception.

# Changes
- Ensured that the user password is base64 encrypted when submitted via API request.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 #832 
