### PR TITLE
Adds saas config base info to connection config responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ The types of changes are:
 
 * Update fidesops to use bcrypt for hashing [#876](https://github.com/ethyca/fidesops/pull/876)
 
-
+### Added
+* Adds saas config base info to connection config responses [#904](https://github.com/ethyca/fidesops/pull/904)
 
 
 ## [1.6.3](https://github.com/ethyca/fidesops/compare/1.6.2...1.6.3)

--- a/src/fidesops/schemas/connection_configuration/connection_config.py
+++ b/src/fidesops/schemas/connection_configuration/connection_config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Extra
 
 from fidesops.models.connectionconfig import AccessLevel, ConnectionType
 from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
+from fidesops.schemas.saas.saas_config import SaaSConfigBase
 from fidesops.schemas.shared_schemas import FidesOpsKey
 
 
@@ -69,6 +70,7 @@ class ConnectionConfigurationResponse(BaseModel):
     disabled: Optional[bool] = False
     last_test_timestamp: Optional[datetime]
     last_test_succeeded: Optional[bool]
+    saas_config: Optional[SaaSConfigBase]
 
     class Config:
         """Set orm_mode to support mapping to ConnectionConfig"""

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -201,6 +201,14 @@ class SaaSConfigBase(BaseModel):
     name: str
     type: SaaSType
 
+    @property
+    def fides_key(self):
+        return self.fides_key
+
+    @property
+    def name(self):
+        return self.name
+
     @validator("type", pre=True)
     def lowercase_saas_type(cls, value: str) -> str:
         """Enforce lowercase on saas type."""
@@ -275,11 +283,6 @@ class SaaSConfig(SaaSConfigBase):
             collections=collections,
             connection_key=super().fides_key,
         )
-
-    class Config:
-        """Populate models with the raw value of enum fields, rather than the enum itself"""
-
-        use_enum_values = True
 
 
 class SaaSConfigValidationDetails(BaseSchema):

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -199,7 +199,7 @@ class SaaSConfigBase(BaseModel):
 
     fides_key: FidesOpsKey
     name: str
-    connection_type: SaaSType = Field(..., alias="type")
+    type: SaaSType
 
     @property
     def fides_key_prop(self) -> FidesOpsKey:

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Union
 
-from pydantic import BaseModel, Extra, Field, root_validator, validator
+from pydantic import BaseModel, Extra, root_validator, validator
 
 from fidesops.graph.config import (
     Collection,

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Union
 
-from pydantic import BaseModel, Extra, root_validator, validator
+from pydantic import BaseModel, Extra, root_validator, validator, Field
 
 from fidesops.graph.config import (
     Collection,
@@ -199,7 +199,7 @@ class SaaSConfigBase(BaseModel):
 
     fides_key: FidesOpsKey
     name: str
-    type: SaaSType
+    connection_type: SaaSType = Field(..., alias="type")
 
     @property
     def fides_key_prop(self) -> FidesOpsKey:

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -192,7 +192,27 @@ class SaaSType(Enum):
     custom = "custom"
 
 
-class SaaSConfig(BaseModel):
+class SaaSConfigBase(BaseModel):
+    """
+    Used to store base info for a saas config
+    """
+
+    fides_key: FidesOpsKey
+    name: str
+    type: SaaSType
+
+    @validator("type", pre=True)
+    def lowercase_saas_type(cls, value: str) -> str:
+        """Enforce lowercase on saas type."""
+        return value.lower()
+
+    class Config:
+        """Populate models with the raw value of enum fields, rather than the enum itself"""
+
+        use_enum_values = True
+
+
+class SaaSConfig(SaaSConfigBase):
     """
     Used to store endpoint and param configurations for a SaaS connector.
     This is done to separate the details of how to make the API calls
@@ -203,9 +223,6 @@ class SaaSConfig(BaseModel):
     for the graph traversal.
     """
 
-    fides_key: FidesOpsKey
-    name: str
-    type: SaaSType
     description: str
     version: str
     connector_params: List[ConnectorParam]
@@ -213,11 +230,6 @@ class SaaSConfig(BaseModel):
     endpoints: List[Endpoint]
     test_request: SaaSRequest
     data_protection_request: Optional[SaaSRequest] = None  # GDPR Delete
-
-    @validator("type", pre=True)
-    def lowercase_saas_type(cls, value: str) -> str:
-        """Enforce lowercase on saas type."""
-        return value.lower()
 
     @property
     def top_level_endpoint_dict(self) -> Dict[str, Endpoint]:
@@ -259,9 +271,9 @@ class SaaSConfig(BaseModel):
                 )
 
         return Dataset(
-            name=self.name,
+            name=super().name,
             collections=collections,
-            connection_key=self.fides_key,
+            connection_key=super().fides_key,
         )
 
     class Config:

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -201,14 +201,6 @@ class SaaSConfigBase(BaseModel):
     name: str
     type: SaaSType
 
-    @property
-    def fides_key_prop(self) -> FidesOpsKey:
-        return self.fides_key
-
-    @property
-    def name_prop(self) -> str:
-        return self.name
-
     @validator("type", pre=True)
     def lowercase_saas_type(cls, value: str) -> str:
         """Enforce lowercase on saas type."""
@@ -230,6 +222,9 @@ class SaaSConfig(SaaSConfigBase):
     merged with the standard Fidesops Dataset to provide a complete set of dependencies
     for the graph traversal.
     """
+
+    def __init__(self):
+        super().__init__()
 
     description: str
     version: str
@@ -279,9 +274,9 @@ class SaaSConfig(SaaSConfigBase):
                 )
 
         return Dataset(
-            name=super().name_prop,
+            name=self.name,
             collections=collections,
-            connection_key=super().fides_key_prop,
+            connection_key=self.fides_key,
         )
 
 

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Union
 
-from pydantic import BaseModel, Extra, root_validator, validator, Field
+from pydantic import BaseModel, Extra, Field, root_validator, validator
 
 from fidesops.graph.config import (
     Collection,

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -202,11 +202,11 @@ class SaaSConfigBase(BaseModel):
     type: SaaSType
 
     @property
-    def fides_key_prop(self):
+    def fides_key_prop(self) -> FidesOpsKey:
         return self.fides_key
 
     @property
-    def name_prop(self):
+    def name_prop(self) -> str:
         return self.name
 
     @validator("type", pre=True)

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -201,6 +201,14 @@ class SaaSConfigBase(BaseModel):
     name: str
     type: SaaSType
 
+    @property
+    def fides_key_prop(self) -> FidesOpsKey:
+        return self.fides_key
+
+    @property
+    def name_prop(self) -> str:
+        return self.name
+
     @validator("type", pre=True)
     def lowercase_saas_type(cls, value: str) -> str:
         """Enforce lowercase on saas type."""
@@ -222,9 +230,6 @@ class SaaSConfig(SaaSConfigBase):
     merged with the standard Fidesops Dataset to provide a complete set of dependencies
     for the graph traversal.
     """
-
-    def __init__(self):
-        super().__init__()
 
     description: str
     version: str
@@ -274,9 +279,9 @@ class SaaSConfig(SaaSConfigBase):
                 )
 
         return Dataset(
-            name=self.name,
+            name=super().name_prop,
             collections=collections,
-            connection_key=self.fides_key,
+            connection_key=super().fides_key_prop,
         )
 
 

--- a/src/fidesops/schemas/saas/saas_config.py
+++ b/src/fidesops/schemas/saas/saas_config.py
@@ -202,11 +202,11 @@ class SaaSConfigBase(BaseModel):
     type: SaaSType
 
     @property
-    def fides_key(self):
+    def fides_key_prop(self):
         return self.fides_key
 
     @property
-    def name(self):
+    def name_prop(self):
         return self.name
 
     @validator("type", pre=True)
@@ -279,9 +279,9 @@ class SaaSConfig(SaaSConfigBase):
                 )
 
         return Dataset(
-            name=super().name,
+            name=super().name_prop,
             collections=collections,
-            connection_key=super().fides_key,
+            connection_key=super().fides_key_prop,
         )
 
 

