### PR TITLE
pin version of pyjwt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pandas==1.4.4
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.3
 pydash==5.1.0
-pyjwt
+pyjwt==2.4.0
 pymongo==3.12.0
 PyMySQL==1.0.2
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
# Purpose

`pyjwt` is currently unpinned in our requirements, and released a version update to `2.5.0` on September 17th. Co-incidentally(?) our tests [also began failing](https://github.com/ethyca/fidesops/actions/runs/3084160052/jobs/4986072014#step:6:321), around PyJWT encoded JWTs.

# Changes
- pins `pyjwt` to `2.4.0`