### PR TITLE
Change references to FIDESOPS__CONFIG_PATH to FIDES__CONFIG_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The types of changes are:
 * Fix analytics opt out environment variable name [#1170](https://github.com/ethyca/fidesops/pull/1170)
 * Added how to view a subject request history and reprocess a subject request [#1164](https://github.com/ethyca/fidesops/pull/1164)
 * Adds section on email communications, and exposes previously hidden guides in nav bar [#1233](https://github.com/ethyca/fidesops/pull/1233)
+* Change references to `FIDESOPS__CONFIG_PATH` to `FIDES__CONFIG_PATH` [#1302](https://github.com/ethyca/fidesops/pull/1302)
 
 ### Fixed
 

--- a/docs/fidesops/docs/development/jetbrains_debugging.md
+++ b/docs/fidesops/docs/development/jetbrains_debugging.md
@@ -48,7 +48,7 @@ Go to: **Run/Debug Configurations** -> **+** -> **Python**
 
 - To debug fidesops, debug the `<path on your machine>/src/fidesops/main.py` script
 - Make sure to select **Use specified interpreter** set the Remote Python Docker Compose *(created in the previous section)*
-- Add `FIDESOPS__CONFIG_PATH=/fidesops` to **Environment variables**
+- Add `FIDES__CONFIG_PATH=/fidesops` to **Environment variables**
 
 See screenshot below:
 

--- a/docs/fidesops/docs/guides/configuration_reference.md
+++ b/docs/fidesops/docs/guides/configuration_reference.md
@@ -5,7 +5,7 @@
 
 The fidesops application configuration variables are provided in the `fidesops.toml` file in `.toml` format. Fidesops will take the first config file it finds from the following locations:
 
-- The location according to the `FIDESOPS__CONFIG_PATH` environment variable
+- The location according to the `FIDES__CONFIG_PATH` environment variable
 - The current working directory (`./fidesops.toml`)
 - The parent of the current working directory (`../fidesops.toml`)
 - The user's home directory (`~/fidesops.toml`)
@@ -129,7 +129,7 @@ Note: The configuration is case-sensitive, so the variables must be specified in
 | `FIDESOPS__LOG_PII` | False | If this is set to "True", pii values will display unmasked in log output. This variable should always be set to "False" in production systems.
 | `FIDESOPS__HOT_RELOAD` | False | If "True", the fidesops server will reload code changes without you needing to restart the server. This variable should always be set to "False" in production systems.|
 | `FIDESOPS__DEV_MODE` | False | If "True", the fidesops server will log error tracebacks, and log details of third party requests. This variable should always be set to "False" in production systems.|
-| `FIDESOPS__CONFIG_PATH` | None | If this variable is set to a path, that path will be used to load .toml files first. That is, any .toml files on this path will override any installed .toml files. |
+| `FIDES__CONFIG_PATH` | None | If this variable is set to a path, that path will be used to load .toml files first. That is, any .toml files on this path will override any installed .toml files. |
 | `FIDESOPS__DATABASE__SQLALCHEMY_DATABASE_URI` | None | An optional override for the URI used for the database connection, in the form of `postgresql://<user>:<password>@<hostname>:<port>/<database>`. |
 | `TESTING` | False | This variable does not need to be set - Pytest will set it to True when running unit tests, so we run against the test database. |
 

--- a/tests/ops/core/test_config.py
+++ b/tests/ops/core/test_config.py
@@ -26,7 +26,7 @@ def test_config_from_default() -> None:
     clear=True,
 )
 def test_config_from_path() -> None:
-    """Test reading config using the FIDESOPS__CONFIG_PATH option."""
+    """Test reading config using the FIDES__CONFIG_PATH option."""
     config = get_config(FidesopsConfig)
     assert config.database.server == "testserver"
     assert config.redis.host == "testredis"


### PR DESCRIPTION
# Purpose

Change the references to `FIDESOPS__CONFIG_PATH` to the new name of `FIDES__CONFIG_PATH`.

# Changes
- Change references to `FIDESOPS__CONFIG_PATH` to `FIDES_CONFIG_PATH` in docs.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
