### PR TITLE
Fix quickstart by using `docker-compose run` and docker network for all commands

### DIFF
--- a/noxfiles/run_infrastructure.py
+++ b/noxfiles/run_infrastructure.py
@@ -164,7 +164,7 @@ def _run_quickstart(
     """
     _run_cmd_or_err('echo "Running the quickstart..."')
     _run_cmd_or_err(f"docker-compose {path} up -d")
-    _run_cmd_or_err(f"docker exec -it {service_name} python scripts/quickstart.py")
+    _run_cmd_or_err(f"docker-compose run {service_name} python scripts/quickstart.py")
 
 
 def _run_create_superuser(
@@ -177,7 +177,7 @@ def _run_create_superuser(
     _run_cmd_or_err('echo "Running create superuser..."')
     _run_cmd_or_err(f"docker-compose {path} up -d")
     _run_cmd_or_err(
-        f"docker exec -it {service_name} python scripts/create_superuser.py"
+        f"docker-compose run {service_name} python scripts/create_superuser.py"
     )
 
 
@@ -191,7 +191,7 @@ def _run_create_test_data(
     _run_cmd_or_err('echo "Running create test data..."')
     _run_cmd_or_err(f"docker-compose {path} up -d")
     _run_cmd_or_err(
-        f"docker exec -it {service_name} python scripts/create_test_data.py"
+        f"docker-compose run {service_name} python scripts/create_test_data.py"
     )
 
 

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
 
     # NOTE: In a real application, these secrets and config values would be provided
     # via ENV vars or similar, but we've inlined everything here for simplicity
-    FIDESOPS_URL = "http://0.0.0.0:8080"
+    FIDESOPS_URL = "http://webserver:8080"
     ROOT_CLIENT_ID = "fidesopsadmin"
     ROOT_CLIENT_SECRET = "fidesopsadminsecret"
 


### PR DESCRIPTION
# Purpose
This is a subtle thing, but in trying to reproduce some of the issues on main (e.g. #1055, probably also #1054) I saw we were mixing & matching using `docker-compose` and `docker exec`. If we use `compose` thoroughly, we'll find that the docker network is more predictable for service names, etc.

# Changes
- Edits noxfile commands to use `docker-compose run` for interactive sessions
- Tweaks quickstart.py to reference webserver host name instead of localhost (since it creates a one-off container using `docker-compose run` now)

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1055
Fixes #1054
 
