### PR TITLE
add pagination back to connection types endpoints

### DIFF
--- a/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/connection_type_endpoints.py
@@ -1,8 +1,10 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.params import Security
+from fastapi_pagination import Page, Params, paginate
+from fastapi_pagination.bases import AbstractPage
 from starlette.status import HTTP_404_NOT_FOUND
 
 from fidesops.api.v1.scope_registry import CONNECTION_TYPE_READ
@@ -78,14 +80,20 @@ def get_connection_types(
 @router.get(
     CONNECTION_TYPES,
     dependencies=[Security(verify_oauth_client, scopes=[CONNECTION_TYPE_READ])],
-    response_model=List[ConnectionSystemTypeMap],
+    response_model=Page[ConnectionSystemTypeMap],
 )
 def get_all_connection_types(
-    *, search: Optional[str] = None, system_type: Optional[SystemType] = None
-) -> List[ConnectionSystemTypeMap]:
+    *,
+    params: Params = Depends(),
+    search: Optional[str] = None,
+    system_type: Optional[SystemType] = None,
+) -> AbstractPage[ConnectionSystemTypeMap]:
     """Returns a list of connection options in Fidesops - includes only database and saas options here."""
 
-    return get_connection_types(search, system_type)
+    return paginate(
+        get_connection_types(search, system_type),
+        params,
+    )
 
 
 @router.get(

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -39,7 +39,7 @@ class TestGetConnections:
     ) -> None:
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
         resp = api_client.get(url, headers=auth_header)
-        data = resp.json()
+        data = resp.json()["items"]
         assert resp.status_code == 200
         assert len(data) == 18
 
@@ -62,7 +62,7 @@ class TestGetConnections:
 
         resp = api_client.get(url + "?search=str", headers=auth_header)
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["items"]
         assert len(data) == 1
         assert data[0] == {
             "identifier": SaaSType.stripe.value,
@@ -71,7 +71,7 @@ class TestGetConnections:
 
         resp = api_client.get(url + "?search=re", headers=auth_header)
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["items"]
         assert len(data) == 3
         assert data == [
             {
@@ -108,14 +108,14 @@ class TestGetConnections:
 
         resp = api_client.get(url + "?search=str&system_type=saas", headers=auth_header)
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["items"]
         assert len(data) == 1
 
         resp = api_client.get(
             url + "?search=re&system_type=database", headers=auth_header
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["items"]
         assert len(data) == 2
 
 


### PR DESCRIPTION
# Purpose

This PR adds pagination back to the GET connection types endpoints, in line with the rest of the platform.

# Ticket
Fixes #950