### PR TITLE
SaaS Connector Template Creation Fix: Integer fides_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The types of changes are:
 ### Added
 * Adds users and owners configuration for Hubspot connector [#1091](https://github.com/ethyca/fidesops/pull/1091)
 
+### Fixed
+* Accounts for integer "instance_fides_keys" when creating a saas connector from a template [#1166](https://github.com/ethyca/fidesops/pull/1166)
+
+
 ## [1.7.1](https://github.com/ethyca/fidesops/compare/1.7.0...1.7.1)
 
 ### Added

--- a/src/fidesops/ops/util/saas_util.py
+++ b/src/fidesops/ops/util/saas_util.py
@@ -39,7 +39,7 @@ def load_config_with_replacement(
 ) -> Dict:
     """Loads the saas config from the yaml file and replaces any string with the given value"""
     yaml_str: str = load_yaml_as_string(filename).replace(
-        string_to_replace, replacement
+        string_to_replace, f'"{replacement}"'
     )
     return yaml.safe_load(yaml_str).get("saas_config", [])
 
@@ -55,7 +55,7 @@ def load_dataset_with_replacement(
 ) -> Dict:
     """Loads the dataset from the yaml file and replaces any string with the given value"""
     yaml_str: str = load_yaml_as_string(filename).replace(
-        string_to_replace, replacement
+        string_to_replace, f'"{replacement}"'
     )
     return yaml.safe_load(yaml_str).get("dataset", [])
 

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -503,6 +503,43 @@ class TestInstantiateConnectionFromTemplate:
         ).first()
         assert dataset_config is None
 
+    def test_instantiate_connection_from_template_integer_key(
+        self, db, generate_auth_header, api_client, base_url
+    ):
+        auth_header = generate_auth_header(scopes=[SAAS_CONNECTION_INSTANTIATE])
+        request_body = {
+            "instance_key": "111",
+            "secrets": {
+                "domain": "test_mailchimp_domain",
+                "username": "test_mailchimp_username",
+                "api_key": "test_mailchimp_api_key",
+            },
+            "name": "Mailchimp Connector",
+            "description": "Mailchimp ConnectionConfig description",
+            "key": "mailchimp_connection_config",
+        }
+        resp = api_client.post(
+            base_url.format(saas_connector_type="mailchimp"),
+            headers=auth_header,
+            json=request_body,
+        )
+
+        connection_config = ConnectionConfig.filter(
+            db=db, conditions=(ConnectionConfig.key == "mailchimp_connection_config")
+        ).first()
+        dataset_config = DatasetConfig.filter(
+            db=db,
+            conditions=(DatasetConfig.fides_key == "111"),
+        ).first()
+
+        saas_config_fides_key = connection_config.saas_config["fides_key"]
+        dataset_fides_key = dataset_config.fides_key
+        embedded_dataset_fides_key = dataset_config.dataset["fides_key"]
+
+        assert saas_config_fides_key == dataset_fides_key == embedded_dataset_fides_key
+        dataset_config.delete(db)
+        connection_config.delete(db)
+
     def test_instantiate_connection_from_template(
         self, db, generate_auth_header, api_client, base_url
     ):
@@ -568,6 +605,12 @@ class TestInstantiateConnectionFromTemplate:
 
         assert dataset_config.connection_config_id == connection_config.id
         assert dataset_config.dataset is not None
+
+        saas_config_fides_key = connection_config.saas_config["fides_key"]
+        dataset_fides_key = dataset_config.fides_key
+        embedded_dataset_fides_key = dataset_config.dataset["fides_key"]
+
+        assert saas_config_fides_key == dataset_fides_key == embedded_dataset_fides_key
 
         dataset_config.delete(db)
         connection_config.delete(db)


### PR DESCRIPTION
# Purpose

![Screen Shot 2022-08-26 at 11 27 22 AM](https://user-images.githubusercontent.com/9755598/186944428-8ed0fe7b-d1f0-4510-8672-32461348768d.png)

We want to have the same identifier used across a saas config and dataset config but integer keys were not accounted for. 
 Spotted by @chriscalhoun1974 - he created a saas connection config from a template in testing and gave it an "instance_fides_key" of "111".  This is saved as a  string type on the `DatasetConfig.fides_key` but is interpreted as an integer when parsing the yaml.  This throws a validation error later when you try to edit the dataset, and we see that the datasetconfig.fides_key field does not match the `fides_key` in the saas config.



# Changes
- Use quotes to force a string when replacing <"instance_fides_key"> in the saas config and dataset config yaml.


# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Unticketed 
 
