### PR TITLE
Add setuptools to dev-requirements to fix versioneer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,10 @@ The types of changes are:
 
 ### Fixed
 
-* Correct build arg variable name [925](https://github.com/ethyca/fidesops/pull/925)
+* Correct build arg variable name [#925](https://github.com/ethyca/fidesops/pull/925)
 * Reduce number of clients connected to the application db [#944](https://github.com/ethyca/fidesops/pull/944)
-* Patch versioneer to allow editable installs [1070](https://github.com/ethyca/fidesops/pull/1070)
+* Patch versioneer to allow editable installs [#1070](https://github.com/ethyca/fidesops/pull/1070)
+* Add setuptools to dev-requirements to fix versioneer error and revert patch [#1072](https://github.com/ethyca/fidesops/pull/1072)
 
 ## [1.6.3](https://github.com/ethyca/fidesops/compare/1.6.2...1.6.3)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,7 @@ pytest-cov==3.0.0
 pytest-env==0.6.2
 pytest==6.2.2
 requests-mock==1.9.3
+setuptools>=64.0.2
 types-PyYAML==6.0.11
 types-redis==4.3.4
 types-toml==0.10.8

--- a/versioneer.py
+++ b/versioneer.py
@@ -1605,8 +1605,6 @@ def get_cmdclass(cmdclass=None):
             cfg = get_config_from_root(root)
             versions = get_versions()
             _build_py.run(self)
-            if self.editable_mode:
-                return
 
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value


### PR DESCRIPTION
# Purpose

setuptools 64.0.2 includes a fix to the editable install error with versioneer.

# Changes
- Added setuptools >=  64.0.2 to dev-requiremnts
- Reverted versioneer patch applied in #1071

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1071
 
