### PR TITLE
Update EmailRequestFulfillmentBodyParams Type for Easier Coercion

### DIFF
--- a/src/fidesops/ops/email_templates/templates/erasure_request_email_fulfillment.html
+++ b/src/fidesops/ops/email_templates/templates/erasure_request_email_fulfillment.html
@@ -7,8 +7,8 @@
    <body>
       <main>
          <p>Please locate and erase the associated records from the following collections:</p>
-         {% for collection_address, action_required in dataset_collection_action_required.items() -%}
-         <p><b>{{ collection_address.collection }}</b></p>
+         {% for action_required in dataset_collection_action_required -%}
+         <p><b>{{ action_required.collection.collection }}</b></p>
          {% for action in action_required.action_needed -%}
          <p>Locate the relevant records with:</p>
          <ul>

--- a/src/fidesops/ops/models/privacy_request.py
+++ b/src/fidesops/ops/models/privacy_request.py
@@ -409,20 +409,18 @@ class PrivacyRequest(Base):  # pylint: disable=R0904
 
     def get_email_connector_template_contents_by_dataset(
         self, step: CurrentStep, dataset: str
-    ) -> EmailRequestFulfillmentBodyParams:
+    ) -> List[CheckpointActionRequired]:
         """Retrieve the raw details to populate an email template for collections on a given dataset."""
         cache: FidesopsRedis = get_cache()
         email_contents: Dict[str, Optional[Any]] = cache.get_encoded_objects_by_prefix(
             f"EMAIL_INFORMATION__{self.id}__{step.value}__{dataset}"
         )
