### PR TITLE
1128-Add Retry button back into the subject request detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The types of changes are:
 * SaaS Connector Configuration - Testing a Connection [#985](https://github.com/ethyca/fidesops/pull/1099)
 * Add an endpoint for verifying the user's identity before queuing the privacy request. [#1111](https://github.com/ethyca/fidesops/pull/1111)
 * Adds tests for email endpoints and service [#1112](https://github.com/ethyca/fidesops/pull/1112)
-* Retry a DSR (FE) [#863](https://github.com/ethyca/fidesops/pull/938)
+* Add Retry button back into the subject request detail view [#1128](https://github.com/ethyca/fidesops/pull/1131)
 
 ### Developer Experience
 
@@ -60,6 +60,7 @@ The types of changes are:
 * Added saas config base info to connection config responses [#904](https://github.com/ethyca/fidesops/pull/904)
 * Access and erasure support for Adobe Campaign [#905](https://github.com/ethyca/fidesops/pull/905)
 * Added db vs saas to connection type api [#937](https://github.com/ethyca/fidesops/pull/937)
+* Retry a DSR (FE) [#863](https://github.com/ethyca/fidesops/pull/938)
 * Add a Connection - Select a connector to configure (front end) [#760](https://github.com/ethyca/fidesops/pull/987)
 * Add a Connection - Front End layout structure [#866](https://github.com/ethyca/fidesops/pull/987)
 * Enable python function overrides for SaaS connector request execution [#986](https://github.com/ethyca/fidesops/pull/986)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 * SaaS Connector Configuration - Testing a Connection [#985](https://github.com/ethyca/fidesops/pull/1099)
 * Add an endpoint for verifying the user's identity before queuing the privacy request. [#1111](https://github.com/ethyca/fidesops/pull/1111)
 * Adds tests for email endpoints and service [#1112](https://github.com/ethyca/fidesops/pull/1112)
+* Retry a DSR (FE) [#863](https://github.com/ethyca/fidesops/pull/938)
 
 ### Developer Experience
 
@@ -59,7 +60,6 @@ The types of changes are:
 * Added saas config base info to connection config responses [#904](https://github.com/ethyca/fidesops/pull/904)
 * Access and erasure support for Adobe Campaign [#905](https://github.com/ethyca/fidesops/pull/905)
 * Added db vs saas to connection type api [#937](https://github.com/ethyca/fidesops/pull/937)
-* Retry a DSR (FE) [#863](https://github.com/ethyca/fidesops/pull/938)
 * Add a Connection - Select a connector to configure (front end) [#760](https://github.com/ethyca/fidesops/pull/987)
 * Add a Connection - Front End layout structure [#866](https://github.com/ethyca/fidesops/pull/987)
 * Enable python function overrides for SaaS connector request execution [#986](https://github.com/ethyca/fidesops/pull/986)

--- a/clients/ops/admin-ui/src/constants.ts
+++ b/clients/ops/admin-ui/src/constants.ts
@@ -18,6 +18,10 @@ export const USER_PRIVILEGES: UserPrivileges[] = [
     scope: "privacy-request:review",
   },
   {
+    privilege: "Resume subject requests",
+    scope: "privacy-request:resume",
+  },
+  {
     privilege: "View datastore connections",
     scope: "connection:read",
   },


### PR DESCRIPTION

<img width="1437" alt="Screen Shot 2022-08-23 at 8 53 02 AM" src="https://user-images.githubusercontent.com/68459950/186163798-c06a781a-651a-4ffb-8227-b9d58beb54c2.png">
# Purpose
Original [PR](https://github.com/ethyca/fidesops/pull/938) was previously removed inadvertently. Purpose of this PR is to put back the original PR. 

# Changes
- Added back the Retry button on the Subject Request detail view. 

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1128 
 
