### PR TITLE
Fix the `nox -s dev` command not spinning up the webserver

### DIFF
--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -13,6 +13,7 @@ def dev(session: nox.Session) -> None:
     datastores = session.posargs or None
     if not datastores:
         # Run the webserver without integrations
+        # Spin up the webserver before the RUN
         session.run(*RUN, "/bin/bash", external=True)
     else:
         # Run the webserver with additional datastores

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -1,6 +1,6 @@
 """Contains the nox sessions for running development environments."""
 import nox
-from constants_nox import ANALYTICS_OPT_OUT, COMPOSE_SERVICE_NAME, RUN
+from constants_nox import ANALYTICS_OPT_OUT, COMPOSE_SERVICE_NAME, RUN, START_APP
 from docker_nox import build
 from run_infrastructure import run_infrastructure
 
@@ -13,7 +13,7 @@ def dev(session: nox.Session) -> None:
     datastores = session.posargs or None
     if not datastores:
         # Run the webserver without integrations
-        # Spin up the webserver before the RUN
+        session.run(*START_APP, external=True)
         session.run(*RUN, "/bin/bash", external=True)
     else:
         # Run the webserver with additional datastores


### PR DESCRIPTION
# Purpose

Spin up the webserver for `nox -s dev`

# Changes
* [x] `up` the webserver service before the `RUN` command

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