-        return {
-            CollectionAddress(
-                k.split("__")[-2], k.split("__")[-1]
-            ): CheckpointActionRequired.parse_obj(v)
-            if v
-            else None
-            for k, v in email_contents.items()
-        }
+
+        actions: List[CheckpointActionRequired] = []
+        for email_content in email_contents.values():
+            if email_content:
+                actions.append(CheckpointActionRequired.parse_obj(email_content))
+        return actions
 
     def cache_paused_collection_details(
         self,

--- a/src/fidesops/ops/schemas/email/email.py
+++ b/src/fidesops/ops/schemas/email/email.py
@@ -1,9 +1,9 @@
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Extra
 
-from fidesops.ops.models.privacy_request import EmailRequestFulfillmentBodyParams
+from fidesops.ops.models.privacy_request import CheckpointActionRequired
 from fidesops.ops.schemas import Msg
 from fidesops.ops.schemas.shared_schemas import FidesOpsKey
 
@@ -52,7 +52,7 @@ class FidesopsEmail(
     action_type: EmailActionType
     body_params: Union[
         SubjectIdentityVerificationBodyParams,
-        EmailRequestFulfillmentBodyParams,
+        List[CheckpointActionRequired],
     ]
 
 

--- a/src/fidesops/ops/service/email/email_dispatch_service.py
+++ b/src/fidesops/ops/service/email/email_dispatch_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from sqlalchemy.orm import Session
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from fidesops.ops.common_exceptions import EmailDispatchException
 from fidesops.ops.email_templates import get_email_template
 from fidesops.ops.models.email import EmailConfig
-from fidesops.ops.models.privacy_request import EmailRequestFulfillmentBodyParams
+from fidesops.ops.models.privacy_request import CheckpointActionRequired
 from fidesops.ops.schemas.email.email import (
     EmailActionType,
     EmailForActionType,
@@ -48,7 +48,7 @@ def dispatch_email(
     to_email: Optional[str],
     email_body_params: Union[
         SubjectIdentityVerificationBodyParams,
-        EmailRequestFulfillmentBodyParams,
+        List[CheckpointActionRequired],
     ],
 ) -> None:
     """

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -1198,10 +1198,8 @@ class TestPutConnectionConfigSecrets:
             kwargs["action_type"] == EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT
         )
         assert kwargs["to_email"] == "test@example.com"
-        assert kwargs["email_body_params"] == {
-            CollectionAddress(
-                "test_dataset", "test_collection"
-            ): CheckpointActionRequired(
+        assert kwargs["email_body_params"] == [
+            CheckpointActionRequired(
                 step=CurrentStep.erasure,
                 collection=CollectionAddress("test_dataset", "test_collection"),
                 action_needed=[
@@ -1212,4 +1210,4 @@ class TestPutConnectionConfigSecrets:
                     )
                 ],
             )
-        }
+        ]

--- a/tests/ops/models/test_privacy_request.py
+++ b/tests/ops/models/test_privacy_request.py
@@ -533,7 +533,7 @@ class TestCacheEmailConnectorTemplateContents:
             privacy_request.get_email_connector_template_contents_by_dataset(
                 CurrentStep.erasure, "email_dataset"
             )
-            == {}
+            == []
         )
 
         privacy_request.cache_email_connector_template_contents(
@@ -550,10 +550,8 @@ class TestCacheEmailConnectorTemplateContents:
 
         assert privacy_request.get_email_connector_template_contents_by_dataset(
             CurrentStep.erasure, "email_dataset"
-        ) == {
-            CollectionAddress(
-                "email_dataset", "test_collection"
-            ): CheckpointActionRequired(
+        ) == [
+            CheckpointActionRequired(
                 step=CurrentStep.erasure,
                 collection=CollectionAddress("email_dataset", "test_collection"),
                 action_needed=[
@@ -564,7 +562,7 @@ class TestCacheEmailConnectorTemplateContents:
                     )
                 ],
             )
-        }
+        ]
 
 
 class TestCanRunFromCheckpoint:

--- a/tests/ops/service/connectors/test_email_connector.py
+++ b/tests/ops/service/connectors/test_email_connector.py
@@ -9,7 +9,6 @@ from fidesops.ops.graph.config import (
 )
 from fidesops.ops.graph.graph import Edge, Node
 from fidesops.ops.graph.traversal import TraversalNode, artificial_traversal_node
-from fidesops.ops.models.policy import ActionType, Policy, Rule, RuleTarget
 from fidesops.ops.models.privacy_request import ManualAction
 from fidesops.ops.service.connectors import EmailConnector
 

--- a/tests/ops/service/email/email_dispatch_service_test.py
+++ b/tests/ops/service/email/email_dispatch_service_test.py
@@ -4,16 +4,19 @@ from unittest.mock import Mock
 import pytest
 import requests.exceptions
 import requests_mock
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from fidesops.ops.common_exceptions import EmailDispatchException
+from fidesops.ops.graph.config import CollectionAddress
 from fidesops.ops.models.email import EmailConfig
+from fidesops.ops.models.policy import CurrentStep
+from fidesops.ops.models.privacy_request import CheckpointActionRequired, ManualAction
 from fidesops.ops.schemas.email.email import (
     EmailActionType,
     EmailForActionType,
     EmailServiceDetails,
     EmailServiceType,
+    FidesopsEmail,
     SubjectIdentityVerificationBodyParams,
 )
 from fidesops.ops.service.email.email_dispatch_service import dispatch_email
@@ -121,3 +124,36 @@ def test_email_dispatch_mailgun_failed_email(db: Session, email_config) -> None:
             exc.value.args[0]
             == "Email failed to send due to: Email failed to send with status code 403"
         )
+
+
+def test_fidesops_email_parse_object():
+    body = [
+        CheckpointActionRequired(
+            step=CurrentStep.erasure,
+            collection=CollectionAddress("email_dataset", "test_collection"),
+            action_needed=[
+                ManualAction(
+                    locators={"email": "test@example.com"},
+                    get=None,
+                    update={"phone": "null_rewrite"},
+                )
+            ],
+        )
+    ]
+
+    FidesopsEmail.parse_obj(
+        {
+            "action_type": EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT,
+            "body_params": [action.dict() for action in body],
+        }
+    )
+
+    FidesopsEmail.parse_obj(
+        {
+            "action_type": EmailActionType.SUBJECT_IDENTITY_VERIFICATION,
+            "body_params": {
+                "verification_code": "123456",
+                "verification_code_ttl_seconds": 1000,
+            },
+        }
+    )

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -16,7 +16,6 @@ from fidesops.ops.common_exceptions import (
     PrivacyRequestPaused,
 )
 from fidesops.ops.core.config import config
-from fidesops.ops.graph.config import CollectionAddress
 from fidesops.ops.models.connectionconfig import AccessLevel
 from fidesops.ops.models.email import EmailConfig
 from fidesops.ops.models.policy import CurrentStep, PolicyPostWebhook
@@ -1647,11 +1646,11 @@ class TestPrivacyRequestsEmailConnector:
         cached_email_contents = pr.get_email_connector_template_contents_by_dataset(
             CurrentStep.erasure, "email_dataset"
         )
-        assert set(cached_email_contents.keys()) == {
-            CollectionAddress("email_dataset", "payment"),
-            CollectionAddress("email_dataset", "children"),
-            CollectionAddress("email_dataset", "daycare_customer"),
-        }
+        assert len(cached_email_contents) == 3
+        assert {
+            contents.collection.collection for contents in cached_email_contents
+        } == {"payment", "children", "daycare_customer"}
+
         pr.delete(db=db)
         assert mailgun_send.called is False
 
@@ -1699,7 +1698,7 @@ class TestPrivacyRequestsEmailConnector:
             CurrentStep.erasure, "email_dataset"
         )
         assert (
-            set(cached_email_contents.keys()) == set()
+            len(cached_email_contents) == 0
         ), "No data cached to erase, because this connector is read-only"
 
         pr.delete(db=db)
@@ -1747,30 +1746,12 @@ class TestPrivacyRequestsEmailConnector:
         cached_email_contents = pr.get_email_connector_template_contents_by_dataset(
             CurrentStep.erasure, "email_dataset"
         )
-        assert set(cached_email_contents.keys()) == {
-            CollectionAddress("email_dataset", "payment"),
-            CollectionAddress("email_dataset", "children"),
-            CollectionAddress("email_dataset", "daycare_customer"),
-        }
-        assert (
-            cached_email_contents[CollectionAddress("email_dataset", "payment")]
-            .action_needed[0]
-            .update
-            is None
-        )
-        assert (
-            cached_email_contents[CollectionAddress("email_dataset", "children")]
-            .action_needed[0]
-            .update
-            is None
-        )
-        assert (
-            cached_email_contents[
-                CollectionAddress("email_dataset", "daycare_customer")
-            ]
-            .action_needed[0]
-            .update
-            is None
+        assert {
+            contents.collection.collection for contents in cached_email_contents
+        } == {"payment", "children", "daycare_customer"}
+
+        assert not any(
+            [contents.action_needed[0].update for contents in cached_email_contents]
         )
 
         pr.delete(db=db)


### PR DESCRIPTION
# Purpose

Make EmailRequestFulfillmentBodyParams a Pydantic schema instead of just a python type


# Changes

Instead of passing around EmailRequestFulfillmentBodyParams which is currently type: `Dict[CollectionAddress, Optional[CheckpointActionRequired]]`, update the type to a list of CheckpointActionRequired. 

so: 

`List[CheckpointActionRequired]`