--- a/tests/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_config_endpoints.py
@@ -612,6 +612,7 @@ class TestGetConnections:
         assert len(items) == 1
         assert items[0]["connection_type"] == "saas"
         assert items[0]["key"] == stripe_connection_config.key
+        assert items[0]["saas_config"]["type"] == "stripe"
 
         resp = api_client.get(url + "?system_type=database", headers=auth_header)
         items = resp.json()["items"]

--- a/tests/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_config_endpoints.py
@@ -470,6 +470,7 @@ class TestGetConnections:
             "connection_type",
             "access",
             "updated_at",
+            "saas_config",
             "name",
             "last_test_timestamp",
             "last_test_succeeded",

--- a/tests/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_config_endpoints.py
@@ -727,6 +727,7 @@ class TestGetConnection:
             "created_at",
             "disabled",
             "description",
+            "saas_config",
         }
 
         assert response_body["key"] == "my_postgres_db_1"

--- a/tests/api/v1/endpoints/test_policy_webhook_endpoints.py
+++ b/tests/api/v1/endpoints/test_policy_webhook_endpoints.py
@@ -35,6 +35,7 @@ def embedded_http_connection_config(connection_config: ConnectionConfig) -> Dict
         "last_test_succeeded": None,
         "disabled": False,
         "description": None,
+        "saas_config": None,
     }
 
 


### PR DESCRIPTION
# Purpose
Adds saas config base info to connection config responses

# Changes
- Adds new base class for saas config to inherit from
- Return base class as new prop on connection config response
- Update test

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #828 
 
