### PR TITLE
Updating offset pagination strategy to parse numeric strings as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 ### Fixed
 * Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)
 * Fix Redis Cache Early Expiration in Tests [#1358](https://github.com/ethyca/fidesops/pull/1358)
+* Limit values for the offset pagination strategy are now cast to integers before use [#1364](https://github.com/ethyca/fidesops/pull/1364)
 
 ### Added
 

--- a/src/fidesops/ops/service/pagination/pagination_strategy_offset.py
+++ b/src/fidesops/ops/service/pagination/pagination_strategy_offset.py
@@ -53,6 +53,12 @@ class OffsetPaginationStrategy(PaginationStrategy):
                 raise FidesopsException(
                     f"Unable to find value for 'limit' with the connector_param reference '{self.limit.connector_param}'"
                 )
+            try:
+                limit = int(limit)
+            except ValueError:
+                raise FidesopsException(
+                    f"The value '{limit}' of the '{self.limit.connector_param}' connector_param could not be cast to an int"
+                )
         param_value += self.increment_by
         if param_value > limit:
             return None


### PR DESCRIPTION
# Purpose
ConnectionConfig secret values might be stored as strings, but when these values are used in the offset pagination strategy, they need to be converted back to integers. This update casts numeric strings to integers or throws a validation error if the string cannot be cast to an integer.

# Changes
- Added str to int conversion in the offset pagination strategy and added the appropriate tests

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
- [x] Good unit test/integration test coverage
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
 
