### PR TITLE
Bump fideslib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 ### Fixed
 
 * Fix issue with fideslog event loop errors [#1174](https://github.com/ethyca/fidesops/pull/1174)
+* Allow passwords to be sent either base64 encode or as plaintext. [#1236](https://github.com/ethyca/fidesops/pull/1236)
 
 
 ## [1.7.2](https://github.com/ethyca/fidesops/compare/1.7.1...1.7.2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi[all]==0.81.0
 fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.9.3
 fideslang==1.2.0
-fideslib==3.1.0
+fideslib==3.1.1
 fideslog==1.2.3
 hvac==0.11.2
 Jinja2==3.1.2


### PR DESCRIPTION
# Purpose

Bump fideslib to version 3.1.1. This allows for passwords to be sent either base64 encoded or as plaintext.

# Changes
- Bump fideslib to 3.1.1.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
