### PR TITLE
Fix error in `publish_docs` Github Actions syntax

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
       - name: Install dependencies
-      - run: pip install -r docs/fidesops/requirements.txt
+        run: pip install -r docs/fidesops/requirements.txt
       - name: Build docs
         run: nox -s docs_build
       - name: Publish docs


### PR DESCRIPTION
Fixes [this error](https://github.com/ethyca/fidesops/commit/5f7b04674ddd6c3dd3fb00809c73c608d1f3ef5e#annotation_4403170976).
