### PR TITLE
Default `FIDESOPS__ADMIN_UI__ENABLED` to `True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 
 ### Changed
 * Users should be able to click on the full field of a dropdown-type filter to open up the dropdown [#747](https://github.com/ethyca/fidesops/pull/903)
+* Serve admin UI by default [#906](https://github.com/ethyca/fidesops/pull/936)
 
 ### Breaking Changes
 

--- a/src/fidesops/core/config.py
+++ b/src/fidesops/core/config.py
@@ -139,7 +139,7 @@ class RootUserSettings(FidesSettings):
 class AdminUiSettings(FidesSettings):
     """Configuration settings for Analytics variables."""
 
-    enabled: bool
+    enabled: bool = True
 
     class Config:
         env_prefix = "FIDESOPS__ADMIN_UI__"


### PR DESCRIPTION
# Purpose

Adds a default value to `FIDESOPS__ADMIN_UI__ENABLED` to avoid the situation where no value for that option is provided.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket
Fixes #906 
 
