### PR TITLE
hook up API request to logout action [Unticketed]

### DIFF
--- a/clients/ops/admin-ui/package.json
+++ b/clients/ops/admin-ui/package.json
@@ -8,6 +8,7 @@
     "build": "next build && next export",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --fix --ext .ts,.tsx",
     "format": "prettier --write src/ __tests__/",
     "format:ci": "prettier --check src/ __tests__/",
     "test": "jest --watch",

--- a/clients/ops/admin-ui/src/features/auth/auth.slice.ts
+++ b/clients/ops/admin-ui/src/features/auth/auth.slice.ts
@@ -10,7 +10,12 @@ import { BASE_URL, STORED_CREDENTIALS_KEY } from "../../constants";
 import { addCommonHeaders } from "../common/CommonHeaders";
 import { utf8ToB64 } from "../common/utils";
 import { User } from "../user-management/types";
-import { LoginRequest, LoginResponse, LogoutRequest, LogoutResponse } from "./types";
+import {
+  LoginRequest,
+  LoginResponse,
+  LogoutRequest,
+  LogoutResponse,
+} from "./types";
 
 export interface AuthState {
   user: User | null;

--- a/clients/ops/admin-ui/src/features/auth/auth.slice.ts
+++ b/clients/ops/admin-ui/src/features/auth/auth.slice.ts
@@ -10,7 +10,7 @@ import { BASE_URL, STORED_CREDENTIALS_KEY } from "../../constants";
 import { addCommonHeaders } from "../common/CommonHeaders";
 import { utf8ToB64 } from "../common/utils";
 import { User } from "../user-management/types";
-import { LoginRequest, LoginResponse } from "./types";
+import { LoginRequest, LoginResponse, LogoutRequest, LogoutResponse } from "./types";
 
 export interface AuthState {
   user: User | null;
@@ -93,8 +93,15 @@ export const authApi = createApi({
       }),
       invalidatesTags: () => ["Auth"],
     }),
+    logout: build.mutation<LogoutResponse, LogoutRequest>({
+      query: () => ({
+        url: "logout",
+        method: "POST",
+      }),
+      invalidatesTags: () => ["Auth"],
+    }),
   }),
 });
 
-export const { useLoginMutation } = authApi;
+export const { useLoginMutation, useLogoutMutation } = authApi;
 export const { reducer } = authSlice;

--- a/clients/ops/admin-ui/src/features/auth/types.ts
+++ b/clients/ops/admin-ui/src/features/auth/types.ts
@@ -12,6 +12,5 @@ export interface LoginResponse {
   };
 }
 
-
-export interface LogoutRequest { }
-export interface LogoutResponse { }
+export interface LogoutRequest {}
+export interface LogoutResponse {}

--- a/clients/ops/admin-ui/src/features/auth/types.ts
+++ b/clients/ops/admin-ui/src/features/auth/types.ts
@@ -11,3 +11,7 @@ export interface LoginResponse {
     access_token: string;
   };
 }
+
+
+export interface LogoutRequest { }
+export interface LogoutResponse { }

--- a/clients/ops/admin-ui/src/features/common/Header.tsx
+++ b/clients/ops/admin-ui/src/features/common/Header.tsx
@@ -15,22 +15,24 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { INDEX_ROUTE } from "../../constants";
-import { logout, selectUser } from "../auth";
+import { useLogoutMutation, logout, selectUser } from "../auth";
 import { UserIcon } from "./Icon";
 import Image from "./Image";
 
 const useHeader = () => {
-  const dispatch = useDispatch();
-  const handleLogout = () => dispatch(logout());
   const { username } = useSelector(selectUser) ?? { username: "" };
-  return {
-    handleLogout,
-    username,
-  };
+  return { username };
 };
 
 const Header: React.FC = () => {
-  const { handleLogout, username } = useHeader();
+  const { username } = useHeader();
+  const [logoutMutation] = useLogoutMutation();
+  const dispatch = useDispatch();
+
+  const handleLogout = async () => {
+    logoutMutation({}).unwrap().then(() => dispatch(logout()));
+  }
+
   return (
     <header>
       <Flex

--- a/clients/ops/admin-ui/src/features/common/Header.tsx
+++ b/clients/ops/admin-ui/src/features/common/Header.tsx
@@ -30,8 +30,10 @@ const Header: React.FC = () => {
   const dispatch = useDispatch();
 
   const handleLogout = async () => {
-    logoutMutation({}).unwrap().then(() => dispatch(logout()));
-  }
+    logoutMutation({})
+      .unwrap()
+      .then(() => dispatch(logout()));
+  };
 
   return (
     <header>

--- a/clients/ops/admin-ui/src/features/common/Header.tsx
+++ b/clients/ops/admin-ui/src/features/common/Header.tsx
@@ -15,7 +15,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { INDEX_ROUTE } from "../../constants";
-import { useLogoutMutation, logout, selectUser } from "../auth";
+import { logout, selectUser, useLogoutMutation } from "../auth";
 import { UserIcon } from "./Icon";
 import Image from "./Image";
 


### PR DESCRIPTION
# Purpose

The Fidesops authentication API is configured to invalidate tokens via calling of the `/logout` endpoint, this PR adds an API call to that endpoint when logout is called to properly invalidate the token, rather than only clearing the token from the application state.

# Changes
-

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
