### PR TITLE
Bump fideslib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 ### Fixed
 
 * HTTP headers are now preserved in requests generated from SaaS connector pagination [#1069](https://github.com/ethyca/fidesops/pull/1069)
+* Bump fideslib to fix issue where the authenticate button in the FastAPI docs did not work [#1092](https://github.com/ethyca/fidesops/pull/1092)
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi[all]==0.79.0
 fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.9.3
 fideslang==1.1.0
-fideslib==3.0.2
+fideslib==3.0.3
 fideslog==1.2.2
 hvac==0.11.2
 multidimensional_urlencode==0.0.4


### PR DESCRIPTION
# Purpose

Bumps fideslib to fix the issue where the authenticate button in the fastapi docs does not work.

# Changes
- Bump fideslib to v3.0.3

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
