### PR TITLE
Manual Webhook Followup: UI scopes / Delete [#1228]

### DIFF
--- a/clients/ops/admin-ui/src/constants.ts
+++ b/clients/ops/admin-ui/src/constants.ts
@@ -65,6 +65,14 @@ export const USER_PRIVILEGES: UserPrivileges[] = [
     privilege: "View roles",
     scope: "user-permission:read",
   },
+  {
+    privilege: "Upload privacy request data",
+    scope: "privacy-request:upload_data",
+  },
+  {
+    privilege: "View privacy request data",
+    scope: "privacy-request:view_data",
+  },
 ];
 
 // API ROUTES

--- a/src/fidesops/ops/models/connectionconfig.py
+++ b/src/fidesops/ops/models/connectionconfig.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime
-from typing import Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from fideslib.db.base import Base
 from fideslib.db.base_class import get_key_from_data
@@ -19,6 +19,9 @@ from sqlalchemy_utils.types.encrypted.encrypted_type import (
 from fidesops.ops.core.config import config
 from fidesops.ops.db.base_class import JSONTypeOverride
 from fidesops.ops.schemas.saas.saas_config import SaaSConfig
+
+if TYPE_CHECKING:
+    from fidesops.ops.models.manual_webhook import AccessManualWebhook
 
 
 class ConnectionTestStatus(enum.Enum):

--- a/src/fidesops/ops/models/connectionconfig.py
+++ b/src/fidesops/ops/models/connectionconfig.py
@@ -10,7 +10,7 @@ from fideslib.exceptions import KeyOrNameAlreadyExists
 from sqlalchemy import Boolean, Column, DateTime, Enum, String, event
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, relationship
 from sqlalchemy_utils.types.encrypted.encrypted_type import (
     AesGcmEngine,
     StringEncryptedType,
@@ -117,6 +117,13 @@ class ConnectionConfig(Base):
     # only applicable to ConnectionConfigs of connection type saas
     saas_config = Column(
         MutableDict.as_mutable(JSONB), index=False, unique=False, nullable=True
+    )
+
+    access_manual_webhook = relationship(
+        "AccessManualWebhook",
+        back_populates="connection_config",
+        cascade="delete",
+        uselist=False,
     )
 
     @classmethod

--- a/src/fidesops/ops/models/manual_webhook.py
+++ b/src/fidesops/ops/models/manual_webhook.py
@@ -6,7 +6,7 @@ from pydantic import create_model
 from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableList
-from sqlalchemy.orm import Session, backref, relationship
+from sqlalchemy.orm import Session, relationship
 
 from fidesops.ops.models.connectionconfig import ConnectionConfig
 
@@ -20,10 +20,13 @@ class AccessManualWebhook(Base):
     """
 
     connection_config_id = Column(
-        String, ForeignKey(ConnectionConfig.id_field_path), unique=True, nullable=False
+        String,
+        ForeignKey(ConnectionConfig.id_field_path),
+        unique=True,
+        nullable=False,
     )
     connection_config = relationship(
-        ConnectionConfig, backref=backref("access_manual_webhook", uselist=False)
+        "ConnectionConfig", back_populates="access_manual_webhook", uselist=False
     )
 
     fields = Column(MutableList.as_mutable(JSONB), nullable=False)

--- a/tests/ops/fixtures/manual_webhook_fixtures.py
+++ b/tests/ops/fixtures/manual_webhook_fixtures.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from fidesops.ops.models.connectionconfig import (
     AccessLevel,
@@ -22,7 +23,10 @@ def integration_manual_webhook_config(db) -> ConnectionConfig:
         },
     )
     yield connection_config
-    connection_config.delete(db)
+    try:
+        connection_config.delete(db)
+    except ObjectDeletedError:
+        pass
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/models/test_connectionconfig.py
+++ b/tests/ops/models/test_connectionconfig.py
@@ -154,3 +154,14 @@ class TestConnectionConfigModel:
     def test_connection_type_human_readable_invalid(self):
         with pytest.raises(ValueError):
             ConnectionType("nonmapped_type").human_readable()
+
+    def test_manual_webhook(
+        self, integration_manual_webhook_config, access_manual_webhook
+    ):
+        assert (
+            integration_manual_webhook_config.access_manual_webhook
+            == access_manual_webhook
+        )
+        assert (
+            access_manual_webhook.connection_config == integration_manual_webhook_config
+        )


### PR DESCRIPTION
# Purpose

It's a multi-step process to add new scopes to existing users unless we expose them in the UI.  Additionally, if you delete a manual webhook connection config, you'll get an IntegrityError because it has an attached manual webhook

# Changes
- Add the new scopes related to uploading or viewing data on a privacy request to the UI.
- Cascade delete any manual webhooks if a connection config is deleted.


# Checklist
- [ ] ~Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file~ Considering this a quick follow-up to already-merged #1285 
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1228 
 
