### PR TITLE
Adding salesforce to SaaSType enum

### DIFF
--- a/data/saas/config/salesforce_config.yml
+++ b/data/saas/config/salesforce_config.yml
@@ -1,6 +1,7 @@
 saas_config:
   fides_key: salesforce_connector_example
   name: Salesforce SaaS Config
+  type: salesforce
   description: A sample schema representing the Salesforce connector for Fidesops
   version: 0.0.1
 

--- a/docs/fidesops/docs/guides/connection_types.md
+++ b/docs/fidesops/docs/guides/connection_types.md
@@ -20,6 +20,7 @@ database options and third party API services with which Fidesops can communicat
         "outreach",
         "postgres",
         "redshift",
+        "salesforce",
         "segment",
         "sentry",
         "snowflake",

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -184,6 +184,7 @@ class SaaSType(Enum):
     mailchimp = "mailchimp"
     hubspot = "hubspot"
     outreach = "outreach"
+    salesforce = "salesforce"
     segment = "segment"
     sentry = "sentry"
     stripe = "stripe"


### PR DESCRIPTION
# Purpose
Adding missing type for Salesforce SaaS config

# Changes
- Updated SaaSType enum
- Added type to Salesforce SaaS config

# Checklist
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
