### PR TITLE
Support case-insensitive connection type search [Unticketed]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The types of changes are:
 
 * Update request status endpoint to return both audit and execution logs [#1068] (https://github.com/ethyca/fidesops/pull/1068/)
 * Update backend routing to handle dynamic frontend routes [#1033](https://github.com/ethyca/fidesops/pull/1033)
-
+* Make connection type search case-insensitive [#1133](https://github.com/ethyca/fidesops/pull/1133)
 
 ## [1.7.0](https://github.com/ethyca/fidesops/compare/1.6.3...1.7.0)
 

--- a/src/fidesops/ops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/connection_type_endpoints.py
@@ -36,7 +36,7 @@ def get_connection_types(
 ) -> List[ConnectionSystemTypeMap]:
     def is_match(elem: str) -> bool:
         """If a search query param was included, is it a substring of an available connector type?"""
-        return search in elem if search else True
+        return search.lower() in elem.lower() if search else True
 
     connection_system_types: List[ConnectionSystemTypeMap] = []
     if system_type == SystemType.database or system_type is None:

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1,4 +1,3 @@
-from typing import List
 from unittest import mock
 
 import pytest
@@ -81,6 +80,40 @@ class TestGetConnections:
         }
 
         resp = api_client.get(url + "?search=re", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()["items"]
+        assert len(data) == 3
+        assert data == [
+            {
+                "identifier": ConnectionType.postgres.value,
+                "type": SystemType.database.value,
+            },
+            {
+                "identifier": ConnectionType.redshift.value,
+                "type": SystemType.database.value,
+            },
+            {"identifier": SaaSType.outreach.value, "type": SystemType.saas.value},
+        ]
+
+    def test_search_connection_types_case_insensitive(
+        self, api_client, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
+
+        resp = api_client.get(url + "?search=St", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()["items"]
+        assert len(data) == 2
+        assert data[0] == {
+            "identifier": ConnectionType.postgres.value,
+            "type": SystemType.database.value,
+        }
+        assert data[1] == {
+            "identifier": SaaSType.stripe.value,
+            "type": SystemType.saas.value,
+        }
+
+        resp = api_client.get(url + "?search=Re", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         assert len(data) == 3


### PR DESCRIPTION
# Purpose

`{{host}}/connection_type?search=St` does not return any results, but we'd expect po**st**gres and **st**ripe to be returned.

# Changes
- Support case-insensitive connection type search 

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [x] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Unticketed 
 
