### PR TITLE
Fix Setup for Postgres and Mariadb Integration Environments 

### DIFF
--- a/tests/integration_tests/setup_scripts/mariadb_setup.py
+++ b/tests/integration_tests/setup_scripts/mariadb_setup.py
@@ -47,12 +47,12 @@ def setup():
                 "connection_type": ConnectionType.mariadb,
                 "access": AccessLevel.write,
                 "secrets": {
-                    "host": pydash.get(integration_config, "mariadb_example.SERVER"),
-                    "port": pydash.get(integration_config, "mariadb_example.PORT"),
-                    "dbname": pydash.get(integration_config, "mariadb_example.DB"),
-                    "username": pydash.get(integration_config, "mariadb_example.USER"),
+                    "host": pydash.get(integration_config, "mariadb_example.server"),
+                    "port": pydash.get(integration_config, "mariadb_example.port"),
+                    "dbname": pydash.get(integration_config, "mariadb_example.db"),
+                    "username": pydash.get(integration_config, "mariadb_example.user"),
                     "password": pydash.get(
-                        integration_config, "mariadb_example.PASSWORD"
+                        integration_config, "mariadb_example.password"
                     ),
                 },
             },

--- a/tests/integration_tests/setup_scripts/postgres_setup.py
+++ b/tests/integration_tests/setup_scripts/postgres_setup.py
@@ -31,12 +31,12 @@ def setup():
                 "connection_type": ConnectionType.postgres,
                 "access": AccessLevel.write,
                 "secrets": {
-                    "host": pydash.get(integration_config, "postgres_example.SERVER"),
-                    "port": pydash.get(integration_config, "postgres_example.PORT"),
-                    "dbname": pydash.get(integration_config, "postgres_example.DB"),
-                    "username": pydash.get(integration_config, "postgres_example.USER"),
+                    "host": pydash.get(integration_config, "postgres_example.server"),
+                    "port": pydash.get(integration_config, "postgres_example.port"),
+                    "dbname": pydash.get(integration_config, "postgres_example.db"),
+                    "username": pydash.get(integration_config, "postgres_example.user"),
                     "password": pydash.get(
-                        integration_config, "postgres_example.PASSWORD"
+                        integration_config, "postgres_example.password"
                     ),
                 },
             },


### PR DESCRIPTION
# Purpose

We can no longer connect to postgres and mariadb databases running in docker for local integration testing.

# Changes
- Fix casing in the setup scripts for postgres and mariadb. Missed in https://github.com/ethyca/fidesops/pull/876 

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Unticketed
 
