### PR TITLE
Fix for pytest-asyncio bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The types of changes are:
 * Fix issue with fideslog event loop errors [#1174](https://github.com/ethyca/fidesops/pull/1174)
 * Allow passwords to be sent either base64 encode or as plaintext. [#1236](https://github.com/ethyca/fidesops/pull/1236)
 * Allow worker to start up successfully for dev and dev_with_worker nox commands [#1250](https://github.com/ethyca/fidesops/pull/1250)
+* Fix for pytest-asyncio bug [#1260](https://github.com/ethyca/fidesops/pull/1260)
 
 ## [1.7.2](https://github.com/ethyca/fidesops/compare/1.7.1...1.7.2)
 

--- a/tests/ops/integration_tests/saas/request_override/test_mailchimp_override_task.py
+++ b/tests/ops/integration_tests/saas/request_override/test_mailchimp_override_task.py
@@ -29,6 +29,7 @@ as the standard Mailchimp config.
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_saas_override
+@pytest.mark.asyncio
 async def test_mailchimp_override_access_request_task(
     db,
     policy,
@@ -140,6 +141,7 @@ async def test_mailchimp_override_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_saas_override
+@pytest.mark.asyncio
 async def test_mailchimp_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_adobe_campaign_task.py
+++ b/tests/ops/integration_tests/saas/test_adobe_campaign_task.py
@@ -22,6 +22,7 @@ def test_adobe_campaign_connection_test(adobe_campaign_connection_config) -> Non
 @pytest.mark.skip(reason="Only staging credentials available")
 @pytest.mark.integration_saas
 @pytest.mark.integration_adobe_campaign
+@pytest.mark.asyncio
 async def test_adobe_campaign_access_request_task(
     policy,
     adobe_campaign_identity_email,
@@ -160,6 +161,7 @@ async def test_adobe_campaign_access_request_task(
 @pytest.mark.skip(reason="Only staging credentials available")
 @pytest.mark.integration_saas
 @pytest.mark.integration_adobe_campaign
+@pytest.mark.asyncio
 async def test_adobe_campaign_saas_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_datadog_task.py
+++ b/tests/ops/integration_tests/saas/test_datadog_task.py
@@ -21,6 +21,7 @@ def test_datadog_connection_test(datadog_connection_config) -> None:
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_datadog
+@pytest.mark.asyncio
 async def test_saas_access_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_datadog_task.py
+++ b/tests/ops/integration_tests/saas/test_datadog_task.py
@@ -52,8 +52,6 @@ async def test_saas_access_request_task(
         db,
     )
 
-    print(v[f"{dataset_name}:events"])
-
     assert_rows_match(
         v[f"{dataset_name}:events"],
         min_size=1,

--- a/tests/ops/integration_tests/saas/test_datadog_task.py
+++ b/tests/ops/integration_tests/saas/test_datadog_task.py
@@ -52,6 +52,8 @@ async def test_saas_access_request_task(
         db,
     )
 
+    print(v[f"{dataset_name}:events"])
+
     assert_rows_match(
         v[f"{dataset_name}:events"],
         min_size=1,

--- a/tests/ops/integration_tests/saas/test_hubspot_task.py
+++ b/tests/ops/integration_tests/saas/test_hubspot_task.py
@@ -23,6 +23,7 @@ def test_hubspot_connection_test(connection_config_hubspot) -> None:
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_hubspot
+@pytest.mark.asyncio
 async def test_saas_access_request_task(
     db,
     policy,
@@ -128,6 +129,7 @@ async def test_saas_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_hubspot
+@pytest.mark.asyncio
 async def test_saas_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_logi_id_task.py
+++ b/tests/ops/integration_tests/saas/test_logi_id_task.py
@@ -94,6 +94,7 @@ async def test_logi_id_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_logi_id
+@pytest.mark.asyncio
 async def test_logi_id_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_logi_id_task.py
+++ b/tests/ops/integration_tests/saas/test_logi_id_task.py
@@ -22,6 +22,7 @@ def test_logi_id_connection_test(logi_id_connection_config) -> None:
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_logi_id
+@pytest.mark.asyncio
 async def test_logi_id_access_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_mailchimp_task.py
+++ b/tests/ops/integration_tests/saas/test_mailchimp_task.py
@@ -12,6 +12,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match, records_matching_
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_mailchimp
+@pytest.mark.asyncio
 async def test_mailchimp_access_request_task(
     db,
     policy,
@@ -123,6 +124,7 @@ async def test_mailchimp_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_mailchimp
+@pytest.mark.asyncio
 async def test_mailchimp_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_outreach_task.py
+++ b/tests/ops/integration_tests/saas/test_outreach_task.py
@@ -15,6 +15,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 @pytest.mark.skip(reason="Currently unable to test OAuth2 connectors")
 @pytest.mark.integration_saas
 @pytest.mark.integration_outreach
+@pytest.mark.asyncio
 async def test_outreach_access_request_task(
     db,
     policy,
@@ -88,6 +89,7 @@ async def test_outreach_access_request_task(
 @pytest.mark.skip(reason="Currently unable to test OAuth2 connectors")
 @pytest.mark.integration_saas
 @pytest.mark.integration_outreach
+@pytest.mark.asyncio
 async def test_outreach_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_salesforce_task.py
+++ b/tests/ops/integration_tests/saas/test_salesforce_task.py
@@ -23,6 +23,7 @@ def test_salesforce_connection_test(salesforce_connection_config) -> None:
 @pytest.mark.skip(reason="Currently unable to test OAuth2 connectors")
 @pytest.mark.integration_saas
 @pytest.mark.integration_salesforce
+@pytest.mark.asyncio
 async def test_salesforce_access_request_task(
     policy,
     salesforce_identity_email,
@@ -371,6 +372,7 @@ async def test_salesforce_access_request_task(
 @pytest.mark.skip(reason="Currently unable to test OAuth2 connectors")
 @pytest.mark.integration_saas
 @pytest.mark.integration_salesforce
+@pytest.mark.asyncio
 async def test_salesforce_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_segment_task.py
+++ b/tests/ops/integration_tests/saas/test_segment_task.py
@@ -15,6 +15,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_segment
+@pytest.mark.asyncio
 async def test_segment_saas_access_request_task(
     db,
     policy,
@@ -140,6 +141,7 @@ async def test_segment_saas_access_request_task(
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_segment
+@pytest.mark.asyncio
 async def test_segment_saas_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_segment_task.py
+++ b/tests/ops/integration_tests/saas/test_segment_task.py
@@ -15,7 +15,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_segment
-@pytest.mark.syncio
+@pytest.mark.asyncio
 async def test_segment_saas_access_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_segment_task.py
+++ b/tests/ops/integration_tests/saas/test_segment_task.py
@@ -15,7 +15,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_segment
-@pytest.mark.asyncio
+@pytest.mark.syncio
 async def test_segment_saas_access_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_sendgrid_task.py
+++ b/tests/ops/integration_tests/saas/test_sendgrid_task.py
@@ -15,6 +15,7 @@ from tests.ops.test_helpers.saas_test_utils import poll_for_existence
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_sendgrid
+@pytest.mark.asyncio
 async def test_sendgrid_access_request_task(
     db,
     policy,
@@ -69,6 +70,7 @@ async def test_sendgrid_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_sendgrid
+@pytest.mark.asyncio
 async def test_sendgrid_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_sentry_task.py
+++ b/tests/ops/integration_tests/saas/test_sentry_task.py
@@ -18,6 +18,7 @@ from tests.ops.test_helpers.saas_test_utils import poll_for_existence
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_sentry
+@pytest.mark.asyncio
 async def test_sentry_access_request_task(
     db,
     policy,
@@ -265,6 +266,7 @@ def sentry_erasure_test_prep(sentry_connection_config, db):
 @pytest.mark.skip(reason="Pending account resolution")
 @pytest.mark.integration_saas
 @pytest.mark.integration_sentry
+@pytest.mark.asyncio
 async def test_sentry_erasure_request_task(
     db, policy, sentry_connection_config, sentry_dataset_config
 ) -> None:

--- a/tests/ops/integration_tests/saas/test_shopify_task.py
+++ b/tests/ops/integration_tests/saas/test_shopify_task.py
@@ -18,7 +18,8 @@ def test_shopify_connection_test(shopify_connection_config) -> None:
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_shopify
-def test_shopify_access_request_task(
+@pytest.mark.asyncio
+async def test_shopify_access_request_task(
     db,
     policy,
     shopify_connection_config,
@@ -37,7 +38,7 @@ def test_shopify_access_request_task(
     merged_graph = shopify_dataset_config.get_graph()
     graph = DatasetGraph(merged_graph)
 
-    v = graph_task.run_access_request(
+    v = await graph_task.run_access_request(
         privacy_request,
         policy,
         graph,

--- a/tests/ops/integration_tests/saas/test_stripe_task.py
+++ b/tests/ops/integration_tests/saas/test_stripe_task.py
@@ -16,6 +16,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_stripe
+@pytest.mark.asyncio
 async def test_stripe_access_request_task(
     db,
     policy,
@@ -634,6 +635,7 @@ async def test_stripe_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_stripe
+@pytest.mark.asyncio
 async def test_stripe_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/saas/test_zendesk_task.py
+++ b/tests/ops/integration_tests/saas/test_zendesk_task.py
@@ -15,6 +15,7 @@ from tests.ops.graph.graph_test_util import assert_rows_match
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_zendesk
+@pytest.mark.asyncio
 async def test_zendesk_access_request_task(
     db,
     policy,
@@ -178,6 +179,7 @@ async def test_zendesk_access_request_task(
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_zendesk
+@pytest.mark.asyncio
 async def test_zendesk_erasure_request_task(
     db,
     policy,

--- a/tests/ops/integration_tests/test_execution.py
+++ b/tests/ops/integration_tests/test_execution.py
@@ -97,6 +97,7 @@ class TestDeleteCollection:
         assert pr.get_results() == {}
 
     @mock.patch("fidesops.ops.task.graph_task.GraphTask.log_start")
+    @pytest.mark.asyncio
     async def test_delete_collection_while_in_progress(
         self,
         mocked_log_start,
@@ -183,6 +184,7 @@ class TestDeleteCollection:
 
         db.delete(mongo_connection_config)
 
+    @pytest.mark.asyncio
     async def test_collection_omitted_on_restart_from_failure(
         self,
         db,
@@ -314,6 +316,7 @@ class TestDeleteCollection:
 
 @pytest.mark.integration
 class TestSkipDisabledCollection:
+    @pytest.mark.asyncio
     async def test_skip_collection_new_request(
         self,
         db,
@@ -359,6 +362,7 @@ class TestSkipDisabledCollection:
         assert mongo_logs.filter_by(status="skipped").count() == 9
 
     @mock.patch("fidesops.ops.task.graph_task.GraphTask.log_start")
+    @pytest.mark.asyncio
     async def test_run_disabled_collections_in_progress(
         self,
         mocked_log_start,
@@ -449,6 +453,7 @@ class TestSkipDisabledCollection:
 
         db.delete(mongo_connection_config)
 
+    @pytest.mark.asyncio
     async def test_skip_collection_on_restart(
         self,
         db,
@@ -581,6 +586,7 @@ class TestSkipDisabledCollection:
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_restart_graph_from_failure(
     db,
     policy,
@@ -717,6 +723,7 @@ async def test_restart_graph_from_failure(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_restart_graph_from_failure_during_erasure(
     db,
     policy,

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -11,6 +11,7 @@ from fidesops.ops.task import graph_task
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_collections_with_manual_erasure_confirmation(
     db,
     erasure_policy,

--- a/tests/ops/integration_tests/test_manual_task.py
+++ b/tests/ops/integration_tests/test_manual_task.py
@@ -20,6 +20,7 @@ from ..task.traversal_data import postgres_and_manual_nodes
 @pytest.mark.integration_postgres
 @pytest.mark.integration
 @pytest.mark.usefixtures("postgres_integration_db")
+@pytest.mark.asyncio
 async def test_postgres_with_manual_input_access_request_task(
     db,
     policy,
@@ -218,6 +219,7 @@ async def test_postgres_with_manual_input_access_request_task(
 @pytest.mark.integration_postgres
 @pytest.mark.integration
 @pytest.mark.usefixtures("postgres_integration_db")
+@pytest.mark.asyncio
 async def test_no_manual_input_found(
     policy,
     db,
@@ -311,6 +313,7 @@ async def test_no_manual_input_found(
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_collections_with_manual_erasure_confirmation(
     db,
     erasure_policy,

--- a/tests/ops/integration_tests/test_mongo_task.py
+++ b/tests/ops/integration_tests/test_mongo_task.py
@@ -36,6 +36,7 @@ empty_policy = Policy()
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_combined_erasure_task(
     db,
     mongo_inserts,
@@ -251,6 +252,7 @@ async def test_combined_erasure_task(
 
 @pytest.mark.integration_mongodb
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config):
     policy = erasure_policy("A", "B")
     seed_email = mongo_inserts["customer"][0]["email"]
@@ -293,6 +295,7 @@ async def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config)
 
 @pytest.mark.integration_mongodb
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_dask_mongo_task(
     db, integration_mongodb_config: ConnectionConfig
 ) -> None:
@@ -329,6 +332,7 @@ async def test_dask_mongo_task(
 
 @pytest.mark.integration_mongodb
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_composite_key_erasure(
     db,
     integration_mongodb_config: ConnectionConfig,
@@ -425,6 +429,7 @@ async def test_composite_key_erasure(
 
 @pytest.mark.integration_mongodb
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_access_erasure_type_conversion(
     db,
     integration_mongodb_config: ConnectionConfig,
@@ -504,6 +509,7 @@ async def test_access_erasure_type_conversion(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_object_querying_mongo(
     db,
     privacy_request,
@@ -600,6 +606,7 @@ async def test_object_querying_mongo(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_cached_data_for_erasures(
     integration_postgres_config, integration_mongodb_config, policy, db
 ) -> None:
@@ -643,6 +650,7 @@ async def test_get_cached_data_for_erasures(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_return_all_elements_config_access_request(
     db,
     privacy_request,
@@ -695,6 +703,7 @@ async def test_return_all_elements_config_access_request(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_return_all_elements_config_erasure(
     db,
     mongo_inserts,
@@ -773,6 +782,7 @@ async def test_return_all_elements_config_erasure(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_array_querying_mongo(
     db,
     privacy_request,

--- a/tests/ops/integration_tests/test_sql_task.py
+++ b/tests/ops/integration_tests/test_sql_task.py
@@ -55,6 +55,7 @@ sample_postgres_configuration_policy = erasure_policy(
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_sql_erasure_ignores_collections_without_pk(
     db, postgres_inserts, integration_postgres_config
 ):
@@ -122,6 +123,7 @@ async def test_sql_erasure_ignores_collections_without_pk(
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_composite_key_erasure(
     db,
     integration_postgres_config: ConnectionConfig,
@@ -227,6 +229,7 @@ async def test_composite_key_erasure(
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_sql_erasure_task(db, postgres_inserts, integration_postgres_config):
     seed_email = postgres_inserts["customer"][0]["email"]
 
@@ -270,6 +273,7 @@ async def test_sql_erasure_task(db, postgres_inserts, integration_postgres_confi
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_postgres_access_request_task(
     db,
     policy,
@@ -359,6 +363,7 @@ async def test_postgres_access_request_task(
 
 @pytest.mark.integration_mssql
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_mssql_access_request_task(
     db,
     policy,
@@ -448,6 +453,7 @@ async def test_mssql_access_request_task(
 
 @pytest.mark.integration_mysql
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_mysql_access_request_task(
     db,
     policy,
@@ -537,6 +543,7 @@ async def test_mysql_access_request_task(
 
 @pytest.mark.integration_mariadb
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_mariadb_access_request_task(
     db,
     policy,
@@ -624,6 +631,7 @@ async def test_mariadb_access_request_task(
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_filter_on_data_categories(
     db,
     privacy_request,
@@ -764,6 +772,7 @@ async def test_filter_on_data_categories(
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_access_erasure_type_conversion(
     db,
     integration_postgres_config: ConnectionConfig,
@@ -962,6 +971,7 @@ class TestRetryIntegration:
     @mock.patch(
         "fidesops.ops.service.connectors.sql_connector.SQLConnector.retrieve_data"
     )
+    @pytest.mark.asyncio
     async def test_retry_access_request(
         self,
         mock_retrieve,
@@ -1014,6 +1024,7 @@ class TestRetryIntegration:
         ]
 
     @mock.patch("fidesops.ops.service.connectors.sql_connector.SQLConnector.mask_data")
+    @pytest.mark.asyncio
     async def test_retry_erasure(
         self,
         mock_mask: Mock,


### PR DESCRIPTION
# Purpose

The `pytest-asyncio` plugin has a bug where tests patched with `unittest` mocks aren't automatically recognized as async so pytest skips them. This fixes that issue.

# Changes
- Add the `@pytest.mark.asyncio` decorator to patched tests.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1240
 
