### PR TITLE
Reduce Idle Connections from Health Checks [#1102]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 
 * HTTP headers are now preserved in requests generated from SaaS connector pagination [#1069](https://github.com/ethyca/fidesops/pull/1069)
 * Bump fideslib to fix issue where the authenticate button in the FastAPI docs did not work [#1092](https://github.com/ethyca/fidesops/pull/1092)
+* Reduced number of connections opened against app db during health checks [#1107](https://github.com/ethyca/fidesops/pull/1107)
 
 ### Changed
 

--- a/src/fidesops/ops/api/deps.py
+++ b/src/fidesops/ops/api/deps.py
@@ -1,10 +1,12 @@
 from typing import Generator
 
-from fideslib.db.session import get_db_session
+from fideslib.db.session import get_db_engine, get_db_session
 
 from fidesops.ops.common_exceptions import FunctionalityNotConfigured
 from fidesops.ops.core.config import config
 from fidesops.ops.util.cache import get_cache as get_redis_connection
+
+_engine = None
 
 
 def get_db() -> Generator:
@@ -14,7 +16,10 @@ def get_db() -> Generator:
             "Application database required, but it is currently disabled! Please update your application configuration to enable integration with an application database."
         )
     try:
-        SessionLocal = get_db_session(config)
+        global _engine  # pylint: disable=W0603
+        if not _engine:
+            _engine = get_db_engine(config=config)
+        SessionLocal = get_db_session(config, engine=_engine)
         db = SessionLocal()
         yield db
     finally:

--- a/src/fidesops/ops/api/deps.py
+++ b/src/fidesops/ops/api/deps.py
@@ -15,6 +15,16 @@ def get_db() -> Generator:
         raise FunctionalityNotConfigured(
             "Application database required, but it is currently disabled! Please update your application configuration to enable integration with an application database."
         )
+    return _get_session()
+
+
+def get_db_for_health_check() -> Generator:
+    """Gets a database session regardless of whether the application db is disabled, for a health check."""
+    return _get_session()
+
+
+def _get_session() -> Generator:
+    """Gets a database session"""
     try:
         global _engine  # pylint: disable=W0603
         if not _engine:

--- a/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
@@ -23,7 +23,9 @@ logging.getLogger("alembic").setLevel(logging.WARNING)
 
 
 @router.get(HEALTH, response_model=Dict[str, Union[bool, str]])
-def health_check(db: Session = Depends(deps.get_db)) -> Dict[str, Union[bool, str]]:
+def health_check(
+    db: Session = Depends(deps.get_db_for_health_check),
+) -> Dict[str, Union[bool, str]]:
     return {
         "webserver": "healthy",
         "database": get_db_health(config.database.sqlalchemy_database_uri, db),

--- a/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
@@ -2,9 +2,11 @@ import logging
 from typing import Dict, Optional, Union
 
 from alembic import migration, script
+from fastapi import Depends
 from redis.exceptions import ResponseError
-from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
+from fidesops.ops.api import deps
 from fidesops.ops.api.v1.urn_registry import HEALTH
 from fidesops.ops.common_exceptions import RedisConnectionError
 from fidesops.ops.core.config import config
@@ -21,29 +23,27 @@ logging.getLogger("alembic").setLevel(logging.WARNING)
 
 
 @router.get(HEALTH, response_model=Dict[str, Union[bool, str]])
-def health_check() -> Dict[str, Union[bool, str]]:
+def health_check(db: Session = Depends(deps.get_db)) -> Dict[str, Union[bool, str]]:
     return {
         "webserver": "healthy",
-        "database": get_db_health(config.database.sqlalchemy_database_uri),
+        "database": get_db_health(config.database.sqlalchemy_database_uri, db),
         "cache": get_cache_health(),
     }
 
 
-def get_db_health(database_url: Optional[str]) -> str:
+def get_db_health(database_url: Optional[str], db: Session) -> str:
     """Checks if the db is reachable and up to date in alembic migrations"""
     if not database_url or not config.database.enabled:
         return "no db configured"
     try:
-        engine = create_engine(database_url)
         alembic_config = get_alembic_config(database_url)
         alembic_script_directory = script.ScriptDirectory.from_config(alembic_config)
-        with engine.begin() as conn:
-            context = migration.MigrationContext.configure(conn)
-            if (
-                context.get_current_revision()
-                != alembic_script_directory.get_current_head()
-            ):
-                return "needs migration"
+        context = migration.MigrationContext.configure(db.connection())
+        if (
+            context.get_current_revision()
+            != alembic_script_directory.get_current_head()
+        ):
+            return "needs migration"
         return "healthy"
     except Exception as error:  # pylint: disable=broad-except
         logger.error(f"Unable to reach the database: {error}")


### PR DESCRIPTION
# Purpose

The health check endpoints are opening up too many connections against the fidesops application database.  Shoutout to @RobertKeyser and @sanders41 for spotting.

# Changes
- Stop creating a new engine as part of the process of running a health check.
- Create an engine to be used across the application, and pass this into `get_db_session` when we go to get a single connection, instead of creating a new engine. (Note we are currently using the default `pool_size` and `max_overflow` parameters. This is something that may need to be configurable in the future).
  - Note that our celery processes intentionally create their own separate engines for managing connections for running privacy requests.


# Background
> The typical usage of [create_engine()](https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine) is once per particular database URL, held globally for the lifetime of a single application process. A single [Engine](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Engine) manages many individual [DBAPI](https://docs.sqlalchemy.org/en/14/glossary.html#term-DBAPI) connections on behalf of the process and is intended to be called upon in a concurrent fashion. The [Engine](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Engine) is not synonymous to the DBAPI connect function, which represents just one connection resource - the [Engine](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Engine) is most efficient when created just once at the module level of an application, not per-object or per-function call.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1102 
 
