### PR TITLE
Add dependabot label to dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,15 +4,31 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  labels:
+    - dependencies
+    - python
+    - dependabot
 - package-ecosystem: npm
   directory: '/clients/admin-ui'
   schedule:
     interval: weekly
+  labels:
+    - dependencies
+    - javascript
+    - dependabot
 - package-ecosystem: npm
   directory: '/clients/privacy-center'
   schedule:
     interval: weekly
+  labels:
+    - dependencies
+    - javascript
+    - dependabot
 - package-ecosystem: github-actions
   directory: '/'
   schedule:
     interval: weekly
+  labels:
+    - dependencies
+    - github_actions
+    - dependabot


### PR DESCRIPTION
# Purpose

Automatically add a dependabot label to PRs from Dependabot so they can be filtered in Slack.

# Changes
- Add labels to the `debendabot.yaml`

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
