### PR TITLE
Adding privacy_request_id placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The types of changes are:
 * Erasure support for Zendesk [#775](https://github.com/ethyca/fidesops/pull/775)
 * Adds endpoint to get the secrets required for different connectors [#795](https://github.com/ethyca/fidesops/pull/795)
 * Adds Vault for secrets management [#688](https://github.com/ethyca/fidesops/pull/869)
+* Adds privacy_request_id placeholder to use in SaaS configs [#911](https://github.com/ethyca/fidesops/pull/911)
 
 ### Changed
 

--- a/data/saas/config/saas_example_config.yml
+++ b/data/saas/config/saas_example_config.yml
@@ -183,3 +183,21 @@ saas_config:
             {
               <all_object_fields>
             }
+    - name: data_management
+      requests:
+        read:
+          method: GET
+          path: /v1/privacy_request/<privacy_request_id>
+          param_values:
+            - name: placeholder
+              identity: email
+        update:
+          method: POST
+          path: /v1/privacy_request/
+          param_values:
+            - name: placeholder
+              identity: email
+          body: |
+            {
+              "unique_id": "<privacy_request_id>"
+            }

--- a/data/saas/dataset/saas_example_dataset.yml
+++ b/data/saas/dataset/saas_example_dataset.yml
@@ -90,15 +90,18 @@ dataset:
                     fidesops_meta:
                       data_type: string
                   - name: zip
-                    data_categories: [user.provided.identifiable.contact.postal_code]
+                    data_categories:
+                      [user.provided.identifiable.contact.postal_code]
                     fidesops_meta:
                       data_type: string
                   - name: country
-                    data_categories: [user.provided.identifiable.contact.country]
+                    data_categories:
+                      [user.provided.identifiable.contact.country]
                     fidesops_meta:
                       data_type: string
               - name: PHONE
-                data_categories: [user.provided.identifiable.contact.phone_number]
+                data_categories:
+                  [user.provided.identifiable.contact.phone_number]
                 fidesops_meta:
                   data_type: string
               - name: BIRTHDAY
@@ -154,9 +157,9 @@ dataset:
       - name: projects
         fields:
           - name: id
-            data_categories: [ system.operations ]
+            data_categories: [system.operations]
           - name: slug
-            data_categories: [ system.operations ]
+            data_categories: [system.operations]
           - name: organization
             fields:
               - name: slug
@@ -165,21 +168,21 @@ dataset:
       - name: users
         fields:
           - name: id
-            data_categories: [ system.operations ]
+            data_categories: [system.operations]
           - name: name
-            data_categories: [ user.provided.identifiable.name ]
+            data_categories: [user.provided.identifiable.name]
           - name: user
             fields:
               - name: username
-                data_categories: [ user.provided.identifiable.name ]
+                data_categories: [user.provided.identifiable.name]
               - name: email
-                data_categories: [ user.provided.identifiable.contact.email ]
+                data_categories: [user.provided.identifiable.contact.email]
               - name: name
-                data_categories: [ user.provided.identifiable.name ]
+                data_categories: [user.provided.identifiable.name]
               - name: ipAddress
-                data_categories: [ user.derived.identifiable.device.ip_address ]
+                data_categories: [user.derived.identifiable.device.ip_address]
           - name: email
-            data_categories: [ user.provided.identifiable.contact.email ]
+            data_categories: [user.provided.identifiable.contact.email]
       - name: customer
         fields:
           - name: id
@@ -201,3 +204,9 @@ dataset:
             data_categories: [system.operations]
             fidesops_meta:
               read_only: True
+      - name: data_management
+        fields:
+          - name: id
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string

--- a/src/fidesops/service/connectors/saas_connector.py
+++ b/src/fidesops/service/connectors/saas_connector.py
@@ -50,7 +50,11 @@ class SaaSConnector(BaseConnector[AuthenticatedClient]):
         # store collection_name for logging purposes
         self.collection_name = node.address.collection
         return SaaSQueryConfig(
-            node, self.endpoints, self.secrets, self.saas_config.data_protection_request  # type: ignore
+            node,
+            self.endpoints,
+            self.secrets,  # type: ignore
+            self.saas_config.data_protection_request,  # type: ignore
+            self.privacy_request,  # type: ignore
         )
 
     def test_connection(self) -> Optional[ConnectionTestStatus]:

--- a/src/fidesops/service/connectors/saas_query_config.py
+++ b/src/fidesops/service/connectors/saas_query_config.py
@@ -33,12 +33,14 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
         endpoints: Dict[str, Endpoint],
         secrets: Dict[str, Any],
         data_protection_request: Optional[SaaSRequest] = None,
+        privacy_request: Optional[PrivacyRequest] = None,
     ):
         super().__init__(node)
         self.collection_name = node.address.collection
         self.endpoints = endpoints
         self.secrets = secrets
         self.data_protection_request = data_protection_request
+        self.privacy_request = privacy_request
         self.action: Optional[str] = None
 
     def get_request_by_action(self, action: str) -> Optional[SaaSRequest]:
@@ -152,6 +154,9 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
                     self.secrets, param_value.connector_param
                 )
 
+        if self.privacy_request:
+            param_values["privacy_request_id"] = self.privacy_request.id
+
         # map param values to placeholders in path, headers, and query params
         saas_request_params: SaaSRequestParams = saas_util.map_param_values(
             self.action, self.collection_name, current_request, param_values  # type: ignore
@@ -191,6 +196,9 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
                 param_values[param_value.name] = pydash.get(
                     self.secrets, param_value.connector_param
                 )
+
+        if self.privacy_request:
+            param_values["privacy_request_id"] = self.privacy_request.id
 
         # remove any row values for fields marked as read-only, these will be omitted from all update maps
         for field_path, field in self.field_map().items():

--- a/tests/api/v1/endpoints/test_saas_config_endpoints.py
+++ b/tests/api/v1/endpoints/test_saas_config_endpoints.py
@@ -244,7 +244,7 @@ class TestPutSaaSConfig:
         )
         saas_config = connection_config.saas_config
         assert saas_config is not None
-        assert len(saas_config["endpoints"]) == 6
+        assert len(saas_config["endpoints"]) == 7
 
 
 def get_saas_config_url(connection_config: Optional[ConnectionConfig] = None) -> str:
@@ -318,7 +318,7 @@ class TestGetSaaSConfig:
             response_body["fides_key"]
             == saas_example_connection_config.get_saas_config().fides_key
         )
-        assert len(response_body["endpoints"]) == 7
+        assert len(response_body["endpoints"]) == 8
         assert response_body["type"] == "custom"
 
 

--- a/tests/service/connectors/test_queryconfig.py
+++ b/tests/service/connectors/test_queryconfig.py
@@ -70,29 +70,23 @@ class TestSQLQueryConfig:
         }
 
         # values exist for all query keys
