### PR TITLE
Upgrades `pyjwt` to `2.5.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pandas==1.4.4
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.3
 pydash==5.1.0
-pyjwt==2.4.0
+pyjwt==2.5.0
 pymongo==3.12.0
 PyMySQL==1.0.2
 python-jose[cryptography]==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pandas==1.4.4
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.3
 pydash==5.1.0
-pyjwt
+pyjwt==2.4.0
 pymongo==3.12.0
 PyMySQL==1.0.2
 python-jose[cryptography]==3.3.0

--- a/tests/ops/api/v1/endpoints/test_drp_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_drp_endpoints.py
@@ -89,10 +89,7 @@ class TestCreateDrpPrivacyRequest:
             privacy_request_id=pr.id,
             identity_attribute="identity",
         )
-        assert (
-            cache.get(identity_key)
-            == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJwaG9uZV9udW1iZXIiOiIrMSAyMzQgNTY3IDg5MTAifQ.kHV4ru6vxQR96Meae31oKIU7mMnTJgt1cnli6GLUBFk"
-        )
+        assert cache.get(identity_key) == encoded_identity
         fidesops_identity_key = get_identity_cache_key(
             privacy_request_id=pr.id,
             identity_attribute="email",
@@ -156,10 +153,7 @@ class TestCreateDrpPrivacyRequest:
             privacy_request_id=pr.id,
             identity_attribute="identity",
         )
-        assert (
-            cache.get(identity_key)
-            == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJhZGRyZXNzIjoic29tZXRoaW5nIn0.VhHzwTNoTjuny7lSebD6_hc0SU8kEZDr3YegONMMfmY"
-        )
+        assert cache.get(identity_key) == encoded_identity
         fidesops_identity_key = get_identity_cache_key(
             privacy_request_id=pr.id,
             identity_attribute="email",


### PR DESCRIPTION
# Purpose

Upgrades `pyjwt` to `2.5.0` and omits the usage of hardcoded encoded data within the tests.