### PR TITLE
Sort table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The types of changes are:
 * Added `nox` commands to replace the `Makefile` [#919](https://github.com/ethyca/fidesops/pull/919)
 * GitHub Actions Workflows leverage `nox` commands [#966](https://github.com/ethyca/fidesops/pull/966)
 * The `docker-compose.yml` file no longer handles builds [#966](https://github.com/ethyca/fidesops/pull/966)
+* Sort the table names before comparing it it the list to prevent randomly failing tests [#1052](https://github.com/ethyca/fidesops/pull/1052)
 
 ### Docs
 

--- a/tests/ops/integration_tests/test_external_database_connections.py
+++ b/tests/ops/integration_tests/test_external_database_connections.py
@@ -71,18 +71,18 @@ def snowflake_test_engine() -> Generator:
 def test_redshift_example_data(redshift_test_engine):
     """Confirm that we can connect to the redshift test db and get table names"""
     inspector = inspect(redshift_test_engine)
-    assert inspector.get_table_names(schema="test") == [
+    assert sorted(inspector.get_table_names(schema="test")) == [
+        "address",
+        "customer",
+        "employee",
+        "login",
+        "order",
+        "order_item",
+        "payment_card",
+        "product",
         "report",
         "service_request",
-        "login",
         "visit",
-        "order_item",
-        "order",
-        "payment_card",
-        "employee",
-        "customer",
-        "address",
-        "product",
     ]
 
 
@@ -91,10 +91,9 @@ def test_redshift_example_data(redshift_test_engine):
 def test_snowflake_example_data(snowflake_test_engine):
     """Confirm that we can connect to the snowflake test db and get table names"""
     inspector = inspect(snowflake_test_engine)
-    assert inspector.get_table_names(schema="test") == [
-        "cc",
-        "report",
+    assert sorted(inspector.get_table_names(schema="test")) == [
         "address",
+        "cc",
         "customer",
         "employee",
         "login",
@@ -102,6 +101,7 @@ def test_snowflake_example_data(snowflake_test_engine):
         "order_item",
         "payment_card",
         "product",
+        "report",
         "report",
         "service_request",
         "visit",
@@ -113,13 +113,13 @@ def test_snowflake_example_data(snowflake_test_engine):
 def test_bigquery_example_data(bigquery_test_engine):
     """Confirm that we can connect to the bigquery test db and get table names"""
     inspector = inspect(bigquery_test_engine)
-    assert inspector.get_table_names(schema="fidesopstest") == [
+    assert sorted(inspector.get_table_names(schema="fidesopstest")) == [
         "address",
         "customer",
         "employee",
         "login",
-        "order_item",
         "orders",
+        "order_item",
         "payment_card",
         "product",
         "report",


### PR DESCRIPTION
# Purpose

Some of the tests calling `get_table_names` were randomly failing, redshift for example. The though is this is because `get_tables_names` doesn't guarantee order. 

# Changes
- Sort the table names before comparing it it the list.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