-        assert (
-            found_query_keys(
-                payment_card_node,
-                {
-                    "id": ["A"],
-                    "customer_id": ["V"],
-                    "ignore_me": ["X"],
-                },
-            )
-            == {"id", "customer_id"}
-        )
+        assert found_query_keys(
+            payment_card_node,
+            {
+                "id": ["A"],
+                "customer_id": ["V"],
+                "ignore_me": ["X"],
+            },
+        ) == {"id", "customer_id"}
         # with no values OR an empty set, these are omitted
-        assert (
-            found_query_keys(
-                payment_card_node,
-                {
-                    "id": ["A"],
-                    "customer_id": [],
-                    "ignore_me": ["X"],
-                },
-            )
-            == {"id"}
-        )
+        assert found_query_keys(
+            payment_card_node,
+            {
+                "id": ["A"],
+                "customer_id": [],
+                "ignore_me": ["X"],
+            },
+        ) == {"id"}
         assert found_query_keys(
             payment_card_node, {"id": ["A"], "ignore_me": ["X"]}
         ) == {"id"}
@@ -100,27 +94,21 @@ class TestSQLQueryConfig:
         assert found_query_keys(payment_card_node, {}) == set()
 
     def test_typed_filtered_values(self):
-        assert (
-            payment_card_node.typed_filtered_values(
-                {
-                    "id": ["A"],
-                    "customer_id": ["V"],
-                    "ignore_me": ["X"],
-                }
-            )
-            == {"id": ["A"], "customer_id": ["V"]}
-        )
+        assert payment_card_node.typed_filtered_values(
+            {
+                "id": ["A"],
+                "customer_id": ["V"],
+                "ignore_me": ["X"],
+            }
+        ) == {"id": ["A"], "customer_id": ["V"]}
 
