### PR TITLE
Fix Redis Cache Expiring Prematurely in Tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.7.2...main)
 
+
+### Fixed
+* Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)
+* Fix Redis Cache Early Expiration in Tests [#1358](https://github.com/ethyca/fidesops/pull/1358)
+
 ## [1.8.0](https://github.com/ethyca/fidesops/compare/1.8.0...main)
 
 ### Developer Experience
@@ -90,7 +95,6 @@ The types of changes are:
 * Remove masking of redis error log [#1288](https://github.com/ethyca/fidesops/pull/1288)
 * Logout with malformed or expired token [#1305](https://github.com/ethyca/fidesops/pull/1305)
 * The `toml` package is now included in the list of direct dependencies (`requirements.txt`) [#1338](https://github.com/ethyca/fidesops/pull/1338)
-* Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)
 * Fix bug where erasure counts instead of access results may be retrieved for certain collections on request retry [#1349](https://github.com/ethyca/fidesops/pull/1349)
 
 ### Security

--- a/tests/ops/fixtures/application_fixtures.py
+++ b/tests/ops/fixtures/application_fixtures.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from fidesops.ops.api.v1.scope_registry import PRIVACY_REQUEST_READ, SCOPE_REGISTRY
-from fidesops.ops.core.config import config
+from fidesops.ops.core.config import FidesopsConfig, config
 from fidesops.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -1257,3 +1257,13 @@ def application_user(
     oauth_client.save(db=db)
     yield user
     user.delete(db=db)
+
+
+@pytest.fixture(scope="function")
+def short_redis_cache_expiration() -> FidesopsConfig:
+    original_value: int = config.redis.default_ttl_seconds
+    config.redis.default_ttl_seconds = (
+        1  # Set redis cache to expire very quickly for testing purposes
+    )
+    yield config
+    config.redis.default_ttl_seconds = original_value

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -13,8 +13,6 @@ from sqlalchemy.orm import Session
 
 from fidesops.ops.common_exceptions import (
     ClientUnsuccessfulException,
-    EmailDispatchException,
-    IdentityNotFoundException,
     PrivacyRequestPaused,
 )
 from fidesops.ops.core.config import config
@@ -1472,10 +1470,8 @@ class TestRunPrivacyRequestRunsWebhooks:
         db,
         privacy_request,
         policy_pre_execution_webhooks,
+        short_redis_cache_expiration,  # Fixture forces cache to expire quickly
     ):
-        config.redis.default_ttl_seconds = (
-            1  # Set redis cache to expire very quickly for testing purposes
-        )
         mock_trigger_policy_webhook.side_effect = PrivacyRequestPaused(
             "Request received to halt"
         )


### PR DESCRIPTION
# Purpose

https://github.com/ethyca/fidesops/actions/runs/3091373106/attempts/1

We have a pre-existing test that sets the redis default expiration to one second without setting it back.  A manual webhook test is sporadically failing that relies on this cache.   

My theory is that this existing bad test runs late in the cycle so most other tests that use the cache aren't affected. This webhook test can sometimes take more than a second and it fails if the existing test has run first. 


# Changes
- In an existing test, use a fixture to set the default redis expiration and then reset after the test is finished.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1359 
 
