### PR TITLE
Removing PII fields from conversations collection

### DIFF
--- a/data/saas/config/mailchimp_config.yml
+++ b/data/saas/config/mailchimp_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Mailchimp SaaS Config
   type: mailchimp
   description: A sample schema representing the Mailchimp connector for Fidesops
-  version: 0.0.1
+  version: 0.0.2
 
   connector_params:
     - name: domain

--- a/data/saas/dataset/mailchimp_dataset.yml
+++ b/data/saas/dataset/mailchimp_dataset.yml
@@ -31,12 +31,6 @@ dataset:
             data_categories: [system.operations]
           - name: list_id
             data_categories: [system.operations]
-          - name: from_email
-            data_categories: [user.contact.email]
-          - name: from_label
-            data_categories: [user.contact.email]
-          - name: subject
-            data_categories: [user]
       - name: member
         fields:
           - name: id


### PR DESCRIPTION
# Purpose
To prevent PII from being returned from the `conversations` collection. This is meant as a workaround until https://github.com/ethyca/fidesops/issues/1385 is implemented.

# Changes
- Removed PII fields from the `conversations` collection in the `mailchimp_dataset`
- Bumped Mailchimp version number

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
- [ ] Good unit test/integration test coverage
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services
 