-        assert (
-            payment_card_node.typed_filtered_values(
-                {
-                    "id": ["A"],
-                    "customer_id": [],
-                    "ignore_me": ["X"],
-                }
-            )
-            == {"id": ["A"]}
-        )
+        assert payment_card_node.typed_filtered_values(
+            {
+                "id": ["A"],
+                "customer_id": [],
+                "ignore_me": ["X"],
+            }
+        ) == {"id": ["A"]}
 
         assert payment_card_node.typed_filtered_values(
             {"id": ["A"], "ignore_me": ["X"]}

--- a/tests/service/connectors/test_queryconfig.py
+++ b/tests/service/connectors/test_queryconfig.py
@@ -70,23 +70,29 @@ class TestSQLQueryConfig:
         }
 
         # values exist for all query keys
-        assert found_query_keys(
-            payment_card_node,
-            {
-                "id": ["A"],
-                "customer_id": ["V"],
-                "ignore_me": ["X"],
-            },
-        ) == {"id", "customer_id"}
+        assert (
+            found_query_keys(
+                payment_card_node,
+                {
+                    "id": ["A"],
+                    "customer_id": ["V"],
+                    "ignore_me": ["X"],
+                },
+            )
+            == {"id", "customer_id"}
+        )
         # with no values OR an empty set, these are omitted
-        assert found_query_keys(
-            payment_card_node,
-            {
-                "id": ["A"],
-                "customer_id": [],
-                "ignore_me": ["X"],
-            },
-        ) == {"id"}
+        assert (
+            found_query_keys(
+                payment_card_node,
+                {
+                    "id": ["A"],
+                    "customer_id": [],
+                    "ignore_me": ["X"],
+                },
+            )
+            == {"id"}
+        )
         assert found_query_keys(
             payment_card_node, {"id": ["A"], "ignore_me": ["X"]}
         ) == {"id"}
@@ -94,21 +100,27 @@ class TestSQLQueryConfig:
         assert found_query_keys(payment_card_node, {}) == set()
 
     def test_typed_filtered_values(self):
-        assert payment_card_node.typed_filtered_values(
-            {
-                "id": ["A"],
-                "customer_id": ["V"],
-                "ignore_me": ["X"],
-            }
-        ) == {"id": ["A"], "customer_id": ["V"]}
+        assert (
+            payment_card_node.typed_filtered_values(
+                {
+                    "id": ["A"],
+                    "customer_id": ["V"],
+                    "ignore_me": ["X"],
+                }
+            )
+            == {"id": ["A"], "customer_id": ["V"]}
+        )
 
-        assert payment_card_node.typed_filtered_values(
-            {
-                "id": ["A"],
-                "customer_id": [],
-                "ignore_me": ["X"],
-            }
-        ) == {"id": ["A"]}
+        assert (
+            payment_card_node.typed_filtered_values(
+                {
+                    "id": ["A"],
+                    "customer_id": [],
+                    "ignore_me": ["X"],
+                }
+            )
+            == {"id": ["A"]}
+        )
 
         assert payment_card_node.typed_filtered_values(
             {"id": ["A"], "ignore_me": ["X"]}
@@ -636,6 +648,10 @@ class TestSaaSQueryConfig:
             CollectionAddress(saas_config.fides_key, "payment_methods")
         ]
 
