### PR TITLE
[#1299] Update healthcheck URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,13 @@ services:
     expose:
       - 8080
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://0.0.0.0:8080/health" ]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://0.0.0.0:8080/api/v1/health"
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/fidesops/docs/deployment.md
+++ b/docs/fidesops/docs/deployment.md
@@ -145,7 +145,7 @@ Note that there's no need for a persistent volume mount for the web server, it's
 
 ### Test the Web Server
 
-To test that your server is running, visit `http://{server_url}/health` in your browser (e.g. http://0.0.0.0:8080/health) and you should see `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}`.
+To test that your server is running, visit `http://{server_url}/api/v1/health` in your browser (e.g. http://0.0.0.0:8080/api/v1/health) and you should see `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}`.
 
 You now have a functional `fidesops` server running! Now you can use the API to set up your OAuth clients, connect to databases, configure policies, execute privacy requests, etc. To learn more, head to the [How-To Guides](guides/oauth.md) for details.
 

--- a/docs/fidesops/docs/getting_started.md
+++ b/docs/fidesops/docs/getting_started.md
@@ -16,7 +16,7 @@ Ensure nothing is running on ports `8080`, `5432`, or `6379` prior to these step
    
 2. Run `docker compose up` from the root of the fidesops project directory. The provided `docker-compose.yml` will create the necessary databases and spin up the server.
    
-3. Visit `http://0.0.0.0:8080/health` in your browser. A response of `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}` indicates a successful deployment.
+3. Visit `http://0.0.0.0:8080/api/v1/health` in your browser. A response of `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}` indicates a successful deployment.
    
 ## Build from your project
 
@@ -38,7 +38,7 @@ Ensure nothing is running on ports `8080`, `5432`, or `6379` prior to these step
         expose:
           - 8080
         healthcheck:
-          test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/health"]
+          test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/api/v1/health"]
           interval: 30s
           timeout: 10s
           retries: 3
@@ -86,4 +86,4 @@ Ensure nothing is running on ports `8080`, `5432`, or `6379` prior to these step
    
 2. Ensure Docker is running, and run `docker compose up` from the project's root directory. This will pull the latest fidesops Docker image, create the sample databases, and start the server.
 
-3. Visit `http://0.0.0.0:8080/health` in your browser. A response of `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}` indicates a successful deployment.
+3. Visit `http://0.0.0.0:8080/api/v1/health` in your browser. A response of `{"webserver": "healthy", "database": "healthy", "cache": "healthy"}` indicates a successful deployment.

--- a/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/health_endpoints.py
@@ -7,7 +7,7 @@ from redis.exceptions import ResponseError
 from sqlalchemy.orm import Session
 
 from fidesops.ops.api import deps
-from fidesops.ops.api.v1.urn_registry import HEALTH
+from fidesops.ops.api.v1 import urn_registry as urls
 from fidesops.ops.common_exceptions import RedisConnectionError
 from fidesops.ops.core.config import config
 from fidesops.ops.db.database import get_alembic_config
@@ -15,7 +15,7 @@ from fidesops.ops.util.api_router import APIRouter
 from fidesops.ops.util.cache import get_cache
 from fidesops.ops.util.logger import Pii
 
-router = APIRouter(tags=["Public"])
+router = APIRouter(tags=["Public"], prefix=urls.V1_URL_PREFIX)
 
 logger = logging.getLogger(__name__)
 # stops polluting logs with sqlalchemy / alembic info-level logs
@@ -23,7 +23,7 @@ logging.getLogger("sqlalchemy.engine").setLevel(logging.ERROR)
 logging.getLogger("alembic").setLevel(logging.WARNING)
 
 
-@router.get(HEALTH, response_model=Dict[str, Union[bool, str]])
+@router.get(urls.HEALTH, response_model=Dict[str, Union[bool, str]])
 def health_check(
     db: Session = Depends(deps.get_db_for_health_check),
 ) -> Dict[str, Union[bool, str]]:


### PR DESCRIPTION
# Purpose

This PR moves the healthcheck endpoint from `/health` to `/api/v1/health` to be consistent with Fidesctl.

# Ticket
Fixes #1299 