### PR TITLE
Create `AuditLog` on privacy request approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ The types of changes are:
 * Enable python function overrides for SaaS connector request execution [#986](https://github.com/ethyca/fidesops/pull/986)
 * add Events and logs section to Subject Request Details Page [#1018](https://github.com/ethyca/fidesops/pull/1018)
 * Access and erasure support for Auth0 [#991](https://github.com/ethyca/fidesops/pull/991)
-* Start better understanding how request execution fails [#993] https://github.com/ethyca/fidesops/pull/993
+* Start better understanding how request execution fails [#993] (https://github.com/ethyca/fidesops/pull/993)
+* Add approval `AuditLog`s for user and sytem approved privacy requests [#1038](https://github.com/ethyca/fidesops/pull/1038)
 
 ### Changed
 

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-branches,too-many-locals
+# pylint: disable=too-many-branches,too-many-locals,too-many-lines
 
 import csv
 import io

--- a/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/api/v1/endpoints/privacy_request_endpoints.py
@@ -194,6 +194,15 @@ def create_privacy_request(
             )
 
             if not config.execution.require_manual_request_approval:
+                AuditLog.create(
+                    db=db,
+                    data={
+                        "user_id": "system",
+                        "privacy_request_id": privacy_request.id,
+                        "action": AuditLogAction.approved,
+                        "message": "",
+                    },
+                )
                 queue_privacy_request(privacy_request.id)
 
         except common_exceptions.RedisConnectionError as exc:
@@ -936,6 +945,15 @@ def approve_privacy_request(
         privacy_request.reviewed_by = user_id
         privacy_request.save(db=db)
 
+        AuditLog.create(
+            db=db,
+            data={
+                "user_id": user_id,
+                "privacy_request_id": privacy_request.id,
+                "action": AuditLogAction.approved,
+                "message": "",
+            },
+        )
         queue_privacy_request(privacy_request_id=privacy_request.id)
 
     return review_privacy_request(

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -15,7 +15,7 @@ from fideslib.cryptography.schemas.jwt import (
     JWE_PAYLOAD_CLIENT_ID,
     JWE_PAYLOAD_SCOPES,
 )
-from fideslib.models.audit_log import AuditLog
+from fideslib.models.audit_log import AuditLog, AuditLogAction
 from fideslib.models.client import ClientDetail
 from fideslib.oauth.jwt import generate_jwe
 from starlette.testclient import TestClient
@@ -436,6 +436,40 @@ class TestCreatePrivacyRequest:
         pr = PrivacyRequest.get(db=db, object_id=response_data[0]["id"])
         assert pr.get_cached_task_id() is not None
         assert pr.get_async_execution_task() is not None
+        pr.delete(db=db)
+
+    @mock.patch(
+        "fidesops.service.privacy_request.request_runner_service.run_privacy_request.delay"
+    )
+    def test_create_privacy_request_creates_system_audit_log(
+        self,
+        run_access_request_mock,
+        url,
+        db,
+        api_client: TestClient,
+        policy,
+    ):
+        data = [
+            {
+                "requested_at": "2021-08-30T16:09:37.359Z",
+                "policy_key": policy.key,
+                "identity": {"email": "test@example.com"},
+            }
+        ]
+        resp = api_client.post(url, json=data)
+        response_data = resp.json()["succeeded"][0]
+        approval_audit_log: AuditLog = AuditLog.filter(
+            db=db,
+            conditions=(
+                (AuditLog.privacy_request_id == response_data["id"])
+                & (AuditLog.action == AuditLogAction.approved)
+            ),
+        ).first()
+        assert approval_audit_log is not None
+        assert approval_audit_log.user_id == "system"
+
+        approval_audit_log.delete(db=db)
+        pr = PrivacyRequest.get(db=db, object_id=response_data["id"])
         pr.delete(db=db)
 
 
@@ -1614,6 +1648,7 @@ class TestApprovePrivacyRequest:
 
         body = {"request_ids": [privacy_request.id]}
         response = api_client.patch(url, headers=auth_header, json=body)
+
         assert response.status_code == 200
 
         response_body = response.json()
@@ -1626,6 +1661,49 @@ class TestApprovePrivacyRequest:
 
         assert submit_mock.called
 
+        privacy_request.delete(db)
+
+    @mock.patch(
+        "fidesops.service.privacy_request.request_runner_service.run_privacy_request.delay"
+    )
+    def test_approve_privacy_request_creates_audit_log(
+        self,
+        submit_mock,
+        db,
+        url,
+        api_client,
+        generate_auth_header,
+        user,
+        privacy_request,
+    ):
+        privacy_request.status = PrivacyRequestStatus.pending
+        privacy_request.save(db=db)
+
+        payload = {
+            JWE_PAYLOAD_SCOPES: user.client.scopes,
+            JWE_PAYLOAD_CLIENT_ID: user.client.id,
+            JWE_ISSUED_AT: datetime.now().isoformat(),
+        }
+        auth_header = {
+            "Authorization": "Bearer "
+            + generate_jwe(json.dumps(payload), config.security.app_encryption_key)
+        }
+
+        body = {"request_ids": [privacy_request.id]}
+        api_client.patch(url, headers=auth_header, json=body)
+        approval_audit_log: AuditLog = AuditLog.filter(
+            db=db,
+            conditions=(
+                (AuditLog.privacy_request_id == privacy_request.id)
+                & (AuditLog.user_id == user.id)
+                & (AuditLog.action == AuditLogAction.approved)
+            ),
+        ).first()
+
+        assert approval_audit_log is not None
+        assert approval_audit_log.message == ""
+
+        approval_audit_log.delete(db)
         privacy_request.delete(db)
 
 


### PR DESCRIPTION
# Purpose
Add approval audit logs to it can be tracked when and who approved a privacy request.

# Changes
- Add approval audit logs to the backend

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1021 
 
