### PR TITLE
Allow `run_infrastructure.py` to bring up no datastores.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,9 @@ docs-serve: docs-build
 user:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
-		python scripts/run_infrastructure.py --run_create_superuser
+		python scripts/run_infrastructure.py --datastores postgres --run_create_superuser
 
 test-data:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
-		python scripts/run_infrastructure.py --run_create_test_data
+		python scripts/run_infrastructure.py --datastores postgres --run_create_test_data

--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,9 @@ docs-serve: docs-build
 user:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
-		python scripts/run_infrastructure.py --datastores postgres --run_create_superuser
+		python scripts/run_infrastructure.py --run_create_superuser
 
 test-data:
 	@virtualenv -p python3 fidesops_test_dispatch; \
 		source fidesops_test_dispatch/bin/activate; \
-		python scripts/run_infrastructure.py --datastores postgres --run_create_test_data
+		python scripts/run_infrastructure.py --run_create_test_data

--- a/noxfiles/run_infrastructure.py
+++ b/noxfiles/run_infrastructure.py
@@ -23,11 +23,14 @@ EXTERNAL_DATASTORE_CONFIG = {
     "bigquery": ["BIGQUERY_KEYFILE_CREDS", "BIGQUERY_DATASET"],
 }
 EXTERNAL_DATASTORES = list(EXTERNAL_DATASTORE_CONFIG.keys())
+ALL_DATASTORES = DOCKERFILE_DATASTORES + EXTERNAL_DATASTORES
 IMAGE_NAME = "webserver"
 
 
 def run_infrastructure(
-    datastores: List[str] = [],  # Which infra should we create? If empty, we create all
+    datastores: List[
+        str
+    ] = ALL_DATASTORES,  # Which infra should we create? By default, we create all
     open_shell: bool = False,  # Should we open a bash shell?
     pytest_path: str = "",  # Which subset of tests should we run?
     run_application: bool = False,  # Should we run the Fidesops webserver?
@@ -45,13 +48,7 @@ def run_infrastructure(
     with `IMAGE_NAME`.
     """
 
-    if len(datastores) == 0:
-        _run_cmd_or_err(
-            'echo "no datastores specified, configuring infrastructure for all datastores"'
-        )
-        datastores = DOCKERFILE_DATASTORES + EXTERNAL_DATASTORES
-    else:
-        _run_cmd_or_err(f'echo "datastores specified: {", ".join(datastores)}"')
+    _run_cmd_or_err(f'echo "datastores to build: {", ".join(datastores)}"')
 
     # De-duplicate datastores
     datastores = set(datastores)

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -25,13 +25,13 @@ COMPOSE_DOWN = (
 @nox.session()
 def create_user(session: nox.Session) -> None:
     """Create a super user in the fidesops database."""
-    run_infrastructure(datastores=["postgres"], run_create_superuser=True)
+    run_infrastructure(datastores=[], run_create_superuser=True)
 
 
 @nox.session()
 def seed_test_data(session: nox.Session) -> None:
     """Seed test data in the Postgres application database."""
-    run_infrastructure(datastores=["postgres"], run_create_test_data=True)
+    run_infrastructure(datastores=[], run_create_test_data=True)
 
 
 @nox.session()

--- a/scripts/run_infrastructure.py
+++ b/scripts/run_infrastructure.py
@@ -22,11 +22,14 @@ EXTERNAL_DATASTORE_CONFIG = {
     "bigquery": ["BIGQUERY_KEYFILE_CREDS", "BIGQUERY_DATASET"],
 }
 EXTERNAL_DATASTORES = list(EXTERNAL_DATASTORE_CONFIG.keys())
+ALL_DATASTORES = DOCKERFILE_DATASTORES + EXTERNAL_DATASTORES
 IMAGE_NAME = "webserver"
 
 
 def run_infrastructure(
-    datastores: List[str] = [],  # Which infra should we create? If empty, we create all
+    datastores: List[
+        str
+    ] = ALL_DATASTORES,  # Which infra should we create? By default, we create all
     open_shell: bool = False,  # Should we open a bash shell?
     pytest_path: str = "",  # Which subset of tests should we run?
     run_application: bool = False,  # Should we run the Fidesops webserver?
@@ -44,13 +47,7 @@ def run_infrastructure(
     with `IMAGE_NAME`.
     """
 
-    if len(datastores) == 0:
-        _run_cmd_or_err(
-            f'echo "no datastores specified, configuring infrastructure for all datastores"'
-        )
-        datastores = DOCKERFILE_DATASTORES + EXTERNAL_DATASTORES
-    else:
-        _run_cmd_or_err(f'echo "datastores specified: {", ".join(datastores)}"')
+    _run_cmd_or_err(f'echo "datastores to build: {", ".join(datastores)}"')
 
     # De-duplicate datastores
     datastores = set(datastores)


### PR DESCRIPTION
# Purpose

I've noticed that in certain places in our util scripts we're passing in `postgres` perhaps thinking this spins up the application database. It actually spins up the `example_postgres` datastore that we use for integration testing. We may also be doing this to avoid spinning up _all_ datastores in those utli commands, because the `run_infrasructure.py` script will create all datastores by default if none are specified (so specifying only `postgres` is the lesser of those evils).

This PR updates `run_infrastructure.py` to allow no `datastores` to be spun up if an empty list is explicitly passed, meaning we don't have to wait for `example_postgres` to come-up in our util commands.