### PR TITLE
Rename fidesops-privacy-center image to fides-privacy-center

### DIFF
--- a/.github/workflows/publish_privacy_center_to_dockerhub.yaml
+++ b/.github/workflows/publish_privacy_center_to_dockerhub.yaml
@@ -2,8 +2,6 @@ name: Docker Build & Push Privacy Center
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "*"
 
@@ -12,7 +10,7 @@ env:
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
 jobs:
-  push-fidesops-privacy-center-image:
+  push-fides-privacy-center-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ethyca/fidesops-privacy-center
+          images: ethyca/fides-privacy-center
 
       - name: Build and publish
         uses: docker/build-push-action@v3

--- a/docs/fidesops/docs/deployment.md
+++ b/docs/fidesops/docs/deployment.md
@@ -155,13 +155,13 @@ You now have a functional `fidesops` server running! Now you can use the API to 
 
 First, ensure that Docker is running on your host, with a minimum version of `20.10.8`.
 
-You can `docker pull ethyca/fidesops-privacy-center` to get the latest image from Ethyca's Docker Hub here: [ethyca/fidesops-privacy-center](https://hub.docker.com/r/ethyca/fidesops-privacy-center).
+You can `docker pull ethyca/fides-privacy-center` to get the latest image from Ethyca's Docker Hub here: [ethyca/fides-privacy-center](https://hub.docker.com/r/ethyca/fides-privacy-center).
 
 ```
-docker pull ethyca/fidesops-privacy-center
+docker pull ethyca/fides-privacy-center
 ```
 
-Once pulled, you can run `docker run -rm -p 3000:3000 ethyca/fidesops-privacy-center:latest` to start the server.
+Once pulled, you can run `docker run -rm -p 3000:3000 ethyca/fides-privacy-center:latest` to start the server.
 
 To configure the privacy center for your environment create a project directory, i.e. `~/custom-privacy-center`, and within
 this directory create a `config` directory. Copy the [config.json](https://github.com/ethyca/fidesops/blob/main/clients/ops/privacy-center/config/config.json)
@@ -172,5 +172,5 @@ After the configuration is updated the docker image can be run using your custom
 directory name to match the name you used) start the docker container:
 
 ```
-docker run --rm -v $(pwd)/config:/app/config -p 3000:3000 ethyca/fidesops-privacy-center:latest`.
+docker run --rm -v $(pwd)/config:/app/config -p 3000:3000 ethyca/fides-privacy-center:latest`.
 ```


### PR DESCRIPTION
# Purpose

Rename the `fidesops-privacy-center` docker image to `fides-privacy-center` so we won't need to rename it again.

# Changes
- Change `fidesops-privacy-center` to `fides-privacy-center` in workflow file
- Change `fidesops-privacy-center` to `fides-privacy-center` in docs

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
