### PR TITLE
Publish on every release

### DIFF
--- a/.github/workflows/publish_privacy_center_to_dockerhub.yaml
+++ b/.github/workflows/publish_privacy_center_to_dockerhub.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "clients/ops/privacy-center
     tags:
       - "*"
 
@@ -22,8 +20,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ env.DOCKER_USER }}  # Needs updating for fidesops privacy center
-          password: ${{ env.DOCKER_TOKEN }}  # Needs updating for fidesops privacy center
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -31,13 +29,10 @@ jobs:
         with:
           images: ethyca/fidesops-privacy-center
 
-      - name: Change to privacy center directory
-        run: cd clients/ops/privacy-center
-
       - name: Build and publish
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./clients/ops/privacy-center
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labes: ${{ steps.metadata.outputs.labesl }}
+          labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
# Purpose

Makes the privacy center publish on every release

# Changes
- Remove the path

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
