### PR TITLE
Explicitly install the `toml` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,6 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.7.2...main)
 
-### Developer Experience
-
-* Created a docker image for the privacy center [#1165](https://github.com/ethyca/fidesops/pull/1165)
-* Adds email scopes to postman collection [#1241](https://github.com/ethyca/fidesops/pull/1241)
-* Clean up docker build [#1252](https://github.com/ethyca/fidesops/pull/1252)
-* Add `Strategy` abstract base class for more extensible strategy development [1254](https://github.com/ethyca/fidesops/pull/1254)
-
-
 ### Added
 
 * Adds users and owners configuration for Hubspot connector [#1091](https://github.com/ethyca/fidesops/pull/1091)
@@ -52,12 +44,18 @@ The types of changes are:
 * Utility to update SaaS config instances based on template updates [#1307](https://github.com/ethyca/fidesops/pull/1307)
 * Added generic request sorting button [#1320](https://github.com/ethyca/fidesops/pull/1320)
 * Adds ability to send email notification upon privacy request review [#1306](https://github.com/ethyca/fidesops/pull/1306)
-* Manual webhook test functionality (#1323)[https://github.com/ethyca/fidesops/pull/1323/] 
-
+* Manual webhook test functionality [#1323](https://github.com/ethyca/fidesops/pull/1323/)
 
 ### Changed
 
 * Renamed `PrivacyRequestIdentity` to `Identity` [#1324](https://github.com/ethyca/fidesops/pull/1324)
+
+### Developer Experience
+
+* Created a docker image for the privacy center [#1165](https://github.com/ethyca/fidesops/pull/1165)
+* Adds email scopes to postman collection [#1241](https://github.com/ethyca/fidesops/pull/1241)
+* Clean up docker build [#1252](https://github.com/ethyca/fidesops/pull/1252)
+* Add `Strategy` abstract base class for more extensible strategy development [1254](https://github.com/ethyca/fidesops/pull/1254)
 
 ### Docs
 
@@ -77,6 +75,7 @@ The types of changes are:
 * Fixed typo in enum value [#1280](https://github.com/ethyca/fidesops/pull/1280)
 * Remove masking of redis error log [#1288](https://github.com/ethyca/fidesops/pull/1288)
 * Logout with malformed or expired token [#1305](https://github.com/ethyca/fidesops/pull/1305)
+* The `toml` package is now included in the list of direct dependencies (`requirements.txt`) [#1338](https://github.com/ethyca/fidesops/pull/1338)
 
 ### Security
 
@@ -123,7 +122,7 @@ The `oauth2` strategy has been renamed to `oauth2_authorization_code` in order t
 * Bump fideslib to fix issue where the authenticate button in the FastAPI docs did not work [#1092](https://github.com/ethyca/fidesops/pull/1092)
 * Escape the Redis user and password to make them URL friendly [#1104](https://github.com/ethyca/fidesops/pull/1104)
 * Reduced number of connections opened against app db during health checks [#1107](https://github.com/ethyca/fidesops/pull/1107)
-* Fix FIDESOPS__ROOT_USER__ANALYTICS_ID generation when env var is set [#1113](https://github.com/ethyca/fidesops/pull/1113) 
+* Fix FIDESOPS__ROOT_USER__ANALYTICS_ID generation when env var is set [#1113](https://github.com/ethyca/fidesops/pull/1113)
 * Set localhost to None for non-endpoint events [#1130](https://github.com/ethyca/fidesops/pull/1130)
 * Fixed docs build in CI [#1138](https://github.com/ethyca/fidesops/pull/1138)
 * Added future annotations to privacy_request.py for backwards compatibility [#1136](https://github.com/ethyca/fidesops/pull/1136)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ click==8.1.3
 cryptography~=3.4.8
 dask==2022.8.0
 emails
-fastapi[all]==0.82.0
 fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.10.0
+fastapi[all]==0.82.0
 fideslang==1.2.0
 fideslib==3.1.2
 fideslog==1.2.3
@@ -30,5 +30,6 @@ sqlalchemy-redshift==0.8.11
 sqlalchemy-stubs==0.4
 SQLAlchemy-Utils==0.38.3
 sqlalchemy==1.4.14
+toml==0.10.2
 Unidecode==1.3.4
 versioneer==0.19

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -5,7 +5,6 @@ import os
 from typing import Any, Dict, List, MutableMapping, Optional
 from urllib.parse import quote_plus
 
-import toml
 from fideslib.core.config import (
     DatabaseSettings,
     FidesSettings,
@@ -16,6 +15,7 @@ from fideslib.core.config import (
 )
 from fideslog.sdk.python.utils import FIDESOPS, generate_client_id
 from pydantic import validator
+from toml import dump
 
 from fidesops.ops.api.v1.scope_registry import SCOPE_REGISTRY
 
@@ -274,7 +274,7 @@ def update_config_file(updates: Dict[str, Dict[str, Any]]) -> None:
             current_config.update({key: value})
 
     with open(config_path, "w") as config_file:  # pylint: disable=W1514
-        toml.dump(current_config, config_file)
+        dump(current_config, config_file)
 
     logger.info("Updated %s:", config_path)
 


### PR DESCRIPTION
# Purpose

The `toml` package is not included in `requirements.txt`, but is referenced in source code as a direct dependency:

https://github.com/ethyca/fidesops/blob/a5d0ca8c7aa97ea1adc58c0aae42f93743f612f6/src/fidesops/ops/core/config.py#L8

This creates installation issues for anyone installing fidesops via `pip`.

# Changes

- Add `toml` to `requirements.txt`
- Reduce `toml` import volume in `config.py`

# Checklist

- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Related to ethyca/fidesops-plus#37