### PR TITLE
Fix default celery queue

### DIFF
--- a/src/fidesops/ops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_runner_service.py
@@ -161,16 +161,22 @@ def upload_access_results(
             privacy_request.status = PrivacyRequestStatus.error
 
 
+default_queue_name = celery_app.conf.get("default_queue_name", "celery")
+
+
 def queue_privacy_request(
     privacy_request_id: str,
     from_webhook_id: Optional[str] = None,
     from_step: Optional[str] = None,
 ) -> str:
     cache: FidesopsRedis = get_cache()
-    task = run_privacy_request.delay(
-        privacy_request_id=privacy_request_id,
-        from_webhook_id=from_webhook_id,
-        from_step=from_step,
+    task = run_privacy_request.apply_async(
+        queue=default_queue_name,
+        kwargs={
+            "privacy_request_id": privacy_request_id,
+            "from_webhook_id": from_webhook_id,
+            "from_step": from_step,
+        },
     )
     try:
         cache.set(

--- a/src/fidesops/ops/tasks/__init__.py
+++ b/src/fidesops/ops/tasks/__init__.py
@@ -72,7 +72,7 @@ def start_worker() -> None:
             "worker",
             "--loglevel=info",
             "--concurrency=2",
-            f"-Q {default_queue_name},{EMAIL_QUEUE_NAME}",
+            f"-Q{default_queue_name},{EMAIL_QUEUE_NAME}",
         ]
     )
 


### PR DESCRIPTION
# Purpose

Privacy requests are no longer running in the default queue.

# Changes
- Remove the leading space in the default fidesops queue name 
- Use `apply_async` to specify the default queue for running privacy requests

# Before
```bash
worker_1            | -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
worker_1            | --- ***** ----- 
worker_1            |  -------------- [queues]
worker_1            |                 .>  fidesops        exchange= fidesops(direct) key= fidesops
worker_1            |                 .> fidesops.email   exchange=fidesops.email(direct) key=fidesops.email
```

# After 
```bash
ebserver_1         | - ** ---------- .> app:         fidesops.ops.tasks:0xffffb1c4b640
webserver_1         | - ** ---------- .> transport:   redis://:**@redis:6379/0
webserver_1         | - ** ---------- .> results:     redis://:**@redis:6379/0
webserver_1         | - *** --- * --- .> concurrency: 2 (prefork)
webserver_1         | -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
webserver_1         | --- ***** ----- 
webserver_1         |  -------------- [queues]
webserver_1         |                 .> fidesops         exchange=fidesops(direct) key=fidesops
webserver_1         |                 .> fidesops.email   exchange=fidesops.email(direct) key=fidesops.email

```
# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
