### PR TITLE
Adds `AuditLog` and `ExecutionLog`s to `seed_test_data` command

### DIFF
--- a/scripts/create_test_data.py
+++ b/scripts/create_test_data.py
@@ -201,8 +201,8 @@ def create_test_data(db: orm.Session) -> FidesUser:
                 ),
             )
             for action_type in [
+                AuditLogAction.denied,  # Run denied before approved to simulate a realistic order
                 AuditLogAction.approved,
-                AuditLogAction.denied,
                 AuditLogAction.finished,
             ]:
                 AuditLog.create(
@@ -233,14 +233,30 @@ def create_test_data(db: orm.Session) -> FidesUser:
                         data={
                             "dataset_name": "dummy_dataset",
                             "collection_name": "dummy_collection",
-                            "fields_affected": ["dummy_field_1", "dummy_field_2"],
+                            "fields_affected": [
+                                {
+                                    "path": "dummy_dataset:dummy_collection:dummy_field_1",
+                                    "field_name": "dummy_field",
+                                    "data_categories": [
+                                        "data_category_1",
+                                        "data_category_2",
+                                    ],
+                                },
+                                {
+                                    "path": "dummy_dataset:dummy_collection:dummy_field_2",
+                                    "field_name": "dummy_field_2",
+                                    "data_categories": [
+                                        "data_category_2",
+                                        "data_category_3",
+                                    ],
+                                },
+                            ],
                             "action_type": action_type,
                             "status": exl_status,
                             "privacy_request_id": pr.id,
                             "message": f"Execution log for request id {pr.id} status {status} and action_type {action_type}",
                         },
                     )
-            # run_privacy_request.apply(args=[pr.id])  # Run the request synchronously
 
     print("Adding connection configs")
     _create_connection_configs(db)


### PR DESCRIPTION
# Purpose

This PR adds test `AuditLog` and `ExecutionLog` data to the `seed_test_data` command.

![Screenshot 2022-08-16 at 17 33 45](https://user-images.githubusercontent.com/1667340/184989141-733b9d7d-ad3b-4b71-a6a8-8116f0656c3c.png)

# Changes
- Create `AuditLog` and `ExecutionLog`s for created `PrivacyRequest` objects of every permutation of action and status.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