+        data_management = combined_traversal.traversal_node_dict[
+            CollectionAddress(saas_config.fides_key, "data_management")
+        ]
+
         # static path with single query param
         config = SaaSQueryConfig(member, endpoints, {})
         prepared_request: SaaSRequestParams = config.generate_query(
@@ -700,6 +716,14 @@ class TestSaaSQueryConfig:
             "query": "customer-1@example.com",
         }
 
+        # using privacy_request_id placeholder
+        config = SaaSQueryConfig(data_management, endpoints, {}, None, privacy_request)
+        prepared_request = config.generate_query(
+            {"email": ["customer-1@example.com"]}, policy
+        )
+        assert prepared_request.method == HTTPMethod.GET.value
+        assert prepared_request.path == f"/v1/privacy_request/{privacy_request.id}"
+
     def test_generate_update_stmt(
         self,
         erasure_policy_string_rewrite,
@@ -712,6 +736,10 @@ class TestSaaSQueryConfig:
 
         member = combined_traversal.traversal_node_dict[
             CollectionAddress(saas_config.fides_key, "member")
+        ]
+
+        data_management = combined_traversal.traversal_node_dict[
+            CollectionAddress(saas_config.fides_key, "data_management")
         ]
 
         config = SaaSQueryConfig(member, endpoints, {}, update_request)
@@ -730,10 +758,18 @@ class TestSaaSQueryConfig:
         assert prepared_request.path == "/3.0/lists/abc/members/123"
         assert prepared_request.headers == {"Content-Type": "application/json"}
         assert prepared_request.query_params == {}
-        assert (
-            prepared_request.body
-            == '{\n  "merge_fields": {"FNAME": "MASKED", "LNAME": "MASKED"}\n}\n'
+        assert json.loads(prepared_request.body) == {
+            "merge_fields": {"FNAME": "MASKED", "LNAME": "MASKED"}
+        }
+
+        # using privacy_request_id placeholder
+        config = SaaSQueryConfig(data_management, endpoints, {}, None, privacy_request)
+        prepared_request = config.generate_update_stmt(
+            row, erasure_policy_string_rewrite, privacy_request
         )
+        assert prepared_request.method == HTTPMethod.POST.value
+        assert prepared_request.path == "/v1/privacy_request/"
+        assert json.loads(prepared_request.body) == {"unique_id": privacy_request.id}
 
     def test_generate_update_stmt_custom_http_method(
         self,
@@ -768,10 +804,9 @@ class TestSaaSQueryConfig:
         assert prepared_request.path == "/3.0/lists/abc/members/123"
         assert prepared_request.headers == {"Content-Type": "application/json"}
         assert prepared_request.query_params == {}
-        assert (
-            prepared_request.body
-            == '{\n  "merge_fields": {"FNAME": "MASKED", "LNAME": "MASKED"}\n}\n'
-        )
+        assert json.loads(prepared_request.body) == {
+            "merge_fields": {"FNAME": "MASKED", "LNAME": "MASKED"}
+        }
 
     def test_generate_update_stmt_with_request_body(
         self,
@@ -847,7 +882,7 @@ class TestSaaSQueryConfig:
         assert prepared_request.path == "/2.0/payment_methods"
         assert prepared_request.headers == {"Content-Type": "application/json"}
         assert prepared_request.query_params == {}
-        assert prepared_request.body == '{\n  "customer_name": "MASKED"\n}\n'
+        assert json.loads(prepared_request.body) == {"customer_name": "MASKED"}
 
     def test_generate_update_stmt_with_url_encoded_body(
         self,


### PR DESCRIPTION
# Purpose
Adds a default placeholder of `privacy_request_id` to be able to include the ID in access and erasure requests.

# Changes
- Updated `SaaSConnector` to pass in the privacy request to the `SaaSQueryConfig`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
- [x] Good unit test/integration test coverage
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
 
