### PR TITLE
Fix localhost setting for non-endpoint analytics calls [#1029]

### DIFF
--- a/src/fidesops/ops/graph/analytics_events.py
+++ b/src/fidesops/ops/graph/analytics_events.py
@@ -79,7 +79,7 @@ def prepare_rerun_graph_analytics_event(
         if step == ActionType.access
         else "rerun_erasure_graph",
         event_created_at=datetime.now(tz=timezone.utc),
-        local_host=False,  # Temporarily defaulting to False, but we are going to change this to None
+        local_host=None,
         endpoint=None,
         status_code=None,
         error=None,
@@ -98,7 +98,7 @@ def failed_graph_analytics_event(
         docker=in_docker_container(),
         event="privacy_request_execution_failure",
         event_created_at=datetime.now(tz=timezone.utc),
-        local_host=False,  # Temporarily defaulting to False, but we are going to change this to None
+        local_host=None,
         endpoint=None,
         status_code=500,
         error=exc.__class__.__name__ if exc else None,

--- a/tests/ops/graph/test_graph_analytics_events.py
+++ b/tests/ops/graph/test_graph_analytics_events.py
@@ -17,4 +17,4 @@ class TestFailedGraphAnalyticsEvent:
         assert analytics_event.error == "FidesopsException"
         assert analytics_event.status_code == 500
         assert analytics_event.endpoint is None
-        assert analytics_event.local_host is False
+        assert analytics_event.local_host is None

--- a/tests/ops/graph/test_graph_differences.py
+++ b/tests/ops/graph/test_graph_differences.py
@@ -881,7 +881,7 @@ class TestPrepareRerunAccessGraphEvent:
         assert analytics_event.error is None
         assert analytics_event.status_code is None
         assert analytics_event.endpoint is None
-        assert analytics_event.local_host is False
+        assert analytics_event.local_host is None
 
     def test_rerun_erasure_graph_analytics_event(
         self, privacy_request, env_a_b, env_a_b_c, resources
@@ -914,4 +914,4 @@ class TestPrepareRerunAccessGraphEvent:
         assert analytics_event.error is None
         assert analytics_event.status_code is None
         assert analytics_event.endpoint is None
-        assert analytics_event.local_host is False
+        assert analytics_event.local_host is None

--- a/tests/ops/integration_tests/test_execution.py
+++ b/tests/ops/integration_tests/test_execution.py
@@ -675,7 +675,7 @@ def test_restart_graph_from_failure(
         assert analytics_event.error is None
         assert analytics_event.status_code is None
         assert analytics_event.endpoint is None
-        assert analytics_event.local_host is False
+        assert analytics_event.local_host is None
 
     assert (
         db.query(ExecutionLog)
@@ -806,7 +806,7 @@ def test_restart_graph_from_failure_during_erasure(
         assert analytics_event.error is None
         assert analytics_event.status_code is None
         assert analytics_event.endpoint is None
-        assert analytics_event.local_host is False
+        assert analytics_event.local_host is None
 
     assert (
         db.query(ExecutionLog)

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -1545,7 +1545,7 @@ def test_privacy_request_log_failure(
         assert sent_event.event == "privacy_request_execution_failure"
         assert sent_event.event_created_at is not None
 
-        assert sent_event.local_host is False
+        assert sent_event.local_host is None
         assert sent_event.endpoint is None
         assert sent_event.status_code == 500
         assert sent_event.error == "KeyError"


### PR DESCRIPTION
…ogging various tasks coming out of celery.


# Purpose

Follow-up to https://github.com/ethyca/fidesops/pull/993

When we added analytics for failed request execution or retrying a request, we couldn't set `localhost` to the proper value because fideslog didn't allow it to be set to None.


# Changes
- Because these analytics events are not coming from API endpoints, but rather celery tasks, set localhost to None instead of a default False.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #029
 
