### PR TITLE
Rename PrivacyRequestIdentity schema to Identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ The types of changes are:
 * Added human readable label to ConnectionType endpoint [#1297](https://github.com/ethyca/fidesops/pull/1297)
 * Add table for consent (#1301)[https://github.com/ethyca/fidesops/pull/1301]
 
+### Changed
+
+* Renamed `PrivacyRequestIdentity` to `Identity` [#1324](https://github.com/ethyca/fidesops/pull/1324)
+
 ### Docs
 
 * Fix analytics opt out environment variable name [#1170](https://github.com/ethyca/fidesops/pull/1170)

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -42,7 +42,6 @@ worker_enabled = false
 
 [root_user]
 analytics_opt_out = false
-analytics_id = "fcfe45e39db50f0aad5d178dcee39759"
 
 [admin_ui]
 enabled = true

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -42,6 +42,7 @@ worker_enabled = false
 
 [root_user]
 analytics_opt_out = false
+analytics_id = "fcfe45e39db50f0aad5d178dcee39759"
 
 [admin_ui]
 enabled = true

--- a/scripts/create_test_data.py
+++ b/scripts/create_test_data.py
@@ -25,7 +25,7 @@ from fidesops.ops.models.privacy_request import (
     PrivacyRequestStatus,
 )
 from fidesops.ops.models.storage import ResponseFormat, StorageConfig
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.schemas.storage.storage import FileNaming, StorageDetails, StorageType
 from fidesops.ops.util.data_category import DataCategory
 
@@ -195,7 +195,7 @@ def create_test_data(db: orm.Session) -> FidesUser:
             )
             pr.persist_identity(
                 db=db,
-                identity=PrivacyRequestIdentity(
+                identity=Identity(
                     email="test@example.com",
                     phone_number="+1 234 567 8910",
                 ),

--- a/src/fidesops/ops/api/v1/endpoints/drp_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/drp_endpoints.py
@@ -31,7 +31,7 @@ from fidesops.ops.schemas.drp_privacy_request import (
     DrpRevokeRequest,
 )
 from fidesops.ops.schemas.privacy_request import PrivacyRequestDRPStatusResponse
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.drp.drp_fidesops_mapper import DrpFidesopsMapper
 from fidesops.ops.service.privacy_request.request_runner_service import (
     queue_privacy_request,
@@ -95,7 +95,7 @@ async def create_drp_privacy_request(
             **jwt.decode(data.identity, jwt_key, algorithms=["HS256"])
         )
 
-        mapped_identity: PrivacyRequestIdentity = DrpFidesopsMapper.map_identity(
+        mapped_identity: Identity = DrpFidesopsMapper.map_identity(
             drp_identity=decrypted_identity
         )
 

--- a/src/fidesops/ops/models/privacy_request.py
+++ b/src/fidesops/ops/models/privacy_request.py
@@ -54,7 +54,7 @@ from fidesops.ops.schemas.external_https import (
     WebhookJWE,
 )
 from fidesops.ops.schemas.masking.masking_secrets import MaskingSecretCache
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.tasks import celery_app
 from fidesops.ops.util.cache import (
     FidesopsRedis,
@@ -260,7 +260,7 @@ class PrivacyRequest(Base):  # pylint: disable=R0904
             provided_identity.delete(db=db)
         super().delete(db=db)
 
-    def cache_identity(self, identity: PrivacyRequestIdentity) -> None:
+    def cache_identity(self, identity: Identity) -> None:
         """Sets the identity's values at their specific locations in the Fidesops app cache"""
         cache: FidesopsRedis = get_cache()
         identity_dict: Dict[str, Any] = dict(identity)
@@ -271,7 +271,7 @@ class PrivacyRequest(Base):  # pylint: disable=R0904
                     value,
                 )
 
-    def persist_identity(self, db: Session, identity: PrivacyRequestIdentity) -> None:
+    def persist_identity(self, db: Session, identity: Identity) -> None:
         """
         Stores the identity provided with the privacy request in a secure way, compatible with
         blind indexing for later searching and audit purposes.
@@ -292,11 +292,11 @@ class PrivacyRequest(Base):  # pylint: disable=R0904
                     },
                 )
 
-    def get_persisted_identity(self) -> PrivacyRequestIdentity:
+    def get_persisted_identity(self) -> Identity:
         """
         Retrieves persisted identity fields from the DB.
         """
-        schema = PrivacyRequestIdentity()
+        schema = Identity()
         for field in self.provided_identities:
             setattr(
                 schema,

--- a/src/fidesops/ops/schemas/external_https.py
+++ b/src/fidesops/ops/schemas/external_https.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from fidesops.ops.models.policy import WebhookDirection
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 
 
 class CallbackType(Enum):
@@ -20,7 +20,7 @@ class SecondPartyRequestFormat(BaseModel):
     privacy_request_id: str
     direction: WebhookDirection
     callback_type: CallbackType
-    identity: PrivacyRequestIdentity
+    identity: Identity
 
     class Config:
         """Using enum values"""
@@ -34,7 +34,7 @@ class SecondPartyResponseFormat(BaseModel):
     Responses are only expected (and considered) for two_way webhooks.
     """
 
-    derived_identity: Optional[PrivacyRequestIdentity] = None
+    derived_identity: Optional[Identity] = None
     halt: bool
 
     class Config:
@@ -46,7 +46,7 @@ class SecondPartyResponseFormat(BaseModel):
 class PrivacyRequestResumeFormat(BaseModel):
     """Expected request body to resume a privacy request after it was paused by a webhook"""
 
-    derived_identity: Optional[PrivacyRequestIdentity] = {}  # type: ignore
+    derived_identity: Optional[Identity] = {}  # type: ignore
 
     class Config:
         """Using enum values"""

--- a/src/fidesops/ops/schemas/privacy_request.py
+++ b/src/fidesops/ops/schemas/privacy_request.py
@@ -16,7 +16,7 @@ from fidesops.ops.models.privacy_request import (
 from fidesops.ops.schemas.api import BulkResponse, BulkUpdateFailed
 from fidesops.ops.schemas.base_class import BaseSchema
 from fidesops.ops.schemas.policy import PolicyResponse as PolicySchema
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.schemas.shared_schemas import FidesOpsKey
 from fidesops.ops.util.encryption.aes_gcm_encryption_scheme import verify_encryption_key
 
@@ -57,7 +57,7 @@ class PrivacyRequestCreate(BaseSchema):
     started_processing_at: Optional[datetime]
     finished_processing_at: Optional[datetime]
     requested_at: Optional[datetime]
-    identity: PrivacyRequestIdentity
+    identity: Identity
     policy_key: FidesOpsKey
     encryption_key: Optional[str] = None
 
@@ -157,7 +157,7 @@ class PrivacyRequestResponse(BaseSchema):
     paused_at: Optional[datetime]
     status: PrivacyRequestStatus
     external_id: Optional[str]
-    # This field intentionally doesn't use the PrivacyRequestIdentity schema
+    # This field intentionally doesn't use the Identity schema
     # as it is an API response field, and we don't want to reveal any more
     # about our PII structure than is explicitly stored in the cache on request
     # creation.

--- a/src/fidesops/ops/schemas/redis_cache.py
+++ b/src/fidesops/ops/schemas/redis_cache.py
@@ -5,7 +5,7 @@ from pydantic import Extra
 from fidesops.ops.schemas.base_class import BaseSchema
 
 
-class PrivacyRequestIdentity(BaseSchema):
+class Identity(BaseSchema):
     """Some PII grouping pertaining to a human"""
 
     phone_number: Optional[str] = None

--- a/src/fidesops/ops/service/drp/drp_fidesops_mapper.py
+++ b/src/fidesops/ops/service/drp/drp_fidesops_mapper.py
@@ -7,7 +7,7 @@ from fidesops.ops.models.privacy_request import (
 )
 from fidesops.ops.schemas.drp_privacy_request import DrpIdentity
 from fidesops.ops.schemas.privacy_request import PrivacyRequestDRPStatus
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ class DrpFidesopsMapper:
     """
 
     @staticmethod
-    def map_identity(drp_identity: DrpIdentity) -> PrivacyRequestIdentity:
+    def map_identity(drp_identity: DrpIdentity) -> Identity:
         """
         Currently, both email and phone_number identity props map 1:1 to the corresponding
-        Fidesops identity props in PrivacyRequestIdentity. This may not always be the case.
+        Fidesops identity props in Identity. This may not always be the case.
         This class also allows us to implement custom logic to handle "verified" id props.
         """
         fidesops_identity_kwargs: Dict[str, str] = {}
@@ -42,7 +42,7 @@ class DrpFidesopsMapper:
                     attr
                 ].value
                 fidesops_identity_kwargs[fidesops_prop] = val
-        return PrivacyRequestIdentity(**fidesops_identity_kwargs)
+        return Identity(**fidesops_identity_kwargs)
 
     @staticmethod
     def map_status(

--- a/src/fidesops/ops/service/privacy_request/onetrust_service.py
+++ b/src/fidesops/ops/service/privacy_request/onetrust_service.py
@@ -17,7 +17,7 @@ from fidesops.ops.core.config import config
 from fidesops.ops.models.policy import Policy
 from fidesops.ops.models.privacy_request import PrivacyRequest
 from fidesops.ops.models.storage import StorageConfig
-from fidesops.ops.schemas.privacy_request import PrivacyRequestIdentity
+from fidesops.ops.schemas.privacy_request import Identity
 from fidesops.ops.schemas.shared_schemas import FidesOpsKey
 from fidesops.ops.schemas.storage.storage import StorageDetails, StorageSecrets
 from fidesops.ops.schemas.third_party.onetrust import (
@@ -92,7 +92,7 @@ class OneTrustService:
         )
         for request in all_requests:
             identity_kwargs = {"email": request.email}
-            identity = PrivacyRequestIdentity(**identity_kwargs)
+            identity = Identity(**identity_kwargs)
             fides_task: Optional[OneTrustSubtask] = OneTrustService._get_fides_subtask(
                 hostname, request.requestQueueRefId, access_token  # type: ignore
             )
@@ -134,7 +134,7 @@ class OneTrustService:
     def _create_privacy_request(  # pylint: disable=R0913
         subtask_id: str,
         requested_at: str,
-        identity: PrivacyRequestIdentity,
+        identity: Identity,
         onetrust_policy: Policy,
         hostname: str,
         access_token: str,
@@ -156,7 +156,7 @@ class OneTrustService:
         privacy_request: PrivacyRequest = PrivacyRequest.create(db=db, data=kwargs)
         privacy_request.persist_identity(
             db=db,
-            identity=PrivacyRequestIdentity(email=identity.email),
+            identity=Identity(email=identity.email),
         )
         privacy_request.cache_identity(identity)
         try:

--- a/src/fidesops/ops/service/privacy_request/request_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_service.py
@@ -7,7 +7,7 @@ from fidesops.ops.models.policy import ActionType, Policy
 from fidesops.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fidesops.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate
 from fidesops.ops.schemas.masking.masking_secrets import MaskingSecretCache
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.masking.strategy.masking_strategy import MaskingStrategy
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ def build_required_privacy_request_kwargs(
 def cache_data(
     privacy_request: PrivacyRequest,
     policy: Policy,
-    identity: PrivacyRequestIdentity,
+    identity: Identity,
     encryption_key: Optional[str],
     drp_request_body: Optional[DrpPrivacyRequestCreate],
 ) -> None:

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -68,7 +68,7 @@ from fidesops.ops.schemas.email.email import (
 )
 from fidesops.ops.schemas.masking.masking_secrets import SecretType
 from fidesops.ops.schemas.policy import PolicyResponse
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.tasks import EMAIL_QUEUE_NAME
 from fidesops.ops.util.cache import (
     get_encryption_cache_key,
@@ -800,7 +800,7 @@ class TestGetPrivacyRequests:
         TEST_EMAIL = "test-12345678910@example.com"
         privacy_request.persist_identity(
             db=db,
-            identity=PrivacyRequestIdentity(
+            identity=Identity(
                 email=TEST_EMAIL,
             ),
         )

--- a/tests/ops/fixtures/application_fixtures.py
+++ b/tests/ops/fixtures/application_fixtures.py
@@ -41,7 +41,7 @@ from fidesops.ops.schemas.email.email import (
     EmailServiceSecretsMailgun,
     EmailServiceType,
 )
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.schemas.storage.storage import (
     FileNaming,
     S3AuthMethod,
@@ -888,7 +888,7 @@ def _create_privacy_request_for_policy(
     pr.cache_identity(identity_kwargs)
     pr.persist_identity(
         db=db,
-        identity=PrivacyRequestIdentity(
+        identity=Identity(
             email=email_identity,
             phone_number="+1 234 567 8910",
         ),
@@ -988,7 +988,7 @@ def succeeded_privacy_request(cache, db: Session, policy: Policy) -> PrivacyRequ
     pr.cache_identity(identity_kwargs)
     pr.persist_identity(
         db=db,
-        identity=PrivacyRequestIdentity(**identity_kwargs),
+        identity=Identity(**identity_kwargs),
     )
     yield pr
     pr.delete(db)

--- a/tests/ops/integration_tests/saas/request_override/test_mailchimp_override_task.py
+++ b/tests/ops/integration_tests/saas/request_override/test_mailchimp_override_task.py
@@ -4,7 +4,7 @@ import pytest
 
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import ExecutionLog, PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.graph.graph_test_util import assert_rows_match, records_matching_fields
@@ -42,7 +42,7 @@ async def test_mailchimp_override_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": mailchimp_identity_email})
+    identity = Identity(**{"email": mailchimp_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = mailchimp_override_connection_config.get_saas_config().fides_key
@@ -156,7 +156,7 @@ async def test_mailchimp_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": mailchimp_identity_email})
+    identity = Identity(**{"email": mailchimp_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = mailchimp_override_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_adobe_campaign_task.py
+++ b/tests/ops/integration_tests/saas/test_adobe_campaign_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -35,7 +35,7 @@ async def test_adobe_campaign_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_adobe_campaign_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": adobe_campaign_identity_email})
+    identity = Identity(**{"email": adobe_campaign_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = adobe_campaign_connection_config.get_saas_config().fides_key
@@ -179,7 +179,7 @@ async def test_adobe_campaign_saas_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": erasure_email})
+    identity = Identity(**{"email": erasure_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = adobe_campaign_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_auth0_task.py
+++ b/tests/ops/integration_tests/saas/test_auth0_task.py
@@ -6,7 +6,7 @@ import requests
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.graph.graph_test_util import assert_rows_match
@@ -27,7 +27,7 @@ async def test_auth0_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_auth0_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": auth0_identity_email})
+    identity = Identity(**{"email": auth0_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = auth0_connection_config.get_saas_config().fides_key
@@ -101,7 +101,7 @@ async def test_auth0_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_auth0_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": auth0_erasure_identity_email})
+    identity = Identity(**{"email": auth0_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = auth0_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_datadog_task.py
+++ b/tests/ops/integration_tests/saas/test_datadog_task.py
@@ -5,7 +5,7 @@ import pytest
 
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from tests.ops.graph.graph_test_util import assert_rows_match
@@ -38,7 +38,7 @@ async def test_saas_access_request_task(
     identity_attribute = "email"
     identity_value = datadog_identity_email
     identity_kwargs = {identity_attribute: identity_value}
-    identity = PrivacyRequestIdentity(**identity_kwargs)
+    identity = Identity(**identity_kwargs)
     privacy_request.cache_identity(identity)
 
     dataset_name = datadog_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_hubspot_task.py
+++ b/tests/ops/integration_tests/saas/test_hubspot_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.filter_results import filter_data_categories
@@ -39,7 +39,7 @@ async def test_saas_access_request_task(
     identity_attribute = "email"
     identity_value = hubspot_identity_email
     identity_kwargs = {identity_attribute: identity_value}
-    identity = PrivacyRequestIdentity(**identity_kwargs)
+    identity = Identity(**identity_kwargs)
     privacy_request.cache_identity(identity)
 
     dataset_name = connection_config_hubspot.get_saas_config().fides_key
@@ -147,7 +147,7 @@ async def test_saas_erasure_request_task(
     )
     identity_attribute = "email"
     identity_kwargs = {identity_attribute: (hubspot_erasure_identity_email)}
-    identity = PrivacyRequestIdentity(**identity_kwargs)
+    identity = Identity(**identity_kwargs)
     privacy_request.cache_identity(identity)
 
     dataset_name = connection_config_hubspot.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_logi_id_task.py
+++ b/tests/ops/integration_tests/saas/test_logi_id_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -35,7 +35,7 @@ async def test_logi_id_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_logi_id_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": logi_id_identity_email})
+    identity = Identity(**{"email": logi_id_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = logi_id_connection_config.get_saas_config().fides_key
@@ -110,7 +110,7 @@ async def test_logi_id_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_logi_id_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": logi_id_erasure_identity_email})
+    identity = Identity(**{"email": logi_id_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = logi_id_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_mailchimp_task.py
+++ b/tests/ops/integration_tests/saas/test_mailchimp_task.py
@@ -4,7 +4,7 @@ import pytest
 
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import ExecutionLog, PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.graph.graph_test_util import assert_rows_match, records_matching_fields
@@ -25,7 +25,7 @@ async def test_mailchimp_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": mailchimp_identity_email})
+    identity = Identity(**{"email": mailchimp_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = mailchimp_connection_config.get_saas_config().fides_key
@@ -139,7 +139,7 @@ async def test_mailchimp_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": mailchimp_identity_email})
+    identity = Identity(**{"email": mailchimp_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = mailchimp_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_outreach_task.py
+++ b/tests/ops/integration_tests/saas/test_outreach_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.filter_results import filter_data_categories
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -28,7 +28,7 @@ async def test_outreach_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": outreach_identity_email})
+    identity = Identity(**{"email": outreach_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = outreach_connection_config.get_saas_config().fides_key
@@ -105,7 +105,7 @@ async def test_outreach_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_outreach_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": outreach_erasure_identity_email})
+    identity = Identity(**{"email": outreach_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = outreach_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_salesforce_task.py
+++ b/tests/ops/integration_tests/saas/test_salesforce_task.py
@@ -6,7 +6,7 @@ import requests
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -36,7 +36,7 @@ async def test_salesforce_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_salesforce_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": salesforce_identity_email})
+    identity = Identity(**{"email": salesforce_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = salesforce_connection_config.get_saas_config().fides_key
@@ -395,7 +395,7 @@ async def test_salesforce_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_salesforce_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": salesforce_erasure_identity_email})
+    identity = Identity(**{"email": salesforce_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = salesforce_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_segment_task.py
+++ b/tests/ops/integration_tests/saas/test_segment_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.filter_results import filter_data_categories
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -28,7 +28,7 @@ async def test_segment_saas_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": segment_identity_email})
+    identity = Identity(**{"email": segment_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = segment_connection_config.get_saas_config().fides_key
@@ -158,7 +158,7 @@ async def test_segment_saas_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": erasure_email})
+    identity = Identity(**{"email": erasure_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = segment_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_sendgrid_task.py
+++ b/tests/ops/integration_tests/saas/test_sendgrid_task.py
@@ -5,7 +5,7 @@ import pytest
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.fixtures.saas.sendgrid_fixtures import contact_exists
@@ -27,7 +27,7 @@ async def test_sendgrid_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": sendgrid_identity_email})
+    identity = Identity(**{"email": sendgrid_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = sendgrid_connection_config.get_saas_config().fides_key
@@ -85,7 +85,7 @@ async def test_sendgrid_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": sendgrid_erasure_identity_email})
+    identity = Identity(**{"email": sendgrid_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = sendgrid_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_sentry_task.py
+++ b/tests/ops/integration_tests/saas/test_sentry_task.py
@@ -7,7 +7,7 @@ import requests
 
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.filter_results import filter_data_categories
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -31,7 +31,7 @@ async def test_sentry_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": sentry_identity_email})
+    identity = Identity(**{"email": sentry_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = sentry_connection_config.get_saas_config().fides_key
@@ -278,7 +278,7 @@ async def test_sentry_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_saas_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": erasure_email})
+    identity = Identity(**{"email": erasure_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = sentry_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_shopify_task.py
+++ b/tests/ops/integration_tests/saas/test_shopify_task.py
@@ -6,7 +6,7 @@ import requests
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -34,7 +34,7 @@ async def test_shopify_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_shopify_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": shopify_identity_email})
+    identity = Identity(**{"email": shopify_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = shopify_connection_config.get_saas_config().fides_key
@@ -282,7 +282,7 @@ async def test_shopify_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_shopify_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": shopify_erasure_identity_email})
+    identity = Identity(**{"email": shopify_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = shopify_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_stripe_task.py
+++ b/tests/ops/integration_tests/saas/test_stripe_task.py
@@ -7,7 +7,7 @@ import requests
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.filter_results import filter_data_categories
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
@@ -29,7 +29,7 @@ async def test_stripe_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_stripe_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": stripe_identity_email})
+    identity = Identity(**{"email": stripe_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = stripe_connection_config.get_saas_config().fides_key
@@ -650,7 +650,7 @@ async def test_stripe_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_stripe_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": stripe_erasure_identity_email})
+    identity = Identity(**{"email": stripe_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = stripe_connection_config.get_saas_config().fides_key

--- a/tests/ops/integration_tests/saas/test_zendesk_task.py
+++ b/tests/ops/integration_tests/saas/test_zendesk_task.py
@@ -7,7 +7,7 @@ import requests
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.task import graph_task
 from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.graph.graph_test_util import assert_rows_match
@@ -28,7 +28,7 @@ async def test_zendesk_access_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_zendesk_access_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": zendesk_identity_email})
+    identity = Identity(**{"email": zendesk_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = zendesk_connection_config.get_saas_config().fides_key
@@ -194,7 +194,7 @@ async def test_zendesk_erasure_request_task(
     privacy_request = PrivacyRequest(
         id=f"test_zendesk_erasure_request_task_{random.randint(0, 1000)}"
     )
-    identity = PrivacyRequestIdentity(**{"email": zendesk_erasure_identity_email})
+    identity = Identity(**{"email": zendesk_erasure_identity_email})
     privacy_request.cache_identity(identity)
 
     dataset_name = zendesk_connection_config.get_saas_config().fides_key

--- a/tests/ops/models/test_privacy_request.py
+++ b/tests/ops/models/test_privacy_request.py
@@ -22,7 +22,7 @@ from fidesops.ops.models.privacy_request import (
     ProvidedIdentity,
     can_run_checkpoint,
 )
-from fidesops.ops.schemas.redis_cache import PrivacyRequestIdentity
+from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors.manual_connector import ManualAction
 from fidesops.ops.util.cache import FidesopsRedis, get_identity_cache_key
 from fidesops.ops.util.constants import API_DATE_FORMAT
@@ -217,7 +217,7 @@ def test_delete_privacy_request_removes_cached_data(
     identity_attribute = "email"
     identity_value = "test@example.com"
     identity_kwargs = {identity_attribute: identity_value}
-    identity = PrivacyRequestIdentity(**identity_kwargs)
+    identity = Identity(**identity_kwargs)
     privacy_request.cache_identity(identity)
     key = get_identity_cache_key(
         privacy_request_id=privacy_request.id,
@@ -240,7 +240,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[0]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         with requests_mock.Mocker() as mock_response:
@@ -268,7 +268,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         with requests_mock.Mocker() as mock_response:
@@ -294,7 +294,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         with requests_mock.Mocker() as mock_response:
@@ -322,7 +322,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         with requests_mock.Mocker() as mock_response:
@@ -350,7 +350,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         with requests_mock.Mocker() as mock_response:
@@ -383,7 +383,7 @@ class TestPrivacyRequestTriggerWebhooks:
         policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
-        identity = PrivacyRequestIdentity(email="customer-1@example.com")
+        identity = Identity(email="customer-1@example.com")
         privacy_request.cache_identity(identity)
 
         # halt not included


### PR DESCRIPTION
# Purpose

I plan to use the `PrivacyRequestIdentity` schema in the consent request workflow. In preparation for that I am renaming it to `Identity` to give a more generic name.

# Changes
- Rename `PrivacyRequestIdentity` to `Identity`

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #
 
