### PR TITLE
1016 frontend ability for users to manually enter pii to an in progress subject request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 * Access support for Rollbar [#1361](https://github.com/ethyca/fidesops/pull/1361)
 * Adds a new Timescale connector [#1327](https://github.com/ethyca/fidesops/pull/1327)
 * Allow querying the non-default schema with the Postgres Connector [#1375](https://github.com/ethyca/fidesops/pull/1375)
+* Frontend - ability for users to manually enter PII to an IN PROGRESS subject request [#1016](https://github.com/ethyca/fidesops/pull/1377)
 
 ### Removed
 

--- a/clients/ops/admin-ui/package-lock.json
+++ b/clients/ops/admin-ui/package-lock.json
@@ -6078,13 +6078,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001314",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
-      "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -17191,9 +17197,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001314",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
-      "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw=="
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg=="
     },
     "chalk": {
       "version": "4.1.2",

--- a/clients/ops/admin-ui/src/features/datastore-connections/add-connection/ConfigureConnector.tsx
+++ b/clients/ops/admin-ui/src/features/datastore-connections/add-connection/ConfigureConnector.tsx
@@ -26,7 +26,7 @@ const ConfigureConnector: React.FC = () => {
   const [steps, setSteps] = useState([STEPS[0], STEPS[1], STEPS[2]]);
   const [canRedirect, setCanRedirect] = useState(false);
 
-  const { connection, connectionOption } = useAppSelector(
+  const { connection, connectionOption, step } = useAppSelector(
     selectConnectionTypeState
   );
 
@@ -43,10 +43,9 @@ const ConfigureConnector: React.FC = () => {
     (value: string) => {
       switch (value) {
         case ConfigurationSettings.DATASET_CONFIGURATION:
+        case ConfigurationSettings.DSR_CUSTOMIZATION:
           dispatch(setStep(STEPS[3]));
           setSteps([STEPS[0], STEPS[1], STEPS[3]]);
-          break;
-        case ConfigurationSettings.DSR_CUSTOMIZATION:
           break;
         case ConfigurationSettings.CONNECTOR_PARAMETERS:
         default:
@@ -68,6 +67,12 @@ const ConfigureConnector: React.FC = () => {
   }, [dispatch]);
 
   useEffect(() => {
+    if (step) {
+      setSelectedItem(
+        connector?.options[Number(step.stepId) - connector.options.length]
+      );
+    }
+
     // If a connection has been initially created, then auto redirect the user accordingly.
     if (connection?.key && canRedirect) {
       handleNavChange(
@@ -77,7 +82,14 @@ const ConfigureConnector: React.FC = () => {
       );
       setCanRedirect(false);
     }
-  }, [canRedirect, connection, connectionOption?.type, handleNavChange]);
+  }, [
+    canRedirect,
+    connection?.key,
+    connectionOption?.type,
+    connector?.options,
+    handleNavChange,
+    step,
+  ]);
 
   return (
     <>

--- a/clients/ops/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/ops/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -48,6 +48,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   const [yamlError, setYamlError] = useState(
     undefined as unknown as YAMLException
   );
+  const [isTouched, setIsTouched] = useState(false);
   const [isEmptyState, setIsEmptyState] = useState(!yamlData);
 
   const validate = (value: string) => {
@@ -57,6 +58,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
 
   const handleChange = (value: string | undefined) => {
     try {
+      setIsTouched(true);
       validate(value as string);
       setIsEmptyState(!!(!value || value.trim() === ""));
     } catch (error) {
@@ -131,7 +133,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           </Button>
         </ButtonGroup>
       </VStack>
-      {(isEmptyState || yamlError) && (
+      {isTouched && (isEmptyState || yamlError) && (
         <SlideFade in>
           <Box w="fit-content">
             <Divider color="gray.100" />

--- a/clients/ops/admin-ui/src/features/datastore-connections/add-connection/manual/DSRCustomization.tsx
+++ b/clients/ops/admin-ui/src/features/datastore-connections/add-connection/manual/DSRCustomization.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/router";
 import React, { useEffect, useRef, useState } from "react";
 import { DATASTORE_CONNECTION_ROUTE } from "src/constants";
 
+import { replaceURL } from "../helpers";
 import DSRCustomizationForm from "./DSRCustomizationForm";
 import { Field } from "./types";
 
@@ -26,7 +27,7 @@ const DSRCustomization: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fields, setFields] = useState([] as Field[]);
 
-  const { connection } = useAppSelector(selectConnectionTypeState);
+  const { connection, step } = useAppSelector(selectConnectionTypeState);
 
   const { data, isFetching, isLoading, isSuccess } =
     useGetAccessManualHookQuery(connection!.key);
@@ -65,10 +66,13 @@ const DSRCustomization: React.FC = () => {
     if (isSuccess && data) {
       setFields(data.fields);
     }
+    if (connection?.key) {
+      replaceURL(connection.key, step.href);
+    }
     return () => {
       mounted.current = false;
     };
-  }, [data, isSuccess]);
+  }, [connection?.key, data, isSuccess, step.href]);
 
   return (
     <VStack align="stretch" gap="24px">

--- a/clients/ops/admin-ui/src/features/datastore-connections/add-connection/manual/DSRCustomizationForm.tsx
+++ b/clients/ops/admin-ui/src/features/datastore-connections/add-connection/manual/DSRCustomizationForm.tsx
@@ -57,10 +57,16 @@ const DSRCustomizationForm: React.FC<DSRCustomizationFormProps> = ({
       validationSchema={Yup.object({
         fields: Yup.array().of(
           Yup.object().shape({
-            pii_field: Yup.string().required("PII Field is required"),
-            dsr_package_label: Yup.string().required(
-              "DSR Package Label is required"
-            ),
+            pii_field: Yup.string()
+              .required("PII Field is required")
+              .min(1, "PII Field must have at least one character")
+              .max(200, "PII Field has a maximum of 200 characters")
+              .label("PII Field"),
+            dsr_package_label: Yup.string()
+              .required("DSR Package Label is required")
+              .min(1, "DSR Package Label must have at least one character")
+              .max(200, "DSR Package Label has a maximum of 200 characters")
+              .label("DSR Package Label"),
           })
         ),
       })}

--- a/clients/ops/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/ops/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -26,6 +26,7 @@ import {
   DatastoreConnectionsResponse,
   DatastoreConnectionStatus,
   GetAccessManualWebhookResponse,
+  GetAllEnabledAccessManualWebhooksResponse,
   PatchAccessManualWebhookRequest,
   PatchAccessManualWebhookResponse,
   PatchDatasetsRequest,
@@ -207,6 +208,15 @@ export const datastoreConnectionApi = createApi({
       }),
       providesTags: () => ["DatastoreConnection"],
     }),
+    getAllEnabledAccessManualHooks: build.query<
+      GetAllEnabledAccessManualWebhooksResponse,
+      void
+    >({
+      query: () => ({
+        url: `access_manual_webhook`,
+      }),
+      providesTags: () => ["DatastoreConnection"],
+    }),
     getDatastoreConnectionByKey: build.query<DatastoreConnection, string>({
       query: (key) => ({
         url: `${CONNECTION_ROUTE}/${key}`,
@@ -322,6 +332,7 @@ export const {
   useCreateAccessManualWebhookMutation,
   useCreateSassConnectionConfigMutation,
   useGetAccessManualHookQuery,
+  useGetAllEnabledAccessManualHooksQuery,
   useGetAllDatastoreConnectionsQuery,
   useGetDatasetsQuery,
   useGetDatastoreConnectionByKeyQuery,

--- a/clients/ops/admin-ui/src/features/datastore-connections/types.ts
+++ b/clients/ops/admin-ui/src/features/datastore-connections/types.ts
@@ -42,6 +42,9 @@ export type CreateAccessManualWebhookResponse = {
   id: string;
 };
 
+export type GetAllEnabledAccessManualWebhooksResponse =
+  GetAccessManualWebhookResponse[];
+
 export type GetAccessManualWebhookResponse = CreateAccessManualWebhookResponse;
 
 export type PatchAccessManualWebhookRequest = CreateAccessManualWebhookRequest;

--- a/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -8,6 +8,7 @@ import { selectToken } from "../auth";
 import {
   DenyPrivacyRequest,
   GetUpdloadedManualWebhookDataRequest,
+  PatchUploadManualWebhookDataRequest,
   PrivacyRequest,
   PrivacyRequestParams,
   PrivacyRequestResponse,
@@ -116,6 +117,17 @@ export const privacyRequestApi = createApi({
       }),
       invalidatesTags: ["Request"],
     }),
+    uploadManualWebhookData: build.mutation<
+      any,
+      PatchUploadManualWebhookDataRequest
+    >({
+      query: (params) => ({
+        url: `privacy-request/${params.privacy_request_id}/access_manual_webhook/${params.connection_key}`,
+        method: "PATCH",
+        body: params.body,
+      }),
+      invalidatesTags: ["Request"],
+    }),
   }),
 });
 
@@ -125,6 +137,7 @@ export const {
   useGetAllPrivacyRequestsQuery,
   useGetUploadedManualWebhookDataQuery,
   useRetryMutation,
+  useUploadManualWebhookDataMutation,
 } = privacyRequestApi;
 
 export const requestCSVDownload = async ({

--- a/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -108,7 +108,13 @@ export const privacyRequestApi = createApi({
       query: (params) => ({
         url: `privacy-request/${params.privacy_request_id}/access_manual_webhook/${params.connection_key}`,
       }),
-      providesTags: () => ["Request"],
+    }),
+    resumePrivacyRequestFromRequiresInput: build.mutation<any, string>({
+      query: (privacy_request_id) => ({
+        url: `privacy-request/${privacy_request_id}/resume_from_requires_input`,
+        method: "POST",
+      }),
+      invalidatesTags: ["Request"],
     }),
     retry: build.mutation<PrivacyRequest, Pick<PrivacyRequest, "id">>({
       query: ({ id }) => ({
@@ -126,7 +132,6 @@ export const privacyRequestApi = createApi({
         method: "PATCH",
         body: params.body,
       }),
-      invalidatesTags: ["Request"],
     }),
   }),
 });
@@ -136,6 +141,7 @@ export const {
   useDenyRequestMutation,
   useGetAllPrivacyRequestsQuery,
   useGetUploadedManualWebhookDataQuery,
+  useResumePrivacyRequestFromRequiresInputMutation,
   useRetryMutation,
   useUploadManualWebhookDataMutation,
 } = privacyRequestApi;

--- a/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -7,6 +7,7 @@ import { BASE_URL } from "../../constants";
 import { selectToken } from "../auth";
 import {
   DenyPrivacyRequest,
+  GetUpdloadedManualWebhookDataRequest,
   PrivacyRequest,
   PrivacyRequestParams,
   PrivacyRequestResponse,
@@ -64,17 +65,6 @@ export const privacyRequestApi = createApi({
   }),
   tagTypes: ["Request"],
   endpoints: (build) => ({
-    getAllPrivacyRequests: build.query<
-      PrivacyRequestResponse,
-      Partial<PrivacyRequestParams>
-    >({
-      query: (filters) => ({
-        url: `privacy-request?${decodeURIComponent(
-          new URLSearchParams(mapFiltersToSearchParams(filters)).toString()
-        )}`,
-      }),
-      providesTags: () => ["Request"],
-    }),
     approveRequest: build.mutation<
       PrivacyRequest,
       Partial<PrivacyRequest> & Pick<PrivacyRequest, "id">
@@ -99,6 +89,26 @@ export const privacyRequestApi = createApi({
       }),
       invalidatesTags: ["Request"],
     }),
+    getAllPrivacyRequests: build.query<
+      PrivacyRequestResponse,
+      Partial<PrivacyRequestParams>
+    >({
+      query: (filters) => ({
+        url: `privacy-request?${decodeURIComponent(
+          new URLSearchParams(mapFiltersToSearchParams(filters)).toString()
+        )}`,
+      }),
+      providesTags: () => ["Request"],
+    }),
+    getUploadedManualWebhookData: build.query<
+      any,
+      GetUpdloadedManualWebhookDataRequest
+    >({
+      query: (params) => ({
+        url: `privacy-request/${params.privacy_request_id}/access_manual_webhook/${params.connection_key}`,
+      }),
+      providesTags: () => ["Request"],
+    }),
     retry: build.mutation<PrivacyRequest, Pick<PrivacyRequest, "id">>({
       query: ({ id }) => ({
         url: `privacy-request/${id}/retry`,
@@ -110,9 +120,10 @@ export const privacyRequestApi = createApi({
 });
 
 export const {
-  useGetAllPrivacyRequestsQuery,
   useApproveRequestMutation,
   useDenyRequestMutation,
+  useGetAllPrivacyRequestsQuery,
+  useGetUploadedManualWebhookDataQuery,
   useRetryMutation,
 } = privacyRequestApi;
 

--- a/clients/ops/admin-ui/src/features/privacy-requests/types.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/types.ts
@@ -45,6 +45,11 @@ export interface ExecutionLog {
   updated_at: string;
 }
 
+export type GetUpdloadedManualWebhookDataRequest = {
+  connection_key: string;
+  privacy_request_id: string;
+};
+
 export interface Rule {
   name: string;
   key: string;

--- a/clients/ops/admin-ui/src/features/privacy-requests/types.ts
+++ b/clients/ops/admin-ui/src/features/privacy-requests/types.ts
@@ -56,6 +56,12 @@ export interface Rule {
   action_type: ActionType;
 }
 
+export type PatchUploadManualWebhookDataRequest = {
+  body: object;
+  connection_key: string;
+  privacy_request_id: string;
+};
+
 export type PrivacyRequestResults = Record<string, ExecutionLog[]>;
 
 export interface PrivacyRequest {

--- a/clients/ops/admin-ui/src/features/subject-request/RequestDetails.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/RequestDetails.tsx
@@ -50,7 +50,7 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
 
   return (
     <>
-      <Heading fontSize="lg" fontWeight="semibold" mb={4}>
+      <Heading color="gray.900" fontSize="lg" fontWeight="semibold" mb={4}>
         Request details
       </Heading>
       <Divider />

--- a/clients/ops/admin-ui/src/features/subject-request/SubjectIdentities.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/SubjectIdentities.tsx
@@ -15,7 +15,7 @@ const SubjectIdentities = ({ subjectRequest }: SubjectIdentitiesProps) => {
   return (
     <>
       <Flex direction="row" justifyContent="space-between">
-        <Heading fontSize="lg" fontWeight="semibold" mb={4}>
+        <Heading color="gray.900" fontSize="lg" fontWeight="semibold" mb={4}>
           Subject identities
         </Heading>
         <Flex flexShrink={0} alignItems="flex-start">

--- a/clients/ops/admin-ui/src/features/subject-request/SubjectRequest.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/SubjectRequest.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import { Box, VStack } from "@fidesui/react";
 
 import { PrivacyRequest } from "../privacy-requests/types";
 import EventsAndLogs from "./events-and-logs/EventsAndLogs";
+import ManualProcessingList from "./manual-processing/ManualProcessingList";
 import RequestDetails from "./RequestDetails";
 import SubjectIdentities from "./SubjectIdentities";
 
@@ -9,12 +10,23 @@ type SubjectRequestProps = {
   subjectRequest: PrivacyRequest;
 };
 
-const SubjectRequest = ({ subjectRequest }: SubjectRequestProps) => (
-  <>
-    <RequestDetails subjectRequest={subjectRequest} />
-    <SubjectIdentities subjectRequest={subjectRequest} />
-    <EventsAndLogs subjectRequest={subjectRequest} />
-  </>
+const SubjectRequest: React.FC<SubjectRequestProps> = ({ subjectRequest }) => (
+  <VStack align="stretch" display="flex-start" spacing={6}>
+    <Box>
+      <RequestDetails subjectRequest={subjectRequest} />
+    </Box>
+    <Box>
+      <SubjectIdentities subjectRequest={subjectRequest} />
+    </Box>
+    {subjectRequest.status === "requires_input" && (
+      <Box>
+        <ManualProcessingList subjectRequest={subjectRequest} />
+      </Box>
+    )}
+    <Box>
+      <EventsAndLogs subjectRequest={subjectRequest} />
+    </Box>
+  </VStack>
 );
 
 export default SubjectRequest;

--- a/clients/ops/admin-ui/src/features/subject-request/events-and-logs/EventsAndLogs.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/events-and-logs/EventsAndLogs.tsx
@@ -14,7 +14,7 @@ const EventsAndLogs = ({ subjectRequest }: EventsAndLogsProps) => {
 
   return (
     <>
-      <Heading fontSize="lg" fontWeight="semibold" mb={4}>
+      <Heading color="gray.900" fontSize="lg" fontWeight="semibold" mb={4}>
         Events and logs
       </Heading>
       <Divider />

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Divider,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -19,19 +20,19 @@ import {
   VStack,
 } from "@fidesui/react";
 import { useAlert, useAPIHelper } from "common/hooks";
-import {
-  AccessManualHookField,
-  GetAccessManualWebhookResponse,
-} from "datastore-connections/types";
 import { Field, Form, Formik } from "formik";
 import React, { useRef, useState } from "react";
 import * as Yup from "yup";
 
+import { ManualInputData } from "./types";
+
 type ManualProcessingDetailProps = {
-  data: GetAccessManualWebhookResponse;
+  connectorName: string;
+  data: ManualInputData;
 };
 
 const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
+  connectorName,
   data,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -54,28 +55,32 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
 
   return (
     <>
-      {/* <Button
-        color="gray.700"
-        fontSize="xs"
-        h="24px"
-        onClick={onOpen}
-        variant="outline"
-        w="58px"
-      >
-        Review
-      </Button> */}
-      <Button
-        color="white"
-        bg="primary.800"
-        fontSize="xs"
-        h="24px"
-        onClick={onOpen}
-        w="127px"
-        _hover={{ bg: "primary.400" }}
-        _active={{ bg: "primary.500" }}
-      >
-        Begin manual input
-      </Button>
+      {data?.checked && (
+        <Button
+          color="gray.700"
+          fontSize="xs"
+          h="24px"
+          onClick={onOpen}
+          variant="outline"
+          w="58px"
+        >
+          Review
+        </Button>
+      )}
+      {!data?.checked && (
+        <Button
+          color="white"
+          bg="primary.800"
+          fontSize="xs"
+          h="24px"
+          onClick={onOpen}
+          w="127px"
+          _hover={{ bg: "primary.400" }}
+          _active={{ bg: "primary.500" }}
+        >
+          Begin manual input
+        </Button>
+      )}
       <Drawer
         isOpen={isOpen}
         placement="right"
@@ -87,8 +92,14 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
         <DrawerOverlay />
         <DrawerContent>
           <DrawerCloseButton />
-          <DrawerHeader color="gray.900" fontSize="18px">
-            PII Requirements
+          <DrawerHeader color="gray.900">
+            <Text fontSize="xl" mb={4}>
+              {connectorName}
+            </Text>
+            <Divider />
+            <Text fontSize="md" mt="8">
+              PII Requirements
+            </Text>
             <Box mt="8px">
               <Text color="gray.700" fontSize="sm" fontWeight="normal">
                 Please complete the following PII fields that have been
@@ -96,11 +107,9 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
               </Text>
             </Box>
           </DrawerHeader>
-          <DrawerBody mt="40px">
+          <DrawerBody mt="24px">
             <Formik
-              initialValues={{
-                fields: data.fields,
-              }}
+              initialValues={{ ...data.fields }}
               onSubmit={handleSubmit}
               validateOnBlur={false}
               validateOnChange={false}
@@ -110,38 +119,36 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
               {(props: FormikProps<Values>) => (
                 <Form id="manual-detail-form" noValidate>
                   <VStack align="stretch" gap="16px">
-                    {data.fields.map(
-                      (f: AccessManualHookField, index: number) => (
-                        <HStack key={f.pii_field}>
-                          <Field name={f.pii_field}>
-                            {({ field }: { field: any }) => (
-                              <FormControl
-                                alignItems="baseline"
-                                display="inline-flex"
+                    {Object.entries(data.fields).map(([key, _value], index) => (
+                      <HStack key={key}>
+                        <Field id={key} name={key}>
+                          {({ field }: { field: any }) => (
+                            <FormControl
+                              alignItems="baseline"
+                              display="inline-flex"
+                            >
+                              <FormLabel
+                                color="gray.900"
+                                fontSize="14px"
+                                fontWeight="semibold"
+                                htmlFor={key}
+                                w="50%"
                               >
-                                <FormLabel
-                                  color="gray.900"
-                                  fontSize="14px"
-                                  fontWeight="semibold"
-                                  htmlFor={f.pii_field}
-                                  w="50%"
-                                >
-                                  {f.pii_field}
-                                </FormLabel>
-                                <Input
-                                  {...field}
-                                  autoComplete="off"
-                                  color="gray.700"
-                                  placeholder={`Please enter ${f.pii_field}`}
-                                  ref={index === 0 ? firstField : undefined}
-                                  size="sm"
-                                />
-                              </FormControl>
-                            )}
-                          </Field>
-                        </HStack>
-                      )
-                    )}
+                                {key}
+                              </FormLabel>
+                              <Input
+                                {...field}
+                                autoComplete="off"
+                                color="gray.700"
+                                placeholder={`Please enter ${key}`}
+                                ref={index === 0 ? firstField : undefined}
+                                size="sm"
+                              />
+                            </FormControl>
+                          )}
+                        </Field>
+                      </HStack>
+                    ))}
                   </VStack>
                 </Form>
               )}

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   Box,
   Button,
@@ -41,7 +42,6 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
   const firstField = useRef();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleSubmit = async (values: any, _actions: any) => {
     const params: PatchUploadManualWebhookDataRequest = {
       connection_key: data.connection_key,
@@ -89,7 +89,7 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
         validationSchema={Yup.object().shape({})}
       >
         {/* @ts-ignore */}
-        {(props: FormikProps<Values>) => (
+        {(_props: FormikProps<Values>) => (
           <Drawer
             isOpen={isOpen}
             placement="right"
@@ -161,7 +161,6 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
                     bg="primary.800"
                     color="white"
                     form="manual-detail-form"
-                    isDisabled={!props.dirty}
                     isLoading={isSubmitting}
                     loadingText="Submitting"
                     size="sm"

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  Text,
+  useDisclosure,
+  VStack,
+} from "@fidesui/react";
+import { useAlert, useAPIHelper } from "common/hooks";
+import {
+  AccessManualHookField,
+  GetAccessManualWebhookResponse,
+} from "datastore-connections/types";
+import { Field, Form, Formik } from "formik";
+import React, { useRef, useState } from "react";
+import * as Yup from "yup";
+
+type ManualProcessingDetailProps = {
+  data: GetAccessManualWebhookResponse;
+};
+
+const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
+  data,
+}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const firstField = useRef();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { errorAlert, successAlert } = useAlert();
+  const { handleError } = useAPIHelper();
+
+  const handleSubmit = (values: any, _actions: any) => {
+    try {
+      setIsSubmitting(true);
+      onClose();
+      successAlert(`Manual input successfully saved`);
+    } catch (error) {
+      handleError(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {/* <Button
+        color="gray.700"
+        fontSize="xs"
+        h="24px"
+        onClick={onOpen}
+        variant="outline"
+        w="58px"
+      >
+        Review
+      </Button> */}
+      <Button
+        color="white"
+        bg="primary.800"
+        fontSize="xs"
+        h="24px"
+        onClick={onOpen}
+        w="127px"
+        _hover={{ bg: "primary.400" }}
+        _active={{ bg: "primary.500" }}
+      >
+        Begin manual input
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        // @ts-ignore
+        initialFocusRef={firstField}
+        onClose={onClose}
+        size="lg"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader color="gray.900" fontSize="18px">
+            PII Requirements
+            <Box mt="8px">
+              <Text color="gray.700" fontSize="sm" fontWeight="normal">
+                Please complete the following PII fields that have been
+                collected for the selected subject.
+              </Text>
+            </Box>
+          </DrawerHeader>
+          <DrawerBody mt="40px">
+            <Formik
+              initialValues={{
+                fields: data.fields,
+              }}
+              onSubmit={handleSubmit}
+              validateOnBlur={false}
+              validateOnChange={false}
+              validationSchema={Yup.object().shape({})}
+            >
+              {/* @ts-ignore */}
+              {(props: FormikProps<Values>) => (
+                <Form id="manual-detail-form" noValidate>
+                  <VStack align="stretch" gap="16px">
+                    {data.fields.map(
+                      (f: AccessManualHookField, index: number) => (
+                        <HStack key={f.pii_field}>
+                          <Field name={f.pii_field}>
+                            {({ field }: { field: any }) => (
+                              <FormControl
+                                alignItems="baseline"
+                                display="inline-flex"
+                              >
+                                <FormLabel
+                                  color="gray.900"
+                                  fontSize="14px"
+                                  fontWeight="semibold"
+                                  htmlFor={f.pii_field}
+                                  w="50%"
+                                >
+                                  {f.pii_field}
+                                </FormLabel>
+                                <Input
+                                  {...field}
+                                  autoComplete="off"
+                                  color="gray.700"
+                                  placeholder={`Please enter ${f.pii_field}`}
+                                  ref={index === 0 ? firstField : undefined}
+                                  size="sm"
+                                />
+                              </FormControl>
+                            )}
+                          </Field>
+                        </HStack>
+                      )
+                    )}
+                  </VStack>
+                </Form>
+              )}
+            </Formik>
+          </DrawerBody>
+          <DrawerFooter justifyContent="flex-start">
+            <ButtonGroup size="sm" spacing="8px" variant="outline">
+              <Button onClick={onClose} variant="outline">
+                Cancel
+              </Button>
+              <Button
+                bg="primary.800"
+                color="white"
+                form="manual-detail-form"
+                isLoading={isSubmitting}
+                loadingText="Submitting"
+                size="sm"
+                variant="solid"
+                type="submit"
+                _active={{ bg: "primary.500" }}
+                _disabled={{ opacity: "inherit" }}
+                _hover={{ bg: "primary.400" }}
+              >
+                Save
+              </Button>
+            </ButtonGroup>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
+
+export default ManualProcessingDetail;

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingDetail.tsx
@@ -21,7 +21,6 @@ import {
 import { Field, Form, Formik } from "formik";
 import { PatchUploadManualWebhookDataRequest } from "privacy-requests/types";
 import React, { useRef } from "react";
-import { shallowEqual } from "react-redux";
 import * as Yup from "yup";
 
 import { ManualInputData } from "./types";
@@ -44,8 +43,6 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleSubmit = async (values: any, _actions: any) => {
-    const hasChanged = !shallowEqual(data.fields, values);
-    if (!hasChanged) return;
     const params: PatchUploadManualWebhookDataRequest = {
       connection_key: data.connection_key,
       privacy_request_id: data.privacy_request_id,
@@ -83,100 +80,104 @@ const ManualProcessingDetail: React.FC<ManualProcessingDetailProps> = ({
           Begin manual input
         </Button>
       )}
-      <Drawer
-        isOpen={isOpen}
-        placement="right"
-        // @ts-ignore
-        initialFocusRef={firstField}
-        onClose={onClose}
-        size="lg"
+      <Formik
+        enableReinitialize
+        initialValues={{ ...data.fields }}
+        onSubmit={handleSubmit}
+        validateOnBlur={false}
+        validateOnChange={false}
+        validationSchema={Yup.object().shape({})}
       >
-        <DrawerOverlay />
-        <DrawerContent>
-          <DrawerCloseButton />
-          <DrawerHeader color="gray.900">
-            <Text fontSize="xl" mb={4}>
-              {connectorName}
-            </Text>
-            <Divider />
-            <Text fontSize="md" mt="8">
-              PII Requirements
-            </Text>
-            <Box mt="8px">
-              <Text color="gray.700" fontSize="sm" fontWeight="normal">
-                Please complete the following PII fields that have been
-                collected for the selected subject.
-              </Text>
-            </Box>
-          </DrawerHeader>
-          <DrawerBody mt="24px">
-            <Formik
-              initialValues={{ ...data.fields }}
-              onSubmit={handleSubmit}
-              validateOnBlur={false}
-              validateOnChange={false}
-              validationSchema={Yup.object().shape({})}
-            >
-              <Form id="manual-detail-form" noValidate>
-                <VStack align="stretch" gap="16px">
-                  {Object.entries(data.fields).map(([key], index) => (
-                    <HStack key={key}>
-                      <Field id={key} name={key}>
-                        {({ field }: { field: any }) => (
-                          <FormControl
-                            alignItems="baseline"
-                            display="inline-flex"
-                          >
-                            <FormLabel
-                              color="gray.900"
-                              fontSize="14px"
-                              fontWeight="semibold"
-                              htmlFor={key}
-                              w="50%"
+        {/* @ts-ignore */}
+        {(props: FormikProps<Values>) => (
+          <Drawer
+            isOpen={isOpen}
+            placement="right"
+            // @ts-ignore
+            initialFocusRef={firstField}
+            onClose={onClose}
+            size="lg"
+          >
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerCloseButton />
+              <DrawerHeader color="gray.900">
+                <Text fontSize="xl" mb={4}>
+                  {connectorName}
+                </Text>
+                <Divider />
+                <Text fontSize="md" mt="8">
+                  PII Requirements
+                </Text>
+                <Box mt="8px">
+                  <Text color="gray.700" fontSize="sm" fontWeight="normal">
+                    Please complete the following PII fields that have been
+                    collected for the selected subject.
+                  </Text>
+                </Box>
+              </DrawerHeader>
+              <DrawerBody mt="24px">
+                <Form id="manual-detail-form" noValidate>
+                  <VStack align="stretch" gap="16px">
+                    {Object.entries(data.fields).map(([key], index) => (
+                      <HStack key={key}>
+                        <Field id={key} name={key}>
+                          {({ field }: { field: any }) => (
+                            <FormControl
+                              alignItems="baseline"
+                              display="inline-flex"
                             >
-                              {key}
-                            </FormLabel>
-                            <Input
-                              {...field}
-                              autoComplete="off"
-                              color="gray.700"
-                              placeholder={`Please enter ${key}`}
-                              ref={index === 0 ? firstField : undefined}
-                              size="sm"
-                            />
-                          </FormControl>
-                        )}
-                      </Field>
-                    </HStack>
-                  ))}
-                </VStack>
-              </Form>
-            </Formik>
-          </DrawerBody>
-          <DrawerFooter justifyContent="flex-start">
-            <ButtonGroup size="sm" spacing="8px" variant="outline">
-              <Button onClick={onClose} variant="outline">
-                Cancel
-              </Button>
-              <Button
-                bg="primary.800"
-                color="white"
-                form="manual-detail-form"
-                isLoading={isSubmitting}
-                loadingText="Submitting"
-                size="sm"
-                variant="solid"
-                type="submit"
-                _active={{ bg: "primary.500" }}
-                _disabled={{ opacity: "inherit" }}
-                _hover={{ bg: "primary.400" }}
-              >
-                Save
-              </Button>
-            </ButtonGroup>
-          </DrawerFooter>
-        </DrawerContent>
-      </Drawer>
+                              <FormLabel
+                                color="gray.900"
+                                fontSize="14px"
+                                fontWeight="semibold"
+                                htmlFor={key}
+                                w="50%"
+                              >
+                                {key}
+                              </FormLabel>
+                              <Input
+                                {...field}
+                                autoComplete="off"
+                                color="gray.700"
+                                placeholder={`Please enter ${key}`}
+                                ref={index === 0 ? firstField : undefined}
+                                size="sm"
+                              />
+                            </FormControl>
+                          )}
+                        </Field>
+                      </HStack>
+                    ))}
+                  </VStack>
+                </Form>
+              </DrawerBody>
+              <DrawerFooter justifyContent="flex-start">
+                <ButtonGroup size="sm" spacing="8px" variant="outline">
+                  <Button onClick={onClose} variant="outline">
+                    Cancel
+                  </Button>
+                  <Button
+                    bg="primary.800"
+                    color="white"
+                    form="manual-detail-form"
+                    isDisabled={!props.dirty}
+                    isLoading={isSubmitting}
+                    loadingText="Submitting"
+                    size="sm"
+                    variant="solid"
+                    type="submit"
+                    _active={{ bg: "primary.500" }}
+                    _hover={{ bg: "primary.400" }}
+                  >
+                    Save
+                  </Button>
+                </ButtonGroup>
+              </DrawerFooter>
+            </DrawerContent>
+          </Drawer>
+        )}
+      </Formik>
     </>
   );
 };

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingList.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingList.tsx
@@ -1,0 +1,176 @@
+import {
+  Box,
+  Button,
+  Center,
+  Divider,
+  Heading,
+  Spinner,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Tfoot,
+  Th,
+  Thead,
+  Tr,
+  VStack,
+} from "@fidesui/react";
+import { useGetAllEnabledAccessManualHooksQuery } from "datastore-connections/datastore-connection.slice";
+import { privacyRequestApi } from "privacy-requests/privacy-requests.slice";
+import { PrivacyRequest } from "privacy-requests/types";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+
+import ManualProcessingDetail from "./ManualProcessingDetail";
+import { ManualInputData } from "./types";
+
+type ManualProcessingListProps = {
+  subjectRequest: PrivacyRequest;
+};
+
+const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
+  subjectRequest,
+}) => {
+  const dispatch = useDispatch();
+  const mounted = useRef(false);
+  const [dataList, setDataList] = useState([] as unknown as ManualInputData[]);
+
+  const { data, isFetching, isLoading, isSuccess } =
+    useGetAllEnabledAccessManualHooksQuery();
+
+  const fetchUploadedManuaWebhookData = useCallback(() => {
+    const promises: any[] = [];
+    const keys = data?.map((item) => item.connection_config.key);
+    keys?.every((k) =>
+      promises.push(
+        dispatch(
+          privacyRequestApi.endpoints.getUploadedManualWebhookData.initiate({
+            connection_key: k,
+            privacy_request_id: subjectRequest.id,
+          })
+        )
+      )
+    );
+    Promise.allSettled(promises).then((results) => {
+      const list: ManualInputData[] = [];
+      results.forEach((result) => {
+        if (
+          result.status === "fulfilled" &&
+          result.value.isSuccess &&
+          result.value.data
+        ) {
+          list.push({
+            checked: result.value.data.checked,
+            fields: result.value.data.fields,
+            key: result.value.originalArgs.connection_key,
+          });
+        }
+      });
+      setDataList(list);
+    });
+  }, [data, dispatch, subjectRequest.id]);
+
+  useEffect(() => {
+    mounted.current = true;
+    if (isSuccess && data!.length > 0) {
+      fetchUploadedManuaWebhookData();
+    }
+    return () => {
+      mounted.current = false;
+    };
+  }, [fetchUploadedManuaWebhookData, data, isSuccess]);
+
+  return (
+    <VStack align="stretch" spacing={8}>
+      <Box>
+        <Heading color="gray.900" fontSize="lg" fontWeight="semibold" mb={4}>
+          Manual Processing
+        </Heading>
+        <Divider />
+      </Box>
+      <Box>
+        <Text color="gray.700" fontSize="sm">
+          The following table details the integrations that require manual input
+          from you.
+        </Text>
+      </Box>
+      <Box>
+        {(isFetching || isLoading) && (
+          <Center>
+            <Spinner />
+          </Center>
+        )}
+        {isSuccess && data ? (
+          <TableContainer>
+            <Table size="sm" variant="unstyled">
+              <Thead>
+                <Tr>
+                  <Th
+                    fontSize="sm"
+                    fontWeight="semibold"
+                    pl="0"
+                    textTransform="none"
+                  >
+                    Connector name
+                  </Th>
+                  <Th fontSize="sm" fontWeight="semibold" textTransform="none">
+                    Description
+                  </Th>
+                  <Th />
+                </Tr>
+              </Thead>
+              <Tbody>
+                {data.length > 0 &&
+                  data.map((item) => (
+                    <Tr key={item.id}>
+                      <Td pl="0">{item.connection_config.name}</Td>
+                      <Td>{item.connection_config.description}</Td>
+                      <Td>
+                        <ManualProcessingDetail data={item} />
+                      </Td>
+                    </Tr>
+                  ))}
+                {data.length === 0 && (
+                  <Tr>
+                    <Td colSpan={3} pl="0">
+                      <Center>
+                        <Text>
+                          You don&lsquo;t have any Manual Webhook connections
+                          set up yet.
+                        </Text>
+                      </Center>
+                    </Td>
+                  </Tr>
+                )}
+              </Tbody>
+              {data.length > 0 && (
+                <Tfoot>
+                  <Tr>
+                    <Th />
+                    <Th />
+                    <Th>
+                      <Button
+                        color="white"
+                        bg="primary.800"
+                        fontSize="xs"
+                        h="24px"
+                        w="127px"
+                        _hover={{ bg: "primary.400" }}
+                        _active={{ bg: "primary.500" }}
+                      >
+                        Complete DSR
+                      </Button>
+                    </Th>
+                  </Tr>
+                </Tfoot>
+              )}
+            </Table>
+          </TableContainer>
+        ) : null}
+      </Box>
+    </VStack>
+  );
+};
+
+export default ManualProcessingList;

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingList.tsx
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/ManualProcessingList.tsx
@@ -60,11 +60,16 @@ const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
           result.value.isSuccess &&
           result.value.data
         ) {
-          list.push({
+          const item = {
             checked: result.value.data.checked,
-            fields: result.value.data.fields,
+            fields: [],
             key: result.value.originalArgs.connection_key,
+          } as ManualInputData;
+          Object.entries(result.value.data.fields).forEach(([key, value]) => {
+            // @ts-ignore
+            item.fields[key] = value || "";
           });
+          list.push(item);
         }
       });
       setDataList(list);
@@ -127,7 +132,16 @@ const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
                       <Td pl="0">{item.connection_config.name}</Td>
                       <Td>{item.connection_config.description}</Td>
                       <Td>
-                        <ManualProcessingDetail data={item} />
+                        {dataList.length > 0 ? (
+                          <ManualProcessingDetail
+                            connectorName={item.connection_config.name}
+                            data={
+                              dataList.find(
+                                (i) => i.key === item.connection_config.key
+                              ) as ManualInputData
+                            }
+                          />
+                        ) : null}
                       </Td>
                     </Tr>
                   ))}
@@ -144,7 +158,7 @@ const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
                   </Tr>
                 )}
               </Tbody>
-              {data.length > 0 && (
+              {dataList.length > 0 && dataList.every((item) => item.checked) ? (
                 <Tfoot>
                   <Tr>
                     <Th />
@@ -164,7 +178,7 @@ const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
                     </Th>
                   </Tr>
                 </Tfoot>
-              )}
+              ) : null}
             </Table>
           </TableContainer>
         ) : null}

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
@@ -1,0 +1,7 @@
+import { Field } from "datastore-connections/add-connection/manual/types";
+
+export type ManualInputData = {
+  checked: boolean;
+  key: string;
+  fields: Field;
+};

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
@@ -1,9 +1,15 @@
 export type ManualInputData = {
   checked: boolean;
-  fields: ManualInputDataField[];
-  key: string;
+  connection_key: string;
+  fields: ManualInputDataFieldMap;
+  privacy_request_id: string;
 };
 
-export type ManualInputDataField = {
+export type ManualInputDataFieldMap = {
   [key: string]: any;
+};
+
+export type SaveCompleteResponse = {
+  connection_key: string;
+  fields: ManualInputDataFieldMap;
 };

--- a/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
+++ b/clients/ops/admin-ui/src/features/subject-request/manual-processing/types.ts
@@ -1,7 +1,9 @@
-import { Field } from "datastore-connections/add-connection/manual/types";
-
 export type ManualInputData = {
   checked: boolean;
+  fields: ManualInputDataField[];
   key: string;
-  fields: Field;
+};
+
+export type ManualInputDataField = {
+  [key: string]: any;
 };

--- a/clients/ops/admin-ui/src/pages/subject-request/[id].tsx
+++ b/clients/ops/admin-ui/src/pages/subject-request/[id].tsx
@@ -10,14 +10,13 @@ import {
 } from "@fidesui/react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import React from "react";
+import SubjectRequest from "subject-request/SubjectRequest";
 
 import { INDEX_ROUTE } from "../../constants";
 import ProtectedRoute from "../../features/auth/ProtectedRoute";
 import Head from "../../features/common/Head";
 import NavBar from "../../features/common/NavBar";
 import { useGetAllPrivacyRequestsQuery } from "../../features/privacy-requests";
-import SubjectRequest from "../../features/subject-request/SubjectRequest";
 
 const useSubjectRequestDetails = () => {
   const router = useRouter();

--- a/clients/ops/admin-ui/src/theme/index.ts
+++ b/clients/ops/admin-ui/src/theme/index.ts
@@ -12,6 +12,11 @@ const theme = extendTheme({
     },
   },
   components: {
+    Divider: {
+      baseStyle: {
+        opacity: 1,
+      },
+    },
     Spinner: {
       baseStyle: {
         color: "secondary.500",


### PR DESCRIPTION
[1016 - Frontend ability for users to manually enter pii to an in progress subject request.webm](https://user-images.githubusercontent.com/68459950/191971209-1b6b15e9-e89f-4ce5-9bc2-3978a283d69f.webm)

# Purpose

For a given Subject Request record with a status of **Requires Input**, this UI feature allows a user to enter required manual input data to one or more Manual connections via the Subject Request detail screen (**Manual Processing** section). Once all of the given Manual connection(s) have the required manual input data entered, each Manual connection will be in a **Review** status. There will be a Complete DSR button displayed located below the last Manual connection record. Upon clicked, this will update the Subject Request record to a status of **In Progress** and the user will be redirected to the Subject Requests landing page.

Figma designs
https://www.figma.com/file/MTbZohIGvB4bq2f2wkiDHO/Fidesops-Management-UI?node-id=3458%3A48952

# Changes
- Display Manual Processing section via the Subject Request detail screen based on a given Subject Request record with a status of **Requires Input**
- When a user clicks the **Begin manual input** or **Review** button, a sliding panel will be displayed via the left hand side. This panel lists each DSR Package Label defined for a given Manual connection. The user can enter the manual input data for a given Manual connection.
- After each Manual connection has been reviewed, the Subject Request record can be submitted via clicking the **Complete DSR** button. This will change the status from **Requires Input** to **In Progress**.

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1016 
 
