### PR TITLE
Allow the user to logout with a malformed or expired token [#1257]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The types of changes are:
 * Make admin ui work when volumes are mounted [#1266](https://github.com/ethyca/fidesops/pull/1266)
 * Fixed typo in enum value [#1280](https://github.com/ethyca/fidesops/pull/1280)
 * Remove masking of redis error log [#1288](https://github.com/ethyca/fidesops/pull/1288)
+* Logout with malformed or expired token [#1305](https://github.com/ethyca/fidesops/pull/1305)
 
 ### Security
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fastapi[all]==0.82.0
 fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.9.3
 fideslang==1.2.0
-fideslib==3.1.1
+fideslib==3.1.2
 fideslog==1.2.3
 hvac==0.11.2
 Jinja2==3.1.2

--- a/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
@@ -132,7 +132,9 @@ def logout_oauth_client(
         return None
 
     client_id = token_data.get(JWE_PAYLOAD_CLIENT_ID)
-    if not client_id:
+    if (
+        not client_id or client_id == config.security.oauth_root_client_id
+    ):  # The root client is not a persisted object
         return None
 
     client = ClientDetail.get(

--- a/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
@@ -5,9 +5,7 @@ from typing import Optional
 import jose.exceptions
 from fastapi import Depends, HTTPException, Security
 from fideslib.cryptography.cryptographic_util import b64_str_to_str
-from fideslib.cryptography.schemas.jwt import (
-    JWE_PAYLOAD_CLIENT_ID,
-)
+from fideslib.cryptography.schemas.jwt import JWE_PAYLOAD_CLIENT_ID
 from fideslib.exceptions import AuthenticationError
 from fideslib.models.client import ClientDetail
 from fideslib.models.fides_user import FidesUser

--- a/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/user_endpoints.py
@@ -1,9 +1,17 @@
+import json
 import logging
+from typing import Optional
 
+import jose.exceptions
 from fastapi import Depends, HTTPException, Security
 from fideslib.cryptography.cryptographic_util import b64_str_to_str
+from fideslib.cryptography.schemas.jwt import (
+    JWE_PAYLOAD_CLIENT_ID,
+)
+from fideslib.exceptions import AuthenticationError
 from fideslib.models.client import ClientDetail
 from fideslib.models.fides_user import FidesUser
+from fideslib.oauth.oauth_util import extract_payload
 from fideslib.oauth.schemas.user import UserPasswordReset, UserResponse, UserUpdate
 from sqlalchemy.orm import Session
 from starlette.status import (
@@ -14,12 +22,21 @@ from starlette.status import (
 )
 
 from fidesops.ops.api import deps
+from fidesops.ops.api.deps import get_db
 from fidesops.ops.api.v1 import urn_registry as urls
-from fidesops.ops.api.v1.scope_registry import USER_PASSWORD_RESET, USER_UPDATE
+from fidesops.ops.api.v1.scope_registry import (
+    SCOPE_REGISTRY,
+    USER_PASSWORD_RESET,
+    USER_UPDATE,
+)
 from fidesops.ops.api.v1.urn_registry import V1_URL_PREFIX
 from fidesops.ops.core.config import config
 from fidesops.ops.util.api_router import APIRouter
-from fidesops.ops.util.oauth_util import get_current_user, verify_oauth_client
+from fidesops.ops.util.oauth_util import (
+    get_current_user,
+    oauth2_scheme,
+    verify_oauth_client,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Users"], prefix=V1_URL_PREFIX)
@@ -98,19 +115,48 @@ def update_user_password(
     return current_user
 
 
+def logout_oauth_client(
+    authorization: str = Security(oauth2_scheme), db: Session = Depends(get_db)
+) -> Optional[ClientDetail]:
+    """
+    Streamlined oauth checks for logout.  Only raises an error if no authorization is supplied.
+    Otherwise, regardless if the token is malformed or expired, still return a 204.
+    Returns a client if we can extract one from the token.
+    """
+    if authorization is None:
+        raise AuthenticationError(detail="Authentication Failure")
+
+    try:
+        token_data = json.loads(
+            extract_payload(authorization, config.security.app_encryption_key)
+        )
+    except jose.exceptions.JWEParseError:
+        return None
+
+    client_id = token_data.get(JWE_PAYLOAD_CLIENT_ID)
+    if not client_id:
+        return None
+
+    client = ClientDetail.get(
+        db, object_id=client_id, config=config, scopes=SCOPE_REGISTRY
+    )
+
+    return client
+
+
 @router.post(
     urls.LOGOUT,
     status_code=HTTP_204_NO_CONTENT,
 )
 def user_logout(
     *,
-    client: ClientDetail = Security(
-        verify_oauth_client,
-        scopes=[],
+    client: Optional[ClientDetail] = Security(
+        logout_oauth_client,
     ),
     db: Session = Depends(deps.get_db),
 ) -> None:
-    """Logout the user by deleting its client"""
+    """Logout the user by deleting its client where applicable"""
 
     logger.info("Logging out user.")
-    client.delete(db)
+    if client:
+        client.delete(db)

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -810,7 +810,7 @@ class TestUserLogout:
         # Assert user does not still have client reference
         assert user_search.client is None
 
-        # Outdated client token still gives a 401
+        # Outdated client token logout gives a 204
         payload = {
             JWE_PAYLOAD_SCOPES: scopes,
             JWE_PAYLOAD_CLIENT_ID: client_id,

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List
 
 import pytest
@@ -749,6 +749,32 @@ class TestUserLogout:
     def url(self, oauth_client: ClientDetail) -> str:
         return V1_URL_PREFIX + LOGOUT
 
+    def test_malformed_token_ignored(self, db, url, api_client, user):
+        auth_header = {"Authorization": "Bearer invalid"}
+        response = api_client.post(url, headers=auth_header, json={})
+        assert response.status_code == HTTP_204_NO_CONTENT
+
+    def test_user_can_logout_with_expired_token(self, db, url, api_client, user):
+        client_id = user.client.id
+        scopes = user.client.scopes
+
+        payload = {
+            JWE_PAYLOAD_SCOPES: scopes,
+            JWE_PAYLOAD_CLIENT_ID: client_id,
+            JWE_ISSUED_AT: (datetime.now() - timedelta(days=360)).isoformat(),
+        }
+
+        auth_header = {
+            "Authorization": "Bearer "
+            + generate_jwe(json.dumps(payload), config.security.app_encryption_key)
+        }
+        response = api_client.post(url, headers=auth_header, json={})
+        assert response.status_code == HTTP_204_NO_CONTENT
+
+        # Verify client was deleted
+        client_search = ClientDetail.get_by(db, field="id", value=client_id)
+        assert client_search is None
+
     def test_user_not_deleted_on_logout(self, db, url, api_client, user):
         user_id = user.id
         client_id = user.client.id
@@ -784,8 +810,7 @@ class TestUserLogout:
         # Assert user does not still have client reference
         assert user_search.client is None
 
-        # Ensure that the client token is invalidated after logout
-        # Assert a request with the outdated client token gives a 401
+        # Outdated client token still gives a 401
         payload = {
             JWE_PAYLOAD_SCOPES: scopes,
             JWE_PAYLOAD_CLIENT_ID: client_id,
@@ -796,7 +821,7 @@ class TestUserLogout:
             + generate_jwe(json.dumps(payload), config.security.app_encryption_key)
         }
         response = api_client.post(url, headers=auth_header, json={})
-        assert HTTP_403_FORBIDDEN == response.status_code
+        assert HTTP_204_NO_CONTENT == response.status_code
 
     def test_logout(self, db, url, api_client, generate_auth_header, oauth_client):
         oauth_client_id = oauth_client.id
@@ -808,6 +833,6 @@ class TestUserLogout:
         client_search = ClientDetail.get_by(db, field="id", value=oauth_client_id)
         assert client_search is None
 
-        # Gets AuthorizationError - client does not exist, this token can't be used anymore
+        # Even though client doesn't exist, we still return a 204
         response = api_client.post(url, headers=auth_header, json={})
-        assert response.status_code == HTTP_403_FORBIDDEN
+        assert response.status_code == HTTP_204_NO_CONTENT


### PR DESCRIPTION
# Purpose

Whenever the user logs out from the Admin UI, the local auth token should be deleted no matter what happens on the server (403, 500, etc.). This would prevent you from getting into an unrecoverable state where you cannot clear your token

# Changes
- Bump fideslib version to raise a 403 on other endpoints besides logout if a token is malformed https://github.com/ethyca/fideslib/pull/71 
- Fix issues with logout due to bad/expired tokens
  - Unless a token is not supplied from the logout endpoint, or the client delete fails (currently a 500), return a 204 on logout. 
  - Create new security callable to use for logout: `logout_oauth_client` instead of using the `verify_oauth_client` from fideslib: 
     - If there's no token, throw a 401
     - If token malformed, ignore, and return a 204
     - Skip checking token expiration for logout, this shouldn't effect if we can get rid of this token
     - If there's no client on the token, ignore, and return a 204
     - If the client on the token doesn't exist in the db, ignore and return a 204
     - If the client exists in the db, delete, and return a 204.
   - I don't distingush between error codes on logout - 204 or 200 depending on whether client was deleted or not, just straight 204's across the board, unless no token is supplied.
  - I believe this successful 204 response lets the token get deleted from local storage too

# Testing

See testing instructions in #1257 

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket
Fixes #1257 
 
