### PR TITLE
1310- use existing celery queue for all email dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The types of changes are:
 ### Changed
 
 * Renamed `PrivacyRequestIdentity` to `Identity` [#1324](https://github.com/ethyca/fidesops/pull/1324)
+* Use existing Celery queue for all email dispatch calls [#1341](https://github.com/ethyca/fidesops/pull/1341)
 
 ### Developer Experience
 

--- a/src/fidesops/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -239,7 +239,7 @@ async def create_privacy_request(
                 continue  # Skip further processing for this privacy request
             if config.notifications.send_request_receipt_notification:
                 _send_privacy_request_receipt_email_to_user(
-                    db, policy, privacy_request_data.identity.email
+                    policy, privacy_request_data.identity.email
                 )
             if not config.execution.require_manual_request_approval:
                 AuditLog.create(
@@ -292,7 +292,8 @@ def _send_verification_code_to_user(
     )  # Validates Fidesops is currently configured to send emails
     verification_code: str = generate_id_verification_code()
     privacy_request.cache_identity_verification_code(verification_code)
-    dispatch_email_task.apply_async(
+    # synchronous call for now since failure to send verification code is fatal to request
+    dispatch_email_task.apply(
         queue=EMAIL_QUEUE_NAME,
         kwargs={
             "email_meta": FidesopsEmail(
@@ -308,7 +309,7 @@ def _send_verification_code_to_user(
 
 
 def _send_privacy_request_receipt_email_to_user(
-    db: Session, policy: Optional[Policy], email: Optional[str]
+    policy: Optional[Policy], email: Optional[str]
 ) -> None:
     """Helper function to send request receipt email to the user"""
     if not email:
@@ -329,20 +330,16 @@ def _send_privacy_request_receipt_email_to_user(
     for action_type in ActionType:
         if policy.get_rules_for_action(action_type=ActionType(action_type)):
             request_types.add(action_type)
-    try:
-        dispatch_email_task.apply_async(
-            queue=EMAIL_QUEUE_NAME,
-            kwargs={
-                "email_meta": FidesopsEmail(
-                    action_type=EmailActionType.PRIVACY_REQUEST_RECEIPT,
-                    body_params=RequestReceiptBodyParams(request_types=request_types),
-                ).dict(),
-                "to_email": email,
-            },
-        )
-    except EmailDispatchException as exc:
-        # catch early since this failure isn't fatal to privacy request, unlike the subject id verification email
-        logger.info("Email dispatch failed with exception %s", exc)
+    dispatch_email_task.apply_async(
+        queue=EMAIL_QUEUE_NAME,
+        kwargs={
+            "email_meta": FidesopsEmail(
+                action_type=EmailActionType.PRIVACY_REQUEST_RECEIPT,
+                body_params=RequestReceiptBodyParams(request_types=request_types),
+            ).dict(),
+            "to_email": email,
+        },
+    )
 
 
 def privacy_request_csv_download(
@@ -1120,7 +1117,6 @@ def review_privacy_request(
 
 
 def _send_privacy_request_review_email_to_user(
-    db: Session,
     action_type: EmailActionType,
     email: Optional[str],
     rejection_reason: Optional[str],
@@ -1132,24 +1128,20 @@ def _send_privacy_request_review_email_to_user(
                 "Identity email was not found, so request review email could not be sent."
             )
         )
-    try:
-        dispatch_email_task.apply_async(
-            queue=EMAIL_QUEUE_NAME,
-            kwargs={
-                "email_meta": FidesopsEmail(
-                    action_type=action_type,
-                    body_params=RequestReviewDenyBodyParams(
-                        rejection_reason=rejection_reason
-                    )
-                    if action_type is EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
-                    else None,
-                ).dict(),
-                "to_email": email,
-            },
-        )
-    except EmailDispatchException as exc:
-        # this failure isn't fatal to privacy request
-        logger.info("Email dispatch failed with exception %s", exc)
+    dispatch_email_task.apply_async(
+        queue=EMAIL_QUEUE_NAME,
+        kwargs={
+            "email_meta": FidesopsEmail(
+                action_type=action_type,
+                body_params=RequestReviewDenyBodyParams(
+                    rejection_reason=rejection_reason
+                )
+                if action_type is EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
+                else None,
+            ).dict(),
+            "to_email": email,
+        },
+    )
 
 
 @router.post(
@@ -1179,13 +1171,10 @@ async def verify_identification_code(
         )
         if config.notifications.send_request_receipt_notification:
             _send_privacy_request_receipt_email_to_user(
-                db, policy, privacy_request.get_persisted_identity().email
+                policy, privacy_request.get_persisted_identity().email
             )
     except IdentityVerificationException as exc:
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=exc.message)
-    except EmailDispatchException as exc:
-        # not fatal to request lifecycle, do not raise error, continue with request
-        logger.info("Email dispatch failed with exception %s", exc)
     except PermissionError as exc:
         logger.info("Invalid verification code provided for %s.", privacy_request.id)
         raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=exc.args[0])
@@ -1241,7 +1230,6 @@ def approve_privacy_request(
         )
         if config.notifications.send_request_review_notification:
             _send_privacy_request_review_email_to_user(
-                db=db,
                 action_type=EmailActionType.PRIVACY_REQUEST_REVIEW_APPROVE,
                 email=privacy_request.get_cached_identity_data().get(
                     ProvidedIdentityType.email.value
@@ -1294,7 +1282,6 @@ def deny_privacy_request(
         )
         if config.notifications.send_request_review_notification:
             _send_privacy_request_review_email_to_user(
-                db=db,
                 action_type=EmailActionType.PRIVACY_REQUEST_REVIEW_DENY,
                 email=privacy_request.get_cached_identity_data().get(
                     ProvidedIdentityType.email.value

--- a/src/fidesops/ops/schemas/email/email.py
+++ b/src/fidesops/ops/schemas/email/email.py
@@ -47,20 +47,6 @@ class SubjectIdentityVerificationBodyParams(BaseModel):
         return self.verification_code_ttl_seconds // 60
 
 
-class FidesopsEmail(
-    BaseModel,
-    smart_union=True,
-    arbitrary_types_allowed=True,
-):
-    """A mapping of action_type to body_params"""
-
-    action_type: EmailActionType
-    body_params: Union[
-        SubjectIdentityVerificationBodyParams,
-        List[CheckpointActionRequired],
-    ]
-
-
 class RequestReceiptBodyParams(BaseModel):
     """Body params required for privacy request receipt email template"""
 
@@ -77,6 +63,25 @@ class RequestReviewDenyBodyParams(BaseModel):
     """Body params required for privacy request review deny email template"""
 
     rejection_reason: Optional[str]
+
+
+class FidesopsEmail(
+    BaseModel,
+    smart_union=True,
+    arbitrary_types_allowed=True,
+):
+    """A mapping of action_type to body_params"""
+
+    action_type: EmailActionType
+    body_params: Optional[
+        Union[
+            SubjectIdentityVerificationBodyParams,
+            RequestReceiptBodyParams,
+            RequestReviewDenyBodyParams,
+            AccessRequestCompleteBodyParams,
+            List[CheckpointActionRequired],
+        ]
+    ]
 
 
 class EmailForActionType(BaseModel):

--- a/src/fidesops/ops/service/connectors/email_connector.py
+++ b/src/fidesops/ops/service/connectors/email_connector.py
@@ -54,7 +54,8 @@ class EmailConnector(BaseConnector[None]):
         logger.info("Starting test connection to %s", self.configuration.key)
 
         try:
-            dispatch_email_task.apply_async(
+            # synchronous for now since failure to send is considered a connection test failure
+            dispatch_email_task.apply(
                 queue=EMAIL_QUEUE_NAME,
                 kwargs={
                     "email_meta": FidesopsEmail(
@@ -197,7 +198,8 @@ def email_connector_erasure_send(db: Session, privacy_request: PrivacyRequest) -
                 "No email sent: no masking needed on '%s'", ds.dataset.get("fides_key")
             )
             return
-        dispatch_email_task.apply_async(
+        # synchronous for now since failure to send erasure request is a failure for this connector
+        dispatch_email_task.apply(
             queue=EMAIL_QUEUE_NAME,
             kwargs={
                 "email_meta": FidesopsEmail(

--- a/src/fidesops/ops/service/connectors/email_connector.py
+++ b/src/fidesops/ops/service/connectors/email_connector.py
@@ -23,10 +23,11 @@ from fidesops.ops.models.privacy_request import (
     PrivacyRequest,
 )
 from fidesops.ops.schemas.connection_configuration import EmailSchema
-from fidesops.ops.schemas.email.email import EmailActionType
+from fidesops.ops.schemas.email.email import EmailActionType, FidesopsEmail
 from fidesops.ops.service.connectors.base_connector import BaseConnector
 from fidesops.ops.service.connectors.query_config import ManualQueryConfig
-from fidesops.ops.service.email.email_dispatch_service import dispatch_email
+from fidesops.ops.service.email.email_dispatch_service import dispatch_email_task
+from fidesops.ops.tasks import EMAIL_QUEUE_NAME
 from fidesops.ops.util.collection_util import Row, append
 
 logger = logging.getLogger(__name__)
@@ -52,28 +53,32 @@ class EmailConnector(BaseConnector[None]):
         config = EmailSchema(**self.configuration.secrets or {})
         logger.info("Starting test connection to %s", self.configuration.key)
 
-        db = Session.object_session(self.configuration)
-
         try:
-            dispatch_email(
-                db=db,
-                action_type=EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT,
-                to_email=config.test_email,
-                email_body_params=[
-                    CheckpointActionRequired(
-                        step=CurrentStep.erasure,
-                        collection=CollectionAddress("test_dataset", "test_collection"),
-                        action_needed=[
-                            ManualAction(
-                                locators={"id": ["example_id"]},
-                                get=None,
-                                update={
-                                    "test_field": "null_rewrite",
-                                },
+            dispatch_email_task.apply_async(
+                queue=EMAIL_QUEUE_NAME,
+                kwargs={
+                    "email_meta": FidesopsEmail(
+                        action_type=EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT,
+                        body_params=[
+                            CheckpointActionRequired(
+                                step=CurrentStep.erasure,
+                                collection=CollectionAddress(
+                                    "test_dataset", "test_collection"
+                                ),
+                                action_needed=[
+                                    ManualAction(
+                                        locators={"id": ["example_id"]},
+                                        get=None,
+                                        update={
+                                            "test_field": "null_rewrite",
+                                        },
+                                    )
+                                ],
                             )
                         ],
-                    )
-                ],
+                    ).dict(),
+                    "to_email": config.test_email,
+                },
             )
         except EmailDispatchException as exc:
             logger.info("Email connector test failed with exception %s", exc)
@@ -192,12 +197,15 @@ def email_connector_erasure_send(db: Session, privacy_request: PrivacyRequest) -
                 "No email sent: no masking needed on '%s'", ds.dataset.get("fides_key")
             )
             return
-
-        dispatch_email(
-            db,
-            action_type=EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT,
-            to_email=cc.secrets.get("to_email"),
-            email_body_params=template_values,
+        dispatch_email_task.apply_async(
+            queue=EMAIL_QUEUE_NAME,
+            kwargs={
+                "email_meta": FidesopsEmail(
+                    action_type=EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT,
+                    body_params=template_values,
+                ).dict(),
+                "to_email": cc.secrets.get("to_email"),
+            },
         )
 
         logger.info(

--- a/src/fidesops/ops/service/email/email_dispatch_service.py
+++ b/src/fidesops/ops/service/email/email_dispatch_service.py
@@ -63,6 +63,7 @@ def dispatch_email(
     Sends an email to `to_email` with content supplied in `email_body_params`
     """
     if not to_email:
+        logger.error("Email failed to send. No email supplied.")
         raise EmailDispatchException("No email supplied.")
 
     logger.info("Retrieving email config")

--- a/src/fidesops/ops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_runner_service.py
@@ -437,7 +437,8 @@ def initiate_privacy_request_completion_email(
             "Identity email was not found, so request completion email could not be sent."
         )
     if policy.get_rules_for_action(action_type=ActionType.access):
-        dispatch_email_task.apply_async(
+        # synchronous for now since failure to send complete emails is fatal to request
+        dispatch_email_task.apply(
             queue=EMAIL_QUEUE_NAME,
             kwargs={
                 "email_meta": FidesopsEmail(
@@ -450,7 +451,7 @@ def initiate_privacy_request_completion_email(
             },
         )
     if policy.get_rules_for_action(action_type=ActionType.erasure):
-        dispatch_email_task.apply_async(
+        dispatch_email_task.apply(
             queue=EMAIL_QUEUE_NAME,
             kwargs={
                 "email_meta": FidesopsEmail(

--- a/src/fidesops/ops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_runner_service.py
@@ -45,10 +45,9 @@ from fidesops.ops.models.privacy_request import (
 from fidesops.ops.schemas.email.email import (
     AccessRequestCompleteBodyParams,
     EmailActionType,
-    FidesopsEmail,
 )
 from fidesops.ops.service.connectors.email_connector import email_connector_erasure_send
-from fidesops.ops.service.email.email_dispatch_service import dispatch_email_task
+from fidesops.ops.service.email.email_dispatch_service import dispatch_email
 from fidesops.ops.service.storage.storage_uploader_service import upload
 from fidesops.ops.task.filter_results import filter_data_categories
 from fidesops.ops.task.graph_task import (
@@ -56,7 +55,7 @@ from fidesops.ops.task.graph_task import (
     run_access_request,
     run_erasure,
 )
-from fidesops.ops.tasks import EMAIL_QUEUE_NAME, DatabaseTask, celery_app
+from fidesops.ops.tasks import DatabaseTask, celery_app
 from fidesops.ops.tasks.scheduled.scheduler import scheduler
 from fidesops.ops.util.cache import (
     FidesopsRedis,
@@ -396,7 +395,7 @@ async def run_privacy_request(
         if config.notifications.send_request_completion_notification:
             try:
                 initiate_privacy_request_completion_email(
-                    policy, access_result_urls, identity_data
+                    session, policy, access_result_urls, identity_data
                 )
             except (IdentityNotFoundException, EmailDispatchException) as e:
                 privacy_request.error_processing(db=session)
@@ -422,6 +421,7 @@ async def run_privacy_request(
 
 
 def initiate_privacy_request_completion_email(
+    session: Session,
     policy: Policy,
     access_result_urls: List[str],
     identity_data: Dict[str, Any],
@@ -438,28 +438,20 @@ def initiate_privacy_request_completion_email(
         )
     if policy.get_rules_for_action(action_type=ActionType.access):
         # synchronous for now since failure to send complete emails is fatal to request
-        dispatch_email_task.apply(
-            queue=EMAIL_QUEUE_NAME,
-            kwargs={
-                "email_meta": FidesopsEmail(
-                    action_type=EmailActionType.PRIVACY_REQUEST_COMPLETE_ACCESS,
-                    body_params=AccessRequestCompleteBodyParams(
-                        download_links=access_result_urls
-                    ),
-                ).dict(),
-                "to_email": identity_data.get(ProvidedIdentityType.email.value),
-            },
+        dispatch_email(
+            db=session,
+            action_type=EmailActionType.PRIVACY_REQUEST_COMPLETE_ACCESS,
+            to_email=identity_data.get(ProvidedIdentityType.email.value),
+            email_body_params=AccessRequestCompleteBodyParams(
+                download_links=access_result_urls
+            ),
         )
     if policy.get_rules_for_action(action_type=ActionType.erasure):
-        dispatch_email_task.apply(
-            queue=EMAIL_QUEUE_NAME,
-            kwargs={
-                "email_meta": FidesopsEmail(
-                    action_type=EmailActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
-                    body_params=None,
-                ).dict(),
-                "to_email": identity_data.get(ProvidedIdentityType.email.value),
-            },
+        dispatch_email(
+            db=session,
+            action_type=EmailActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
+            to_email=identity_data.get(ProvidedIdentityType.email.value),
+            email_body_params=None,
         )
 
 

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -1211,7 +1211,7 @@ class TestPutConnectionConfigSecrets:
         )
 
     @mock.patch(
-        "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply_async"
+        "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply"
     )
     def test_put_email_connection_config_secrets(
         self,

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -94,7 +94,7 @@ class TestCreatePrivacyRequest:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_create_privacy_request(
         self,
@@ -1799,7 +1799,7 @@ class TestApprovePrivacyRequest:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_approve_privacy_request(
         self,
@@ -1847,7 +1847,7 @@ class TestApprovePrivacyRequest:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_approve_privacy_request_creates_audit_log_and_sends_email(
         self,
@@ -1888,11 +1888,16 @@ class TestApprovePrivacyRequest:
         approval_audit_log.delete(db)
 
         call_args = mock_dispatch_email.call_args[1]
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
         assert (
-            call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_APPROVE
+            email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_APPROVE
         )
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] is None
+        assert email_meta["body_params"] is None
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
 
 class TestDenyPrivacyRequest:
@@ -1965,7 +1970,7 @@ class TestDenyPrivacyRequest:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_deny_privacy_request_without_denial_reason(
         self,
@@ -2009,12 +2014,18 @@ class TestDenyPrivacyRequest:
                 & (AuditLog.user_id == user.id)
             ),
         ).first()
+
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReviewDenyBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
+        assert email_meta["body_params"] == RequestReviewDenyBodyParams(
             rejection_reason=None
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
         assert denial_audit_log.message is None
 
@@ -2026,7 +2037,7 @@ class TestDenyPrivacyRequest:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_deny_privacy_request_with_denial_reason(
         self,
@@ -2070,12 +2081,18 @@ class TestDenyPrivacyRequest:
                 & (AuditLog.user_id == user.id)
             ),
         ).first()
+
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReviewDenyBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_REVIEW_DENY
+        assert email_meta["body_params"] == RequestReviewDenyBodyParams(
             rejection_reason=denial_reason
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
         assert denial_audit_log.message == denial_reason
 
@@ -2685,7 +2702,7 @@ class TestVerifyIdentity:
         )
 
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_verification_code_expired(
         self,
@@ -2709,7 +2726,7 @@ class TestVerifyIdentity:
         assert not mock_dispatch_email.called
 
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_invalid_code(
         self,
@@ -2737,7 +2754,7 @@ class TestVerifyIdentity:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_verify_identity_no_admin_approval_needed(
         self,
@@ -2780,17 +2797,22 @@ class TestVerifyIdentity:
         assert mock_dispatch_email.called
 
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReceiptBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
+        assert email_meta["body_params"] == RequestReceiptBodyParams(
             request_types={ActionType.access.value}
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
     @mock.patch(
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_verify_identity_no_admin_approval_needed_email_disabled(
         self,
@@ -2835,7 +2857,7 @@ class TestVerifyIdentity:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_verify_identity_admin_approval_needed(
         self,
@@ -2878,11 +2900,16 @@ class TestVerifyIdentity:
         assert mock_dispatch_email.called
 
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReceiptBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
+        assert email_meta["body_params"] == RequestReceiptBodyParams(
             request_types={ActionType.access.value}
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
 
 class TestCreatePrivacyRequestEmailVerificationRequired:
@@ -3430,7 +3457,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_create_privacy_request_no_email_config(
         self,
@@ -3461,11 +3488,16 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         assert mock_dispatch_email.called
 
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReceiptBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
+        assert email_meta["body_params"] == RequestReceiptBodyParams(
             request_types={ActionType.access.value}
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
         pr.delete(db=db)
 
@@ -3473,7 +3505,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
     )
     def test_create_privacy_request_with_email_config(
         self,
@@ -3504,10 +3536,15 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         assert mock_dispatch_email.called
 
         call_args = mock_dispatch_email.call_args[1]
-        assert call_args["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
-        assert call_args["to_email"] == "test@example.com"
-        assert call_args["email_body_params"] == RequestReceiptBodyParams(
+        task_kwargs = call_args["kwargs"]
+        assert task_kwargs["to_email"] == "test@example.com"
+
+        email_meta = task_kwargs["email_meta"]
+        assert email_meta["action_type"] == EmailActionType.PRIVACY_REQUEST_RECEIPT
+        assert email_meta["body_params"] == RequestReceiptBodyParams(
             request_types={ActionType.access.value}
         )
+        queue = call_args["queue"]
+        assert queue == EMAIL_QUEUE_NAME
 
         pr.delete(db=db)

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -2958,7 +2958,7 @@ class TestCreatePrivacyRequestEmailVerificationRequired:
         "fidesops.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(
-        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply_async"
+        "fidesops.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_email_task.apply"
     )
     def test_create_privacy_request_with_email_config(
         self,

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -21,7 +21,7 @@ from fidesops.ops.task import graph_task
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
-@mock.patch("fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply")
+@mock.patch("fidesops.ops.service.connectors.email_connector.dispatch_email")
 @pytest.mark.asyncio
 async def test_email_connector_cache_and_delayed_send(
     mock_email_dispatch,

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -21,9 +21,7 @@ from fidesops.ops.task import graph_task
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
-@mock.patch(
-    "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply"
-)
+@mock.patch("fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply")
 @pytest.mark.asyncio
 async def test_email_connector_cache_and_delayed_send(
     mock_email_dispatch,

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -21,7 +21,9 @@ from fidesops.ops.task import graph_task
 
 @pytest.mark.integration_postgres
 @pytest.mark.integration
-@mock.patch("fidesops.ops.service.connectors.email_connector.dispatch_email")
+@mock.patch(
+    "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply_async"
+)
 @pytest.mark.asyncio
 async def test_email_connector_cache_and_delayed_send(
     mock_email_dispatch,

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -22,7 +22,7 @@ from fidesops.ops.task import graph_task
 @pytest.mark.integration_postgres
 @pytest.mark.integration
 @mock.patch(
-    "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply_async"
+    "fidesops.ops.service.connectors.email_connector.dispatch_email_task.apply"
 )
 @pytest.mark.asyncio
 async def test_email_connector_cache_and_delayed_send(

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -71,7 +71,7 @@ def privacy_request_complete_email_notification_enabled():
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_policy_upload_dispatch_email_called(
@@ -90,7 +90,7 @@ def test_policy_upload_dispatch_email_called(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_sets_started_processing_at(
@@ -116,7 +116,7 @@ def test_start_processing_sets_started_processing_at(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_doesnt_overwrite_started_processing_at(
@@ -167,7 +167,7 @@ def test_halts_proceeding_if_cancelled(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.upload_access_results"
@@ -217,7 +217,7 @@ def test_from_graph_resume_does_not_run_pre_webhooks(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.run_webhooks_and_report_status",
@@ -1830,7 +1830,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
     )
     def test_email_complete_send_erasure(
         self,
@@ -1866,7 +1866,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access(
@@ -1905,7 +1905,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access_and_erasure(

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -71,7 +71,7 @@ def privacy_request_complete_email_notification_enabled():
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_policy_upload_dispatch_email_called(
@@ -90,7 +90,7 @@ def test_policy_upload_dispatch_email_called(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_sets_started_processing_at(
@@ -116,7 +116,7 @@ def test_start_processing_sets_started_processing_at(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_doesnt_overwrite_started_processing_at(
@@ -167,7 +167,7 @@ def test_halts_proceeding_if_cancelled(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.upload_access_results"
@@ -217,7 +217,7 @@ def test_from_graph_resume_does_not_run_pre_webhooks(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.run_webhooks_and_report_status",
@@ -1830,7 +1830,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
     )
     def test_email_complete_send_erasure(
         self,
@@ -1866,7 +1866,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access(
@@ -1905,7 +1905,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply_async"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access_and_erasure(

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -71,7 +71,7 @@ def privacy_request_complete_email_notification_enabled():
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_policy_upload_dispatch_email_called(
@@ -90,7 +90,7 @@ def test_policy_upload_dispatch_email_called(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_sets_started_processing_at(
@@ -116,7 +116,7 @@ def test_start_processing_sets_started_processing_at(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
 )
 @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
 def test_start_processing_doesnt_overwrite_started_processing_at(
@@ -167,7 +167,7 @@ def test_halts_proceeding_if_cancelled(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.upload_access_results"
@@ -217,7 +217,7 @@ def test_from_graph_resume_does_not_run_pre_webhooks(
 
 
 @mock.patch(
-    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+    "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
 )
 @mock.patch(
     "fidesops.ops.service.privacy_request.request_runner_service.run_webhooks_and_report_status",
@@ -1830,7 +1830,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
     )
     def test_email_complete_send_erasure(
         self,
@@ -1866,7 +1866,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access(
@@ -1905,7 +1905,7 @@ class TestPrivacyRequestsEmailNotifications:
     @pytest.mark.integration_postgres
     @pytest.mark.integration
     @mock.patch(
-        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email_task.apply"
+        "fidesops.ops.service.privacy_request.request_runner_service.dispatch_email"
     )
     @mock.patch("fidesops.ops.service.privacy_request.request_runner_service.upload")
     def test_email_complete_send_access_and_erasure(
@@ -1953,6 +1953,7 @@ class TestPrivacyRequestsEmailNotifications:
                     db=ANY,
                     action_type=EmailActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
                     to_email=customer_email,
+                    email_body_params=None,
                 ),
             ],
             any_order=True,


### PR DESCRIPTION
# Purpose
Use existing celery queue for all email dispatch, excluding emails that require special handling upon email failure

# Changes
- Use existing celery queue for all email dispatch calls
- Update tests to reflect replacing email dispatch with async

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1310
 
