### PR TITLE
[#1222] Fix reference in data categories upgrade migration

### DIFF
--- a/src/fidesops/ops/migrations/versions/7abe778b7082_update_fideslang_data_categories.py
+++ b/src/fidesops/ops/migrations/versions/7abe778b7082_update_fideslang_data_categories.py
@@ -178,7 +178,8 @@ def run_migration(migration_direction: str) -> None:
                 if counter % 10 == 0:
                     logger.info("Upgrading fideslang categories")
 
-                collections = dataset.get("collections")
+                dataset_json = dataset.dataset
+                collections = dataset_json.get("collections")
 
                 if collections:
                     for collection in collections:


### PR DESCRIPTION
# Purpose

Fixes a bug when running the `7abe778b7082_update_fideslang_data_categories_py` migration:

```
INFO:fidesops.main:Running any pending DB migrations...
INFO:7abe778b7082_update_fideslang_data_categories_py:Upgrading fideslang categories
ERROR:fidesops.main:Connection to database failed: get() missing 1 required keyword-only argument: 'object_id'
```

# Changes
- Reference the `DatasetConfig.dataset` json correctly.

# Ticket

Fixes #1222