### PR TITLE
Fix download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 * Allow passwords to be sent either base64 encode or as plaintext. [#1236](https://github.com/ethyca/fidesops/pull/1236)
 * Allow worker to start up successfully for dev and dev_with_worker nox commands [#1250](https://github.com/ethyca/fidesops/pull/1250)
 * Fix for pytest-asyncio bug [#1260](https://github.com/ethyca/fidesops/pull/1260)
+* Fix download link in privacy center [#1264](https://github.com/ethyca/fidesops/pull/1264)
 
 ## [1.7.2](https://github.com/ethyca/fidesops/compare/1.7.1...1.7.2)
 

--- a/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -3,7 +3,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { addCommonHeaders } from "common/CommonHeaders";
 
 import type { RootState } from "../../app/store";
-import { BASE_API_URN, BASE_URL } from "../../constants";
+import { BASE_URL } from "../../constants";
 import { selectToken } from "../auth";
 import {
   DenyPrivacyRequest,
@@ -124,7 +124,7 @@ export const requestCSVDownload = async ({
   }
 
   return fetch(
-    `${BASE_API_URN}/privacy-request?${new URLSearchParams({
+    `${BASE_URL}/privacy-request?${new URLSearchParams({
       ...mapFiltersToSearchParams({
         id,
         from,


### PR DESCRIPTION
# Purpose

Fix the bad response for server message. `BASE_API_URN` contains `api/v1`, but not the base of the URL so the resulting URL was defaulting to the web server URL: `http://localhost:3000...` instead of `http://localhost:8080...`

# Changes
- Changed `BASE_API_URN` to `BASE_URL`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1263
 
