### PR TITLE
Add db vs saas to connection type api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 * Erasure support for Salesforce [#888](https://github.com/ethyca/fidesops/pull/888)
 * Access and erasure support for Sendgrid contacts endpoint [#883](https://github.com/ethyca/fidesops/pull/883)
 * Added saas config base info to connection config responses [#904](https://github.com/ethyca/fidesops/pull/904)
+* Added db vs saas to connection type api [#937](https://github.com/ethyca/fidesops/pull/937)
 
 ### Changed
 * Users should be able to click on the full field of a dropdown-type filter to open up the dropdown [#747](https://github.com/ethyca/fidesops/pull/903)

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -93,10 +93,7 @@ def get_connection_type_secret_schema(
     to authenticate.
     """
     connection_system_types: List[ConnectionSystemTypeMap] = get_connection_types()
-    if not any(
-        item.identifier == connection_type
-        for item in connection_system_types
-    ):
+    if not any(item.identifier == connection_type for item in connection_system_types):
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,
             detail=f"No connection type found with name '{connection_type}'.",

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -94,7 +94,7 @@ def get_connection_type_secret_schema(
     """
     connection_system_types: List[ConnectionSystemTypeMap] = get_connection_types()
     if not any(
-        item.identifier and item.identifier.value == connection_type
+        item.identifier == connection_type
         for item in connection_system_types
     ):
         raise HTTPException(

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -94,7 +94,7 @@ def get_connection_type_secret_schema(
     """
     connection_system_types: List[ConnectionSystemTypeMap] = get_connection_types()
     if not any(
-        item.identifier.value == connection_type for item in connection_system_types
+            item.identifier and item.identifier.value == connection_type for item in connection_system_types
     ):
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -94,7 +94,8 @@ def get_connection_type_secret_schema(
     """
     connection_system_types: List[ConnectionSystemTypeMap] = get_connection_types()
     if not any(
-            item.identifier and item.identifier.value == connection_type for item in connection_system_types
+        item.identifier and item.identifier.value == connection_type
+        for item in connection_system_types
     ):
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -35,7 +35,7 @@ def get_connection_types(search: Optional[str] = None) -> List[ConnectionSystemT
         return search in elem if search else True
 
     connection_system_types: List[ConnectionSystemTypeMap] = []
-    database_types: List[ConnectionType.value] = sorted(
+    database_types: List[str] = sorted(
         [
             conn_type.value
             for conn_type in ConnectionType
@@ -50,7 +50,7 @@ def get_connection_types(search: Optional[str] = None) -> List[ConnectionSystemT
             for item in database_types
         ]
     )
-    saas_types: List[SaaSType.value] = sorted(
+    saas_types: List[str] = sorted(
         [
             saas_type.value
             for saas_type in SaaSType

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -1,10 +1,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.params import Security
-from fastapi_pagination import Page, Params, paginate
-from fastapi_pagination.bases import AbstractPage
 from starlette.status import HTTP_404_NOT_FOUND
 
 from fidesops.api.v1.scope_registry import CONNECTION_TYPE_READ
@@ -18,6 +16,10 @@ from fidesops.schemas.connection_configuration import (
     SaaSSchemaFactory,
     secrets_validators,
 )
+from fidesops.schemas.connection_configuration.connection_config import (
+    ConnectionSystemTypeMap,
+    SystemType,
+)
 from fidesops.schemas.saas.saas_config import SaaSConfig, SaaSType
 from fidesops.util.oauth_util import verify_oauth_client
 from fidesops.util.saas_util import load_config
@@ -27,41 +29,55 @@ router = APIRouter(tags=["Connection Types"], prefix=V1_URL_PREFIX)
 logger = logging.getLogger(__name__)
 
 
-def get_connection_types(search: Optional[str] = None) -> List[str]:
+def get_connection_types(search: Optional[str] = None) -> List[ConnectionSystemTypeMap]:
     def is_match(elem: str) -> bool:
         """If a search query param was included, is it a substring of an available connector type?"""
         return search in elem if search else True
 
-    database_types: List[str] = [
-        conn_type.value
-        for conn_type in ConnectionType
-        if conn_type
-        not in [ConnectionType.saas, ConnectionType.https, ConnectionType.manual]
-        and is_match(conn_type.value)
-    ]
-    saas_types: List[str] = [
-        saas_type.value
-        for saas_type in SaaSType
-        if saas_type != SaaSType.custom and is_match(saas_type.value)
-    ]
-    connection_types: List[str] = sorted(database_types + saas_types)
+    connection_system_types: List[ConnectionSystemTypeMap] = []
+    database_types: List[ConnectionType.value] = sorted(
+        [
+            conn_type.value
+            for conn_type in ConnectionType
+            if conn_type
+            not in [ConnectionType.saas, ConnectionType.https, ConnectionType.manual]
+            and is_match(conn_type.value)
+        ]
+    )
+    connection_system_types.extend(
+        [
+            ConnectionSystemTypeMap(identifier=item, type=SystemType.database)
+            for item in database_types
+        ]
+    )
+    saas_types: List[SaaSType.value] = sorted(
+        [
+            saas_type.value
+            for saas_type in SaaSType
+            if saas_type != SaaSType.custom and is_match(saas_type.value)
+        ]
+    )
+    connection_system_types.extend(
+        [
+            ConnectionSystemTypeMap(identifier=item, type=SystemType.saas)
+            for item in saas_types
+        ]
+    )
 
-    return connection_types
+    return connection_system_types
 
 
 @router.get(
     CONNECTION_TYPES,
     dependencies=[Security(verify_oauth_client, scopes=[CONNECTION_TYPE_READ])],
-    response_model=Page[str],
+    response_model=List[ConnectionSystemTypeMap],
 )
 def get_all_connection_types(
-    *, params: Params = Depends(), search: Optional[str] = None
-) -> AbstractPage[str]:
+    *, search: Optional[str] = None
+) -> List[ConnectionSystemTypeMap]:
     """Returns a list of connection options in Fidesops - includes only database and saas options here."""
 
-    connection_types: List[str] = get_connection_types(search)
-
-    return paginate(connection_types, params)
+    return get_connection_types(search)
 
 
 @router.get(
@@ -76,8 +92,10 @@ def get_connection_type_secret_schema(
     Note that this endpoint should never return actual secrets, we return the *types* of secret fields needed
     to authenticate.
     """
-    connection_types: List[str] = get_connection_types()
-    if connection_type not in connection_types:
+    connection_system_types: List[ConnectionSystemTypeMap] = get_connection_types()
+    if not any(
+        item.identifier.value == connection_type for item in connection_system_types
+    ):
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,
             detail=f"No connection type found with name '{connection_type}'.",

--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -29,40 +29,48 @@ router = APIRouter(tags=["Connection Types"], prefix=V1_URL_PREFIX)
 logger = logging.getLogger(__name__)
 
 
-def get_connection_types(search: Optional[str] = None) -> List[ConnectionSystemTypeMap]:
+def get_connection_types(
+    search: Optional[str] = None, system_type: Optional[SystemType] = None
+) -> List[ConnectionSystemTypeMap]:
     def is_match(elem: str) -> bool:
         """If a search query param was included, is it a substring of an available connector type?"""
         return search in elem if search else True
 
     connection_system_types: List[ConnectionSystemTypeMap] = []
-    database_types: List[str] = sorted(
-        [
-            conn_type.value
-            for conn_type in ConnectionType
-            if conn_type
-            not in [ConnectionType.saas, ConnectionType.https, ConnectionType.manual]
-            and is_match(conn_type.value)
-        ]
-    )
-    connection_system_types.extend(
-        [
-            ConnectionSystemTypeMap(identifier=item, type=SystemType.database)
-            for item in database_types
-        ]
-    )
-    saas_types: List[str] = sorted(
-        [
-            saas_type.value
-            for saas_type in SaaSType
-            if saas_type != SaaSType.custom and is_match(saas_type.value)
-        ]
-    )
-    connection_system_types.extend(
-        [
-            ConnectionSystemTypeMap(identifier=item, type=SystemType.saas)
-            for item in saas_types
-        ]
-    )
+    if system_type == SystemType.database or system_type is None:
+        database_types: List[str] = sorted(
+            [
+                conn_type.value
+                for conn_type in ConnectionType
+                if conn_type
+                not in [
+                    ConnectionType.saas,
+                    ConnectionType.https,
+                    ConnectionType.manual,
+                ]
+                and is_match(conn_type.value)
+            ]
+        )
+        connection_system_types.extend(
+            [
+                ConnectionSystemTypeMap(identifier=item, type=SystemType.database)
+                for item in database_types
+            ]
+        )
+    if system_type == SystemType.saas or system_type is None:
+        saas_types: List[str] = sorted(
+            [
+                saas_type.value
+                for saas_type in SaaSType
+                if saas_type != SaaSType.custom and is_match(saas_type.value)
+            ]
+        )
+        connection_system_types.extend(
+            [
+                ConnectionSystemTypeMap(identifier=item, type=SystemType.saas)
+                for item in saas_types
+            ]
+        )
 
     return connection_system_types
 
@@ -73,11 +81,11 @@ def get_connection_types(search: Optional[str] = None) -> List[ConnectionSystemT
     response_model=List[ConnectionSystemTypeMap],
 )
 def get_all_connection_types(
-    *, search: Optional[str] = None
+    *, search: Optional[str] = None, system_type: Optional[SystemType] = None
 ) -> List[ConnectionSystemTypeMap]:
     """Returns a list of connection options in Fidesops - includes only database and saas options here."""
 
-    return get_connection_types(search)
+    return get_connection_types(search, system_type)
 
 
 @router.get(

--- a/src/fidesops/schemas/connection_configuration/connection_config.py
+++ b/src/fidesops/schemas/connection_configuration/connection_config.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Extra
 
 from fidesops.models.connectionconfig import AccessLevel, ConnectionType
 from fidesops.schemas.api import BulkResponse, BulkUpdateFailed
-from fidesops.schemas.saas.saas_config import SaaSConfigBase
+from fidesops.schemas.saas.saas_config import SaaSConfigBase, SaaSType
 from fidesops.schemas.shared_schemas import FidesOpsKey
 
 
@@ -51,6 +51,21 @@ class SystemType(Enum):
     saas = "saas"
     database = "database"
     manual = "manual"
+
+
+class ConnectionSystemTypeMap(BaseModel):
+    """
+    Describes the returned schema for connection types
+    """
+
+    identifier: Union[ConnectionType, SaaSType]
+    type: SystemType
+
+    class Config:
+        """Use enum values and set orm mode"""
+
+        use_enum_values = True
+        orm_mode = True
 
 
 class ConnectionConfigurationResponse(BaseModel):

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -96,7 +96,7 @@ class TestGetConnections:
         data = resp.json()
         assert len(data) == 10
 
-        resp = api_client.get(url + "?search=database", headers=auth_header)
+        resp = api_client.get(url + "?system_type=database", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 8

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -41,7 +41,7 @@ class TestGetConnections:
         resp = api_client.get(url, headers=auth_header)
         data = resp.json()
         assert resp.status_code == 200
-        assert len(data) == 17
+        assert len(data) == 18
 
         assert {
             "identifier": ConnectionType.postgres.value,

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -111,7 +111,9 @@ class TestGetConnections:
         data = resp.json()
         assert len(data) == 1
 
-        resp = api_client.get(url + "?search=re&system_type=database", headers=auth_header)
+        resp = api_client.get(
+            url + "?search=re&system_type=database", headers=auth_header
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 2

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -94,12 +94,12 @@ class TestGetConnections:
         resp = api_client.get(url + "?system_type=saas", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 8
+        assert len(data) == 10
 
         resp = api_client.get(url + "?search=database", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 10
+        assert len(data) == 8
 
     def test_search_system_type_and_connection_type(
         self, api_client, generate_auth_header, url

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1,5 +1,6 @@
+from typing import List
+
 import pytest
-from fastapi_pagination import Params
 from fideslib.models.client import ClientDetail
 from starlette.testclient import TestClient
 
@@ -9,6 +10,12 @@ from fidesops.api.v1.urn_registry import (
     CONNECTION_TYPES,
     V1_URL_PREFIX,
 )
+from fidesops.models.connectionconfig import ConnectionType
+from fidesops.schemas.connection_configuration.connection_config import (
+    ConnectionSystemTypeMap,
+    SystemType,
+)
+from fidesops.schemas.saas.saas_config import SaaSType
 
 
 class TestGetConnections:
@@ -34,18 +41,21 @@ class TestGetConnections:
         resp = api_client.get(url, headers=auth_header)
         data = resp.json()
         assert resp.status_code == 200
-        assert "items" in data
-        assert "total" in data
-        assert "page" in data
-        assert data["size"] == Params().size
+        assert len(data) == 17
 
-        assert "postgres" in data["items"]
-        assert "stripe" in data["items"]
+        assert {
+            "identifier": ConnectionType.postgres.value,
+            "type": SystemType.database.value,
+        } in data
+        assert {
+            "identifier": SaaSType.stripe.value,
+            "type": SystemType.saas.value,
+        } in data
 
-        assert "saas" not in data["items"]
-        assert "https" not in data["items"]
-        assert "custom" not in data["items"]
-        assert "manual" not in data["items"]
+        assert "saas" not in [item["identifier"] for item in data]
+        assert "https" not in [item["identifier"] for item in data]
+        assert "custom" not in [item["identifier"] for item in data]
+        assert "manual" not in [item["identifier"] for item in data]
 
     def test_search_connection_types(self, api_client, generate_auth_header, url):
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
@@ -53,14 +63,27 @@ class TestGetConnections:
         resp = api_client.get(url + "?search=str", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["items"][0] == "stripe"
+        assert len(data) == 1
+        assert data[0] == {
+            "identifier": SaaSType.stripe.value,
+            "type": SystemType.saas.value,
+        }
 
         resp = api_client.get(url + "?search=re", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 3
-        assert data["items"] == ["outreach", "postgres", "redshift"]
+        assert len(data) == 3
+        assert data == [
+            {
+                "identifier": ConnectionType.postgres.value,
+                "type": SystemType.database.value,
+            },
+            {
+                "identifier": ConnectionType.redshift.value,
+                "type": SystemType.database.value,
+            },
+            {"identifier": SaaSType.outreach.value, "type": SystemType.saas.value},
+        ]
 
 
 class TestGetConnectionSecretSchema:

--- a/tests/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/api/v1/endpoints/test_connection_template_endpoints.py
@@ -85,6 +85,37 @@ class TestGetConnections:
             {"identifier": SaaSType.outreach.value, "type": SystemType.saas.value},
         ]
 
+    def test_search_system_type(self, api_client, generate_auth_header, url):
+        auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
+
+        resp = api_client.get(url + "?system_type=nothing", headers=auth_header)
+        assert resp.status_code == 422
+
+        resp = api_client.get(url + "?system_type=saas", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 8
+
+        resp = api_client.get(url + "?search=database", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 10
+
+    def test_search_system_type_and_connection_type(
+        self, api_client, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
+
+        resp = api_client.get(url + "?search=str&system_type=saas", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+
+        resp = api_client.get(url + "?search=re&system_type=database", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
 
 class TestGetConnectionSecretSchema:
     @pytest.fixture(scope="function")


### PR DESCRIPTION
# Purpose
Add db vs saas to connection type api

# Changes
- Return db vs saas system type from connection type api
- Adds query param to filter for `system_type`, in addition to the already existing `search` query param. e.g `?search=str&system_type=saas`
- Remove pagination from endpoint
- Update tests

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #910
 
