### PR TITLE
Set Schema for Postgres Connector [#1362]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 
 * `api_key` auth strategy for SaaS connectors [#1331](https://github.com/ethyca/fidesops/pull/1331)
 * Access support for Rollbar [#1361](https://github.com/ethyca/fidesops/pull/1361)
+* Allow querying the non-default schema with the Postgres Connector [#1367](https://github.com/ethyca/fidesops/pull/1367)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The types of changes are:
 
 * `api_key` auth strategy for SaaS connectors [#1331](https://github.com/ethyca/fidesops/pull/1331)
 * Access support for Rollbar [#1361](https://github.com/ethyca/fidesops/pull/1361)
-* Allow querying the non-default schema with the Postgres Connector [#1367](https://github.com/ethyca/fidesops/pull/1367)
+* Allow querying the non-default schema with the Postgres Connector [#1375](https://github.com/ethyca/fidesops/pull/1375)
 
 ### Removed
 

--- a/docker/sample_data/postgres_example.sql
+++ b/docker/sample_data/postgres_example.sql
@@ -175,3 +175,25 @@ INSERT INTO public.report VALUES
 INSERT INTO public.type_link_test VALUES
 ('1', 'name1'),
 ('2', 'name2');
+
+
+CREATE SCHEMA backup_schema;
+CREATE TABLE  backup_schema.product (LIKE public.product INCLUDING ALL);
+CREATE TABLE  backup_schema.address (LIKE public.address INCLUDING ALL);
+CREATE TABLE  backup_schema.customer (LIKE public.customer INCLUDING ALL);
+CREATE TABLE  backup_schema.employee (LIKE public.employee INCLUDING ALL);
+CREATE TABLE  backup_schema.payment_card (LIKE public.payment_card INCLUDING ALL);
+CREATE TABLE  backup_schema.orders (LIKE public.orders INCLUDING ALL);
+CREATE TABLE  backup_schema.order_item (LIKE public.order_item INCLUDING ALL);
+CREATE TABLE  backup_schema.visit (LIKE public.visit INCLUDING ALL);
+CREATE TABLE  backup_schema.login (LIKE public.login INCLUDING ALL);
+CREATE TABLE  backup_schema.service_request (LIKE public.service_request INCLUDING ALL);
+CREATE TABLE  backup_schema.report (LIKE public.report INCLUDING ALL);
+CREATE TABLE  backup_schema.composite_pk_test (LIKE public.composite_pk_test INCLUDING ALL);
+CREATE TABLE  backup_schema.type_link_test (LIKE public.type_link_test INCLUDING ALL);
+
+INSERT INTO backup_schema.customer VALUES
+(1, 'customer-500@example.com', 'Johanna Customer', '2022-05-01 12:22:11', 7);
+
+INSERT INTO backup_schema.address VALUES
+(7, '311', 'Test Street', 'Test Town', 'TX', '79843');

--- a/src/fidesops/ops/schemas/connection_configuration/connection_secrets_postgres.py
+++ b/src/fidesops/ops/schemas/connection_configuration/connection_secrets_postgres.py
@@ -12,6 +12,7 @@ class PostgreSQLSchema(ConnectionConfigSecretsSchema):
     username: Optional[str] = None
     password: Optional[str] = None
     dbname: Optional[str] = None
+    db_schema: Optional[str] = None
     host: Optional[
         str
     ] = None  # Either the entire "url" *OR* the "host" should be supplied.

--- a/src/fidesops/ops/service/connectors/sql_connector.py
+++ b/src/fidesops/ops/service/connectors/sql_connector.py
@@ -56,6 +56,7 @@ class SQLConnector(BaseConnector[Engine]):
     secrets_schema: Type[ConnectionConfigSecretsSchema]
 
     def __init__(self, configuration: ConnectionConfig):
+        """Instantiate a SQL-based connector"""
         super().__init__(configuration)
         if not self.secrets_schema:
             raise NotImplementedError(
@@ -174,7 +175,7 @@ class SQLConnector(BaseConnector[Engine]):
 
     def set_schema(self, connection: Connection) -> None:
         """Optionally override to set the schema for a given database that
-        persist through the entire session"""
+        persists through the entire session"""
 
 
 class PostgreSQLConnector(SQLConnector):

--- a/src/fidesops/ops/service/connectors/sql_connector.py
+++ b/src/fidesops/ops/service/connectors/sql_connector.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from snowflake.sqlalchemy import URL as Snowflake_URL
 from sqlalchemy import Column, text
@@ -18,10 +18,11 @@ from sqlalchemy.sql.elements import TextClause
 
 from fidesops.ops.common_exceptions import ConnectionException
 from fidesops.ops.graph.traversal import Row, TraversalNode
-from fidesops.ops.models.connectionconfig import ConnectionTestStatus
+from fidesops.ops.models.connectionconfig import ConnectionConfig, ConnectionTestStatus
 from fidesops.ops.models.policy import Policy
 from fidesops.ops.models.privacy_request import PrivacyRequest
 from fidesops.ops.schemas.connection_configuration import (
+    ConnectionConfigSecretsSchema,
     MicrosoftSQLServerSchema,
     PostgreSQLSchema,
     RedshiftSchema,
@@ -51,6 +52,15 @@ logger = logging.getLogger(__name__)
 class SQLConnector(BaseConnector[Engine]):
     """A SQL connector represents an abstract connector to any datastore that can be
     interacted with via standard SQL via SQLAlchemy"""
+
+    secrets_schema: Type[ConnectionConfigSecretsSchema]
+
+    def __init__(self, configuration: ConnectionConfig):
+        super().__init__(configuration)
+        if not self.secrets_schema:
+            raise NotImplementedError(
+                "SQL Connectors must define their secrets schema class"
+            )
 
     @staticmethod
     def cursor_result_to_rows(results: CursorResult) -> List[Row]:
@@ -119,6 +129,7 @@ class SQLConnector(BaseConnector[Engine]):
             return []
         logger.info("Starting data retrieval for %s", node.address)
         with client.connect() as connection:
+            self.set_schema(connection)
             results = connection.execute(stmt)
             return self.cursor_result_to_rows(results)
 
@@ -140,6 +151,7 @@ class SQLConnector(BaseConnector[Engine]):
             )
             if update_stmt is not None:
                 with client.connect() as connection:
+                    self.set_schema(connection)
                     results: LegacyCursorResult = connection.execute(update_stmt)
                     update_ct = update_ct + results.rowcount
         return update_ct
@@ -150,13 +162,29 @@ class SQLConnector(BaseConnector[Engine]):
             logger.debug(" disposing of %s", self.__class__)
             self.db_client.dispose()
 
+    def create_client(self) -> Engine:
+        """Returns a SQLAlchemy Engine that can be used to interact with a database"""
+        config = self.secrets_schema(**self.configuration.secrets or {})
+        uri = config.url or self.build_uri()
+        return create_engine(
+            uri,
+            hide_parameters=self.hide_parameters,
+            echo=not self.hide_parameters,
+        )
+
+    def set_schema(self, connection: Connection) -> None:
+        """Optionally override to set the schema for a given database that
+        persist through the entire session"""
+
 
 class PostgreSQLConnector(SQLConnector):
     """Connector specific to postgresql"""
 
+    secrets_schema = PostgreSQLSchema
+
     def build_uri(self) -> str:
         """Build URI of format postgresql://[user[:password]@][netloc][:port][/dbname]"""
-        config = PostgreSQLSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
@@ -169,23 +197,24 @@ class PostgreSQLConnector(SQLConnector):
         dbname = f"/{config.dbname}" if config.dbname else ""
         return f"postgresql://{user_password}{netloc}{port}{dbname}"
 
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with a PostgreSQL database"""
-        config = PostgreSQLSchema(**self.configuration.secrets or {})
-        uri = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
+    def set_schema(self, connection: Connection) -> None:
+        """Sets the schema for a postgres database if applicable"""
+        config = self.secrets_schema(**self.configuration.secrets or {})
+        if config.db_schema:
+            logger.info("Setting PostgreSQL search_path before retrieving data")
+            stmt = text("SET search_path to :search_path")
+            stmt = stmt.bindparams(search_path=config.db_schema)
+            connection.execute(stmt)
 
 
 class MySQLConnector(SQLConnector):
     """Connector specific to MySQL"""
 
+    secrets_schema = MySQLSchema
+
     def build_uri(self) -> str:
         """Build URI of format mysql+pymysql://[user[:password]@][netloc][:port][/dbname]"""
-        config = MySQLSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
@@ -199,16 +228,6 @@ class MySQLConnector(SQLConnector):
         url = f"mysql+pymysql://{user_password}{netloc}{port}{dbname}"
         return url
 
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with a MySQL database"""
-        config = MySQLSchema(**self.configuration.secrets or {})
-        uri = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
-
     @staticmethod
     def cursor_result_to_rows(results: LegacyCursorResult) -> List[Row]:
         """
@@ -220,9 +239,11 @@ class MySQLConnector(SQLConnector):
 class MariaDBConnector(SQLConnector):
     """Connector specific to MariaDB"""
 
+    secrets_schema = MariaDBSchema
+
     def build_uri(self) -> str:
         """Build URI of format mariadb+pymysql://[user[:password]@][netloc][:port][/dbname]"""
-        config = MariaDBSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
@@ -236,16 +257,6 @@ class MariaDBConnector(SQLConnector):
         url = f"mariadb+pymysql://{user_password}{netloc}{port}{dbname}"
         return url
 
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with a MariaDB database"""
-        config = MariaDBSchema(**self.configuration.secrets or {})
-        uri = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
-
     @staticmethod
     def cursor_result_to_rows(results: LegacyCursorResult) -> List[Row]:
         """
@@ -257,88 +268,26 @@ class MariaDBConnector(SQLConnector):
 class RedshiftConnector(SQLConnector):
     """Connector specific to Amazon Redshift"""
 
+    secrets_schema = RedshiftSchema
+
     # Overrides BaseConnector.build_uri
     def build_uri(self) -> str:
         """Build URI of format redshift+psycopg2://user:password@[host][:port][/database]"""
-        config = RedshiftSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         port = f":{config.port}" if config.port else ""
         database = f"/{config.database}" if config.database else ""
         url = f"redshift+psycopg2://{config.user}:{config.password}@{config.host}{port}{database}"
         return url
 
-    # Overrides SQLConnector.create_client
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with an Amazon Redshift cluster"""
-        config = RedshiftSchema(**self.configuration.secrets or {})
-        uri = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
-
     def set_schema(self, connection: Connection) -> None:
         """Sets the search_path for the duration of the session"""
-        config = RedshiftSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
         if config.db_schema:
             logger.info("Setting Redshift search_path before retrieving data")
             stmt = text("SET search_path to :search_path")
             stmt = stmt.bindparams(search_path=config.db_schema)
             connection.execute(stmt)
-
-    # Overrides SQLConnector.retrieve_data
-    def retrieve_data(
-        self,
-        node: TraversalNode,
-        policy: Policy,
-        privacy_request: PrivacyRequest,
-        input_data: Dict[str, List[Any]],
-    ) -> List[Row]:
-        """Retrieve data from Amazon Redshift
-
-        For redshift, we also set the search_path to be the schema defined on the ConnectionConfig if
-        applicable - persists for the current session.
-        """
-        query_config = self.query_config(node)
-        client = self.client()
-        stmt = query_config.generate_query(input_data, policy)
-        if stmt is None:
-            return []
-
-        logger.info("Starting data retrieval for %s", node.address)
-        with client.connect() as connection:
-            self.set_schema(connection)
-            results = connection.execute(stmt)
-            return SQLConnector.cursor_result_to_rows(results)
-
-    # Overrides SQLConnector.mask_data
-    def mask_data(
-        self,
-        node: TraversalNode,
-        policy: Policy,
-        privacy_request: PrivacyRequest,
-        rows: List[Row],
-        input_data: Dict[str, List[Any]],
-    ) -> int:
-        """Execute a masking request. Returns the number of records masked
-
-        For redshift, we also set the search_path to be the schema defined on the ConnectionConfig if
-        applicable - persists for the current session.
-        """
-        query_config = self.query_config(node)
-        update_ct = 0
-        client = self.client()
-        for row in rows:
-            update_stmt = query_config.generate_update_stmt(
-                row, policy, privacy_request
-            )
-            if update_stmt is not None:
-                with client.connect() as connection:
-                    self.set_schema(connection)
-                    results: LegacyCursorResult = connection.execute(update_stmt)
-                    update_ct = update_ct + results.rowcount
-        return update_ct
 
     # Overrides SQLConnector.query_config
     def query_config(self, node: TraversalNode) -> RedshiftQueryConfig:
@@ -349,19 +298,23 @@ class RedshiftConnector(SQLConnector):
 class BigQueryConnector(SQLConnector):
     """Connector specific to Google BigQuery"""
 
+    secrets_schema = BigQuerySchema
+
     # Overrides BaseConnector.build_uri
     def build_uri(self) -> str:
         """Build URI of format"""
-        config = BigQuerySchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
         dataset = f"/{config.dataset}" if config.dataset else ""
         return f"bigquery://{config.keyfile_creds.project_id}{dataset}"
 
     # Overrides SQLConnector.create_client
     def create_client(self) -> Engine:
         """
-        Returns a SQLAlchemy Engine that can be used to interact with Google BigQuery
+        Returns a SQLAlchemy Engine that can be used to interact with Google BigQuery.
+
+        Overrides to pass in credentials_info
         """
-        config = BigQuerySchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
         uri = config.url or self.build_uri()
 
         return create_engine(
@@ -402,11 +355,13 @@ class BigQueryConnector(SQLConnector):
 class SnowflakeConnector(SQLConnector):
     """Connector specific to Snowflake"""
 
+    secrets_schema = SnowflakeSchema
+
     def build_uri(self) -> str:
         """Build URI of format 'snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/
         <schema_name>?warehouse=<warehouse_name>&role=<role_name>'
         """
-        config = SnowflakeSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         kwargs = {}
 
@@ -428,16 +383,6 @@ class SnowflakeConnector(SQLConnector):
         url: str = Snowflake_URL(**kwargs)
         return url
 
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with Snowflake"""
-        config = SnowflakeSchema(**self.configuration.secrets or {})
-        uri: str = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
-
     def query_config(self, node: TraversalNode) -> SQLQueryConfig:
         """Query wrapper corresponding to the input traversal_node."""
         return SnowflakeQueryConfig(node)
@@ -448,6 +393,8 @@ class MicrosoftSQLServerConnector(SQLConnector):
     Connector specific to Microsoft SQL Server
     """
 
+    secrets_schema = MicrosoftSQLServerSchema
+
     def build_uri(self) -> URL:
         """
         Build URI of format
@@ -455,7 +402,7 @@ class MicrosoftSQLServerConnector(SQLConnector):
         Returns URL obj, since SQLAlchemy's create_engine method accepts either a URL obj or a string
         """
 
-        config = MicrosoftSQLServerSchema(**self.configuration.secrets or {})
+        config = self.secrets_schema(**self.configuration.secrets or {})
 
         url = URL.create(
             "mssql+pyodbc",
@@ -468,16 +415,6 @@ class MicrosoftSQLServerConnector(SQLConnector):
         )
 
         return url
-
-    def create_client(self) -> Engine:
-        """Returns a SQLAlchemy Engine that can be used to interact with a MicrosoftSQLServer database"""
-        config = MicrosoftSQLServerSchema(**self.configuration.secrets or {})
-        uri = config.url or self.build_uri()
-        return create_engine(
-            uri,
-            hide_parameters=self.hide_parameters,
-            echo=not self.hide_parameters,
-        )
 
     def query_config(self, node: TraversalNode) -> SQLQueryConfig:
         """Query wrapper corresponding to the input traversal_node."""

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -958,6 +958,7 @@ class TestPutConnectionConfigSecrets:
             "username": None,
             "password": None,
             "url": None,
+            "db_schema": None,
         }
 
         payload = {"url": "postgresql://test_user:test_pass@localhost:1234/my_test_db"}
@@ -979,6 +980,7 @@ class TestPutConnectionConfigSecrets:
             "username": None,
             "password": None,
             "url": payload["url"],
+            "db_schema": None,
         }
         assert connection_config.last_test_timestamp is None
         assert connection_config.last_test_succeeded is None

--- a/tests/ops/integration_tests/test_connection_configuration_integration.py
+++ b/tests/ops/integration_tests/test_connection_configuration_integration.py
@@ -70,6 +70,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "username": None,
             "password": None,
             "url": None,
+            "db_schema": None,
         }
         assert connection_config.last_test_timestamp is not None
         assert connection_config.last_test_succeeded is False
@@ -88,6 +89,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "dbname": "postgres_example",
             "username": "postgres",
             "password": "postgres",
+            "db_schema": None,
         }
 
         auth_header = generate_auth_header(scopes=[CONNECTION_CREATE_OR_UPDATE])
@@ -113,6 +115,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "username": "postgres",
             "password": "postgres",
             "url": None,
+            "db_schema": None,
         }
         assert connection_config.last_test_timestamp is not None
         assert connection_config.last_test_succeeded is True
@@ -153,6 +156,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "username": None,
             "password": None,
             "url": payload["url"],
+            "db_schema": None,
         }
         assert connection_config.last_test_timestamp is not None
         assert connection_config.last_test_succeeded is True

--- a/tests/ops/integration_tests/test_sql_task.py
+++ b/tests/ops/integration_tests/test_sql_task.py
@@ -372,9 +372,7 @@ async def test_postgres_privacy_requests_against_non_default_schema(
 ) -> None:
     """Assert that the postgres connector can make access and erasure requests against the non-default (public) schema"""
 
-    privacy_request = PrivacyRequest(
-        id=f"test_postgres_access_request_task_{random.randint(0, 100000)}"
-    )
+    privacy_request = PrivacyRequest(id=str(uuid4()))
     database_name = "postgres_backup"
     customer_email = "customer-500@example.com"
 

--- a/tests/ops/integration_tests/test_sql_task.py
+++ b/tests/ops/integration_tests/test_sql_task.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy import text
 
 from fidesops.ops.core.config import config
 from fidesops.ops.graph.config import (
@@ -359,6 +360,93 @@ async def test_postgres_access_request_task(
         )
         > 0
     )
+
+
+@pytest.mark.integration_postgres
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_postgres_privacy_requests_against_non_default_schema(
+    db,
+    policy,
+    postgres_connection_config_with_schema,
+    postgres_integration_db,
+    erasure_policy,
+) -> None:
+    """Assert that the postgres connector can make access and erasure requests against the non-default (public) schema"""
+
+    privacy_request = PrivacyRequest(
+        id=f"test_postgres_access_request_task_{random.randint(0, 100000)}"
+    )
+    database_name = "postgres_backup"
+    customer_email = "customer-500@example.com"
+
+    dataset = integration_db_dataset(
+        database_name, postgres_connection_config_with_schema.key
+    )
+    graph = DatasetGraph(dataset)
+
+    access_results = await graph_task.run_access_request(
+        privacy_request,
+        policy,
+        graph,
+        [postgres_connection_config_with_schema],
+        {"email": customer_email},
+        db,
+    )
+
+    # Confirm data retrieved from backup_schema, not public schema. This data only exists in the backup_schema.
+    assert access_results == {
+        f"{database_name}:address": [
+            {
+                "id": 7,
+                "street": "Test Street",
+                "city": "Test Town",
+                "state": "TX",
+                "zip": "79843",
+            }
+        ],
+        f"{database_name}:payment_card": [],
+        f"{database_name}:orders": [],
+        f"{database_name}:customer": [
+            {
+                "id": 1,
+                "name": "Johanna Customer",
+                "email": "customer-500@example.com",
+                "address_id": 7,
+            }
+        ],
+    }
+
+    rule = erasure_policy.rules[0]
+    target = rule.targets[0]
+    target.data_category = "user"
+    target.save(db)
+    # Update data category on customer name
+    field([dataset], database_name, "customer", "name").data_categories = ["user.name"]
+
+    erasure_results = await graph_task.run_erasure(
+        privacy_request,
+        erasure_policy,
+        graph,
+        [postgres_connection_config_with_schema],
+        {"email": customer_email},
+        get_cached_data_for_erasures(privacy_request.id),
+        db,
+    )
+
+    # Confirm record masked in non-default schema
+    assert erasure_results == {
+        f"{database_name}:customer": 1,
+        f"{database_name}:payment_card": 0,
+        f"{database_name}:orders": 0,
+        f"{database_name}:address": 0,
+    }, "Only one record on customer table has targeted data category"
+    customer_records = postgres_integration_db.execute(
+        text("select * from backup_schema.customer where id = 1;")
+    )
+    johanna_record = [c for c in customer_records][0]
+    assert johanna_record.email == customer_email  # Not masked
+    assert johanna_record.name is None  # Masked by erasure request
 
 
 @pytest.mark.integration_mssql


### PR DESCRIPTION
# Purpose

Our current PostgreSQL connector can only query the default postgres schema (`public`).  Add support for:

1) the schema to be specified as a Postgres secret
2) Set the schema for the duration of the session when making access or erasure requests for the given connector

# Changes
- Add db_schema as an optional postgres secret.
- Add an empty `set_schema` method on the Base SQL Connector that can optionally be added on a subclass to set a schema for an entire session.
- Define `PostgreSQLConnector.set_schema `to set the search path
- Add a required `secrets_schema` property to be defined on every SQLConnector
- Move "create_client" to the base SQLConnector and remove most locations where it was overridden because the primary element that was changing was the secrets schema.
- Remove Redshift overrides for `retrieve_data` and `mask_data` since their only purposes are to set the schema, which the base sql connector can now do.
- On startup of the postgres example database, add a second schema, `backup_schema`, which contains the same tables as the `public` schema, but only has a few tables populated with sparse rows.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1362 
 
