### PR TITLE
Dispatch a repository event on new published releases

### DIFF
--- a/.github/workflows/release_event.yml
+++ b/.github/workflows/release_event.yml
@@ -1,0 +1,17 @@
+name: Release Dispatch Event
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  Notify-of-New-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: ethyca/fidesops-plus
+          event-type: new-fidesops-release
+          client-payload: '{"tag": "${{ github.event.release.tag_name }}", "url": "${{ github.event.release.html_url }}"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,16 @@ The types of changes are:
 * Removed ipython from the docker install [928](https://github.com/ethyca/fidesops/pull/928)
 * Serve admin UI by default [#906](https://github.com/ethyca/fidesops/pull/936)
 
+### Developer Experience
+
+* When releases are published, dispatch a repository webhook event to ethyca/fidesops-plus [#945](https://github.com/ethyca/fidesops/pull/945)
+
 ### Breaking Changes
 
 * Update fidesops to use bcrypt for hashing [#876](https://github.com/ethyca/fidesops/pull/876)
 
 ### Docs
+
 * Added zendesk and salesforce connection pages [#908](https://github.com/ethyca/fidesops/pull/908)
 
 ### Fixed


### PR DESCRIPTION
# Purpose

There is no way for a GH Actions workflow to read the releases in another repository. In order for an issue to be automatically created in the fidesops-plus repository whenever a new fidesops release is published, the act of publishing the fidesops release must dispatch a repository event to the fidesops-plus repo. This event is used to trigger a separate GH Actions workflow in the fidesops-plus repository, which creates the desired issue.

# Changes

* Add a new GH Actions workflow to dispatch an event on new releases

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)

# Ticket

Related to ethyca/fidesops-plus#43
Blocks ethyca/fidesops-plus#50