### PR TITLE
Fix Corner Case: Retrieving Access Results from Cache on Retry [#1348]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The types of changes are:
 * Remove masking of redis error log [#1288](https://github.com/ethyca/fidesops/pull/1288)
 * Logout with malformed or expired token [#1305](https://github.com/ethyca/fidesops/pull/1305)
 * The `toml` package is now included in the list of direct dependencies (`requirements.txt`) [#1338](https://github.com/ethyca/fidesops/pull/1338)
+* Fix bug where erasure counts instead of access results may be retrieved for certain collections on request retry [#1349](https://github.com/ethyca/fidesops/pull/1349)
 
 ### Security
 

--- a/src/fidesops/ops/task/task_resources.py
+++ b/src/fidesops/ops/task/task_resources.py
@@ -131,8 +131,10 @@ class TaskResources:
         self.cache.set_encoded_object(f"{self.request.id}__{key}", value)
 
     def get_all_cached_objects(self) -> Dict[str, Optional[List[Row]]]:
-        """Retrieve the results of all steps (cache_object)"""
-        value_dict = self.cache.get_encoded_objects_by_prefix(self.request.id)
+        """Retrieve the access results of all steps (cache_object)"""
+        value_dict = self.cache.get_encoded_objects_by_prefix(
+            f"{self.request.id}__access_request"
+        )
         # extract request id to return a map of address:value
         return {k.split("__")[-1]: v for k, v in value_dict.items()}
 

--- a/tests/ops/task/test_task_resources.py
+++ b/tests/ops/task/test_task_resources.py
@@ -2,6 +2,30 @@ from fidesops.ops.task.task_resources import TaskResources
 
 
 class TestTaskResources:
+    def test_cache_object(self, db, privacy_request, policy, integration_manual_config):
+        resources = TaskResources(
+            privacy_request, policy, [integration_manual_config], db
+        )
+
+        assert resources.get_all_cached_objects() == {}
+
+        resources.cache_object(
+            "access_request__postgres_example:customer", [{"id": 1, "last_name": "Doe"}]
+        )
+        resources.cache_object(
+            "access_request__postgres_example:payment",
+            [{"id": 2, "ccn": "111-111-1111-1111", "customer_id": 1}],
+        )
+        resources.cache_erasure("manual_example:filing-cabinet", 2)
+
+        # Only access results from "cache_object" are returned
+        assert resources.get_all_cached_objects() == {
+            "postgres_example:payment": [
+                {"id": 2, "ccn": "111-111-1111-1111", "customer_id": 1}
+            ],
+            "postgres_example:customer": [{"id": 1, "last_name": "Doe"}],
+        }
+
     def test_cache_erasure(
         self, db, privacy_request, policy, integration_manual_config
     ):


### PR DESCRIPTION
# Purpose

Fix bug where erasure count confirmations may be returned instead of selected access request results when attempting to get access requests from the cache.

Because erasure requests are run after access requests, there normally aren't erasure results in the cache when we attempt to get access results.  However, it's possible to run into this in the case of "restarting a privacy request from failure".  If we were retrying a privacy request from a checkpoint that had already erased some data, we could possibly return erasure results instead of access results for selected collections, depending on if the access or erasure key was accessed last.

# Changes
-  Be more specific about the key's prefix when retrieving access results with `TaskResources.get_all_cached_objects` instead of using a key prefix that overlaps with erasure results.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1348 
 
