### PR TITLE
Revert "SaaS Connector Template Creation Fix: Integer fides_key"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ The types of changes are:
 * Foundations for a new email connector type [#1142](https://github.com/ethyca/fidesops/pull/1142)
 
 
-### Fixed
-* Accounts for integer "instance_fides_keys" when creating a saas connector from a template [#1166](https://github.com/ethyca/fidesops/pull/1166)
-
-
 ## [1.7.1](https://github.com/ethyca/fidesops/compare/1.7.0...1.7.1)
 
 ### Added

--- a/src/fidesops/ops/util/saas_util.py
+++ b/src/fidesops/ops/util/saas_util.py
@@ -39,7 +39,7 @@ def load_config_with_replacement(
 ) -> Dict:
     """Loads the saas config from the yaml file and replaces any string with the given value"""
     yaml_str: str = load_yaml_as_string(filename).replace(
-        string_to_replace, f'"{replacement}"'
+        string_to_replace, replacement
     )
     return yaml.safe_load(yaml_str).get("saas_config", [])
 
@@ -55,7 +55,7 @@ def load_dataset_with_replacement(
 ) -> Dict:
     """Loads the dataset from the yaml file and replaces any string with the given value"""
     yaml_str: str = load_yaml_as_string(filename).replace(
-        string_to_replace, f'"{replacement}"'
+        string_to_replace, replacement
     )
     return yaml.safe_load(yaml_str).get("dataset", [])
 

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -503,43 +503,6 @@ class TestInstantiateConnectionFromTemplate:
         ).first()
         assert dataset_config is None
 
-    def test_instantiate_connection_from_template_integer_key(
-        self, db, generate_auth_header, api_client, base_url
-    ):
-        auth_header = generate_auth_header(scopes=[SAAS_CONNECTION_INSTANTIATE])
-        request_body = {
-            "instance_key": "111",
-            "secrets": {
-                "domain": "test_mailchimp_domain",
-                "username": "test_mailchimp_username",
-                "api_key": "test_mailchimp_api_key",
-            },
-            "name": "Mailchimp Connector",
-            "description": "Mailchimp ConnectionConfig description",
-            "key": "mailchimp_connection_config",
-        }
-        resp = api_client.post(
-            base_url.format(saas_connector_type="mailchimp"),
-            headers=auth_header,
-            json=request_body,
-        )
-
-        connection_config = ConnectionConfig.filter(
-            db=db, conditions=(ConnectionConfig.key == "mailchimp_connection_config")
-        ).first()
-        dataset_config = DatasetConfig.filter(
-            db=db,
-            conditions=(DatasetConfig.fides_key == "111"),
-        ).first()
-
-        saas_config_fides_key = connection_config.saas_config["fides_key"]
-        dataset_fides_key = dataset_config.fides_key
-        embedded_dataset_fides_key = dataset_config.dataset["fides_key"]
-
-        assert saas_config_fides_key == dataset_fides_key == embedded_dataset_fides_key
-        dataset_config.delete(db)
-        connection_config.delete(db)
-
     def test_instantiate_connection_from_template(
         self, db, generate_auth_header, api_client, base_url
     ):
@@ -605,12 +568,6 @@ class TestInstantiateConnectionFromTemplate:
 
         assert dataset_config.connection_config_id == connection_config.id
         assert dataset_config.dataset is not None
-
-        saas_config_fides_key = connection_config.saas_config["fides_key"]
-        dataset_fides_key = dataset_config.fides_key
-        embedded_dataset_fides_key = dataset_config.dataset["fides_key"]
-
-        assert saas_config_fides_key == dataset_fides_key == embedded_dataset_fides_key
 
         dataset_config.delete(db)
         connection_config.delete(db)


### PR DESCRIPTION
Reverts ethyca/fidesops#1166

Hey folks, I'm proposing we revert these changes as it breaks the YAML loading capacity of the SaaS config template:

```
webserver_1  | INFO:uvicorn.access:172.22.0.1:63706 - "POST /api/v1/connection/instantiate/sentry HTTP/1.1" 500
webserver_1  | ERROR:uvicorn.error:Exception in ASGI application
webserver_1  | Traceback (most recent call last):
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 372, in run_asgi
webserver_1  |     result = await app(self.scope, self.receive, self.send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
webserver_1  |     return await self.app(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 82, in __call__
webserver_1  |     raise exc from None
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 78, in __call__
webserver_1  |     await self.app(scope, inner_receive, inner_send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 269, in __call__
webserver_1  |     await super().__call__(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 124, in __call__
webserver_1  |     await self.middleware_stack(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
webserver_1  |     raise exc
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
webserver_1  |     await self.app(scope, receive, _send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 92, in __call__
webserver_1  |     await self.simple_response(scope, receive, send, request_headers=headers)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 147, in simple_response
webserver_1  |     await self.app(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/exceptions.py", line 93, in __call__
webserver_1  |     raise exc
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/exceptions.py", line 82, in __call__
webserver_1  |     await self.app(scope, receive, sender)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
webserver_1  |     raise e
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
webserver_1  |     await self.app(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 670, in __call__
webserver_1  |     await route.handle(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 266, in handle
webserver_1  |     await self.app(scope, receive, send)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 65, in app
webserver_1  |     response = await func(request)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 227, in app
webserver_1  |     raw_response = await run_endpoint_function(
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 162, in run_endpoint_function
webserver_1  |     return await run_in_threadpool(dependant.call, **values)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
webserver_1  |     return await anyio.to_thread.run_sync(func, *args)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/anyio/to_thread.py", line 31, in run_sync
webserver_1  |     return await get_asynclib().run_sync_in_worker_thread(
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
webserver_1  |     return await future
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
webserver_1  |     result = context.run(func, *args)
webserver_1  |   File "/fidesops/src/fidesops/ops/api/v1/endpoints/saas_config_endpoints.py", line 308, in instantiate_connection_from_template
webserver_1  |     create_connection_config_from_template_no_save(
webserver_1  |   File "/fidesops/src/fidesops/ops/service/connectors/saas/connector_registry_service.py", line 88, in create_connection_config_from_template_no_save
webserver_1  |     config_from_template: Dict = load_config_with_replacement(
webserver_1  |   File "/fidesops/src/fidesops/ops/util/saas_util.py", line 44, in load_config_with_replacement
webserver_1  |     return yaml.safe_load(yaml_str).get("saas_config", [])
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/__init__.py", line 162, in safe_load
webserver_1  |     return load(stream, SafeLoader)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/__init__.py", line 114, in load
webserver_1  |     return loader.get_single_data()
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/constructor.py", line 49, in get_single_data
webserver_1  |     node = self.get_single_node()
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 36, in get_single_node
webserver_1  |     document = self.compose_document()
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 55, in compose_document
webserver_1  |     node = self.compose_node(None, None)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 84, in compose_node
webserver_1  |     node = self.compose_mapping_node(anchor)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 133, in compose_mapping_node
webserver_1  |     item_value = self.compose_node(node, item_key)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 84, in compose_node
webserver_1  |     node = self.compose_mapping_node(anchor)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 133, in compose_mapping_node
webserver_1  |     item_value = self.compose_node(node, item_key)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 82, in compose_node
webserver_1  |     node = self.compose_sequence_node(anchor)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 111, in compose_sequence_node
webserver_1  |     node.value.append(self.compose_node(node, index))
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 84, in compose_node
webserver_1  |     node = self.compose_mapping_node(anchor)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 133, in compose_mapping_node
webserver_1  |     item_value = self.compose_node(node, item_key)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 82, in compose_node
webserver_1  |     node = self.compose_sequence_node(anchor)
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/composer.py", line 110, in compose_sequence_node
webserver_1  |     while not self.check_event(SequenceEndEvent):
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/parser.py", line 98, in check_event
webserver_1  |     self.current_event = self.state()
webserver_1  |   File "/usr/local/lib/python3.9/site-packages/yaml/parser.py", line 483, in parse_flow_sequence_entry
webserver_1  |     raise ParserError("while parsing a flow sequence", self.marks[-1],
webserver_1  | yaml.parser.ParserError: while parsing a flow sequence
webserver_1  |   in "<unicode string>", line 141, column 14:
webserver_1  |           after: ["test_connector".projects]
webserver_1  |                  ^
webserver_1  | expected ',' or ']', but got '<scalar>'
webserver_1  |   in "<unicode string>", line 141, column 31:
webserver_1  |           after: ["test_connector".projects]
```

This is happening because we're surrounding only part of the string in quotes I believe