### PR TITLE
Remove Masking of Redis Connection Error [#1271]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The types of changes are:
 * Fix download link in privacy center [#1264](https://github.com/ethyca/fidesops/pull/1264)
 * Make admin ui work when volumes are mounted [#1266](https://github.com/ethyca/fidesops/pull/1266)
 * Fixed typo in enum value [#1280](https://github.com/ethyca/fidesops/pull/1280)
+* Remove masking of redis error log [#1288](https://github.com/ethyca/fidesops/pull/1288)
 
 ### Security
 

--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -252,7 +252,7 @@ def start_webserver() -> None:
         try:
             get_cache()
         except (RedisConnectionError, ResponseError) as e:
-            logger.error("Connection to cache failed: %s", Pii(str(e)))
+            logger.error("Connection to cache failed: %s", e)
             return
 
     scheduler.start()


### PR DESCRIPTION
# Purpose

Addressing an internal report that we are masking an important log. This makes it difficult to troubleshoot. 
<img width="467" alt="image" src="https://user-images.githubusercontent.com/9755598/189384361-c96fe05b-0e8b-417b-9998-96ffd6ba9813.png">

# Changes
- Remove Pii label from this log in particular.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1271 
 
