### PR TITLE
Refactor static checks to run outside of Docker

### DIFF
--- a/.github/workflows/fidesops_safe_pr_checks.yml
+++ b/.github/workflows/fidesops_safe_pr_checks.yml
@@ -63,7 +63,6 @@ jobs:
         run: nox -s check_migrations
 
   isort:
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +80,6 @@ jobs:
         run: nox -s isort
 
   Black:
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -121,7 +119,6 @@ jobs:
         run: nox -s docs_check
 
   Pylint:
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -139,7 +136,6 @@ jobs:
         run: nox -s pylint
 
   Mypy:
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -157,7 +153,6 @@ jobs:
         run: nox -s mypy
 
   Xenon:
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/fidesops_safe_pr_checks.yml
+++ b/.github/workflows/fidesops_safe_pr_checks.yml
@@ -66,17 +66,13 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Download fidesops container
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/
-
-      - name: Load fidesops image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -88,17 +84,13 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Download fidesops container
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/
-
-      - name: Load fidesops image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -132,17 +124,13 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Download fidesops container
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/
-
-      - name: Load fidesops image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -154,17 +142,13 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Download fidesops container
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/
-
-      - name: Load fidesops image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -176,17 +160,13 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Download fidesops container
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/
-
-      - name: Load fidesops image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,12 @@ The types of changes are:
 * Access and erasure support for Adobe Campaign [#905](https://github.com/ethyca/fidesops/pull/905)
 * Added db vs saas to connection type api [#937](https://github.com/ethyca/fidesops/pull/937)
 * Retry a DSR (FE) [#863](https://github.com/ethyca/fidesops/pull/938)
-* Add a Connection - Select a connector to configure (front end) [#760] (https://github.com/ethyca/fidesops/pull/987)
-* Add a Connection - Front End layout structure [#866] (https://github.com/ethyca/fidesops/pull/987)
+* Add a Connection - Select a connector to configure (front end) [#760] (<https://github.com/ethyca/fidesops/pull/987>)
+* Add a Connection - Front End layout structure [#866] (<https://github.com/ethyca/fidesops/pull/987>)
 * Enable python function overrides for SaaS connector request execution [#986](https://github.com/ethyca/fidesops/pull/986)
 * add Events and logs section to Subject Request Details Page [#1018](https://github.com/ethyca/fidesops/pull/1018)
 * Access and erasure support for Auth0 [#991](https://github.com/ethyca/fidesops/pull/991)
-* Start better understanding how request execution fails [#993] (https://github.com/ethyca/fidesops/pull/993)
+* Start better understanding how request execution fails [#993] (<https://github.com/ethyca/fidesops/pull/993>)
 * Add approval `AuditLog`s for user and sytem approved privacy requests [#1038](https://github.com/ethyca/fidesops/pull/1038)
 
 ### Changed
@@ -40,6 +40,7 @@ The types of changes are:
 * Users should be able to click on the full field of a dropdown-type filter to open up the dropdown [#747](https://github.com/ethyca/fidesops/pull/903)
 * Updated the python docker base image from slim-buster to slim-bullseye [928](https://github.com/ethyca/fidesops/pull/928)
 * Removed ipython from the docker install [928](https://github.com/ethyca/fidesops/pull/928)
+* Run static nox checks outside of Docker [1053](https://github.com/ethyca/fidesops/pull/1053)
 * Serve admin UI by default [#906](https://github.com/ethyca/fidesops/pull/936)
 * Move tests into an `ops` subdir [#935](https://github.com/ethyca/fidesops/pull/935)
 * Move client code into an `ops` subdir [#964](https://github.com/ethyca/fidesops/pull/964)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,3 +14,4 @@ from utils_nox import *
 
 # Sets the default session to `--list`
 nox.options.sessions = []
+nox.options.reuse_existing_virtualenvs = True

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -9,7 +9,7 @@ from constants_nox import (
     START_APP,
 )
 from run_infrastructure import OPS_TEST_DIR, run_infrastructure
-from utils_nox import db
+from utils_nox import db, install_requirements
 
 
 @nox.session()
@@ -33,48 +33,61 @@ def ci_suite(session: nox.Session) -> None:
     session.notify("pytest_integration")
     session.notify("teardown")
 
-# Make the static checks run outside of docker
+
 # Static Checks
+@nox.session()
+def static_checks(session: nox.Session) -> None:
+    """Run the static checks only."""
+    session.notify("black")
+    session.notify("isort")
+    session.notify("xenon")
+    session.notify("mypy")
+    session.notify("pylint")
+
+
 @nox.session()
 def black(session: nox.Session) -> None:
     """Run the 'black' style linter."""
+    install_requirements(session)
     command = (
-        *RUN_NO_DEPS,
         "black",
         "--check",
         "src",
         "tests",
         "noxfiles",
     )
-    session.run(*command, external=True)
+    session.run(*command)
 
 
 @nox.session()
 def isort(session: nox.Session) -> None:
     """Run the 'isort' import linter."""
-    command = (*RUN_NO_DEPS, "isort", "src", "tests", "noxfiles", "--check")
-    session.run(*command, external=True)
+    install_requirements(session)
+    command = ("isort", "src", "tests", "noxfiles", "--check")
+    session.run(*command)
 
 
 @nox.session()
 def mypy(session: nox.Session) -> None:
     """Run the 'mypy' static type checker."""
-    command = (*RUN_NO_DEPS, "mypy")
-    session.run(*command, external=True)
+    install_requirements(session)
+    command = "mypy"
+    session.run(command)
 
 
 @nox.session()
 def pylint(session: nox.Session) -> None:
     """Run the 'pylint' code linter."""
-    command = (*RUN_NO_DEPS, "pylint", "src", "noxfiles")
-    session.run(*command, external=True)
+    install_requirements(session)
+    command = ("pylint", "src", "noxfiles")
+    session.run(*command)
 
 
 @nox.session()
 def xenon(session: nox.Session) -> None:
     """Run 'xenon' code complexity monitoring."""
+    install_requirements(session)
     command = (
-        *RUN_NO_DEPS,
         "xenon",
         "noxfiles",
         "src",
@@ -85,7 +98,7 @@ def xenon(session: nox.Session) -> None:
         "--ignore 'data, docs'",
         "--exclude src/fidesops/_version.py",
     )
-    session.run(*command, external=True)
+    session.run(*command)
 
 
 @nox.session()

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -33,7 +33,7 @@ def ci_suite(session: nox.Session) -> None:
     session.notify("pytest_integration")
     session.notify("teardown")
 
-
+# Make the static checks run outside of docker
 # Static Checks
 @nox.session()
 def black(session: nox.Session) -> None:

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -73,3 +73,8 @@ def teardown(session: nox.Session) -> None:
     """Tear down the docker dev environment."""
     session.run(*COMPOSE_DOWN, external=True)
     print("Teardown complete")
+
+
+def install_requirements(session: nox.Session) -> None:
+    session.install("-r", "requirements.txt")
+    session.install("-r", "dev-requirements.txt")


### PR DESCRIPTION
# Purpose

Run the static code checks outside of Docker

# Changes
* [x] update the static checks to install dev requirements and run outside of Docker
* [x] set the cpython version to 3.9 when running the commands in CI (mypy breaks using older versions)

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- ~~If docs updated (select one)~~:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] ~~Good unit test/integration test coverage~~
- [ ] ~~This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging~~
- [ ] ~~The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services~~

# Ticket

Fixes #990
 
