### PR TITLE
Push `dev` image on pushes to `main`

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -1,17 +1,18 @@
-name: Publish to DockerHub
+name: Docker Build & Push
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "*"
 
-# push a dev image
 env:
   DOCKER_USER: ethycaci
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
 jobs:
-  push-fidesops:
+  push-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,8 +25,21 @@ jobs:
           username: ${{ env.DOCKER_USER }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      - name: Docker Build
-        run: make docker-build
+      - name: Install Dev Requirements
+        run: pip install -r dev-requirements.txt
 
-      - name: Docker Push
-        run: make docker-push
+      - name: Build Image
+        run: nox -s "build(prod)"
+
+      - name: Push Dev Tag
+        run: nox -s "push(dev)"
+
+      - name: Check Prod Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      - name: Push Prod Tags
+        if: steps.check-tag.outputs.match == 'true'
+        run: nox -s "push(prod)"

--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "*"
 
+# push a dev image
 env:
   DOCKER_USER: ethycaci
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.6.3...main)
 
 ### Added
+
 * Erasure support for Salesforce [#888](https://github.com/ethyca/fidesops/pull/888)
+* Publish a `dev` tagged image on every push to main [#956](https://github.com/ethyca/fidesops/pull/956)
 * Access and erasure support for Sendgrid contacts endpoint [#883](https://github.com/ethyca/fidesops/pull/883)
 * Added saas config base info to connection config responses [#904](https://github.com/ethyca/fidesops/pull/904)
 * Access and erasure support for Adobe Campaign [#905](https://github.com/ethyca/fidesops/pull/905)


### PR DESCRIPTION
# Purpose

Push a `dev` tagged image on every push to `main`

# Changes
- update the docker github workflow to use nox commands
- add a new step for the dev push

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #933 
 
