### PR TITLE
Correct test name for mypy in safe_pr_checks.yml

### DIFF
--- a/.github/workflows/safe_pr_checks.yml
+++ b/.github/workflows/safe_pr_checks.yml
@@ -71,7 +71,7 @@ jobs:
         pip install -U pip
         pip install -r dev-requirements.txt
         pip install -e .
-    - name: run pylint
+    - name: run mypy
       run: mypy src
 
   Docker-Build:


### PR DESCRIPTION
# Purpose

I noticed that the name of the test for mypy in the safe checks is listed as pylint. This is only the name and didn't impact the actual test in any way.

# Changes
- Change the mypy test name from pylint to mypy

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
