### PR TITLE
Backend: Updating or Deleting Access Webhooks [#1388][#1389]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 * Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)
 * Fix Redis Cache Early Expiration in Tests [#1358](https://github.com/ethyca/fidesops/pull/1358)
 * Limit values for the offset pagination strategy are now cast to integers before use [#1364](https://github.com/ethyca/fidesops/pull/1364)
+* Allow `requires_input` PrivacyRequests to be addressed if a webhook is deleted, disabled, or updated [#1394](https://github.com/ethyca/fidesops/pull/1394)
 
 ### Added
 

--- a/src/fidesops/ops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/connection_endpoints.py
@@ -376,6 +376,9 @@ def requeue_requires_input_requests(db: Session) -> None:
     """
     Queue privacy requests with request status "requires_input" if they are no longer blocked by
     access manual webhooks.
+
+    For use when all access manual webhooks have been either disabled or deleted, leaving privacy requests
+    lingering in a "requires_input" state.
     """
     if not AccessManualWebhook.get_enabled(db):
         for pr in PrivacyRequest.filter(

--- a/src/fidesops/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -62,6 +62,7 @@ from fidesops.ops.common_exceptions import (
     FunctionalityNotConfigured,
     IdentityNotFoundException,
     IdentityVerificationException,
+    ManualWebhookFieldsUnset,
     NoCachedManualWebhookEntry,
     PolicyNotFoundException,
     TraversalError,
@@ -1357,6 +1358,11 @@ def view_uploaded_manual_webhook_data(
 ) -> Optional[ManualWebhookData]:
     """
     View uploaded data for this privacy request for the given access manual webhook
+
+    If no data exists for this webhook, we just return all fields as None.
+    If we have missing or extra fields saved, we'll just return the overlap between what is saved and what is defined on the webhook.
+
+    If checked=False, data must be reviewed before submission. The privacy request should not be submitted as-is.
     """
     privacy_request: PrivacyRequest = get_privacy_request_or_error(
         db, privacy_request_id
@@ -1368,7 +1374,8 @@ def view_uploaded_manual_webhook_data(
     if not privacy_request.status == PrivacyRequestStatus.requires_input:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Invalid access manual webhook upload request: privacy request '{privacy_request.id}' status = {privacy_request.status.value}.",  # type: ignore
+            detail=f"Invalid access manual webhook upload request: privacy request "
+            f"'{privacy_request.id}' status = {privacy_request.status.value}.",  # type: ignore
         )
 
     try:
@@ -1377,20 +1384,20 @@ def view_uploaded_manual_webhook_data(
             connection_config.key,
             privacy_request.id,
         )
-        data: Dict[str, Any] = privacy_request.get_manual_webhook_input(
+        data: Dict[str, Any] = privacy_request.get_manual_webhook_input_strict(
             access_manual_webhook
         )
         checked = True
-    except NoCachedManualWebhookEntry as exc:
+    except (
+        PydanticValidationError,
+        ManualWebhookFieldsUnset,
+        NoCachedManualWebhookEntry,
+    ) as exc:
         logger.info(exc)
-        data = access_manual_webhook.empty_fields_dict
-        checked = False
-    except PydanticValidationError:
-        raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Saved fields differ from fields specified on webhook '{access_manual_webhook.connection_config.key}'. "
-            f"Re-upload manual data using '{PRIVACY_REQUEST_ACCESS_MANUAL_WEBHOOK_INPUT.format(connection_key=connection_config.key, privacy_request_id=privacy_request.id)}'.",
+        data = privacy_request.get_manual_webhook_input_non_strict(
+            manual_webhook=access_manual_webhook
         )
+        checked = False
 
     return ManualWebhookData(checked=checked, fields=data)
 
@@ -1424,8 +1431,12 @@ async def resume_privacy_request_from_requires_input(
     )
     try:
         for manual_webhook in access_manual_webhooks:
-            privacy_request.get_manual_webhook_input(manual_webhook)
-    except (NoCachedManualWebhookEntry, PydanticValidationError) as exc:
+            privacy_request.get_manual_webhook_input_strict(manual_webhook)
+    except (
+        NoCachedManualWebhookEntry,
+        PydanticValidationError,
+        ManualWebhookFieldsUnset,
+    ) as exc:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
             detail=f"Cannot resume privacy request. {exc}",

--- a/src/fidesops/ops/common_exceptions.py
+++ b/src/fidesops/ops/common_exceptions.py
@@ -109,6 +109,10 @@ class NoCachedManualWebhookEntry(BaseException):
     """No manual data exists for this webhook on the given privacy request."""
 
 
+class ManualWebhookFieldsUnset(BaseException):
+    """Manual webhook has fields that are not explicitly set: Likely new field has been added"""
+
+
 class PrivacyRequestErasureEmailSendRequired(BaseException):
     """Erasure requests will need to be fulfilled by email send.  Exception is raised to change ExecutionLog details"""
 

--- a/src/fidesops/ops/models/manual_webhook.py
+++ b/src/fidesops/ops/models/manual_webhook.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from fideslib.db.base_class import Base
 from fideslib.schemas.base_class import BaseSchema
-from pydantic import create_model
+from pydantic import BaseConfig, create_model
 from sqlalchemy import Column, ForeignKey, String, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableList
@@ -49,6 +49,14 @@ class AccessManualWebhook(Base):
             **field_definitions,
         )
         return ManualWebhookValidationModel
+
+    @property
+    def fields_non_strict_schema(self) -> BaseSchema:
+        """Returns a dynamic Pydantic Schema for webhook fields that can keep the overlap between
+        fields that are saved and fields that are defined here."""
+        schema: BaseSchema = self.fields_schema
+        schema.__config__ = BaseConfig  # Extra is "ignore" on BaseConfig
+        return schema
 
     @property
     def empty_fields_dict(self) -> Dict[str, None]:

--- a/src/fidesops/ops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_runner_service.py
@@ -16,6 +16,7 @@ from fidesops.ops.common_exceptions import (
     ClientUnsuccessfulException,
     EmailDispatchException,
     IdentityNotFoundException,
+    ManualWebhookFieldsUnset,
     NoCachedManualWebhookEntry,
     PrivacyRequestPaused,
 )
@@ -96,7 +97,11 @@ def get_access_manual_webhook_inputs(
             manual_inputs[manual_webhook.connection_config.key] = [
                 privacy_request.get_manual_webhook_input_strict(manual_webhook)
             ]
-    except (NoCachedManualWebhookEntry, ValidationError) as exc:
+    except (
+        NoCachedManualWebhookEntry,
+        ValidationError,
+        ManualWebhookFieldsUnset,
+    ) as exc:
         logger.info(exc)
         privacy_request.status = PrivacyRequestStatus.requires_input
         privacy_request.save(db)

--- a/src/fidesops/ops/service/privacy_request/request_runner_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_runner_service.py
@@ -94,7 +94,7 @@ def get_access_manual_webhook_inputs(
     try:
         for manual_webhook in AccessManualWebhook.get_enabled(db):
             manual_inputs[manual_webhook.connection_config.key] = [
-                privacy_request.get_manual_webhook_input(manual_webhook)
+                privacy_request.get_manual_webhook_input_strict(manual_webhook)
             ]
     except (NoCachedManualWebhookEntry, ValidationError) as exc:
         logger.info(exc)

--- a/src/fidesops/ops/service/privacy_request/request_service.py
+++ b/src/fidesops/ops/service/privacy_request/request_service.py
@@ -2,13 +2,19 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
+from sqlalchemy.orm import Session
+
 from fidesops.ops.core.config import config
+from fidesops.ops.models.manual_webhook import AccessManualWebhook
 from fidesops.ops.models.policy import ActionType, Policy
 from fidesops.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fidesops.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate
 from fidesops.ops.schemas.masking.masking_secrets import MaskingSecretCache
 from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.masking.strategy.masking_strategy import MaskingStrategy
+from fidesops.ops.service.privacy_request.request_runner_service import (
+    queue_privacy_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,3 +71,25 @@ def cache_data(
                 privacy_request.cache_masking_secret(masking_secret)
     if drp_request_body:
         privacy_request.cache_drp_request_body(drp_request_body)
+
+
+def queue_requires_input_requests(db: Session) -> None:
+    """
+    Queue privacy requests with request status "requires_input" if they are no longer blocked by
+    webhooks.
+    """
+    if not AccessManualWebhook.get_enabled(db):
+        for pr in PrivacyRequest.filter(
+            db=db,
+            conditions=(PrivacyRequest.status == PrivacyRequestStatus.requires_input),
+        ):
+            logger.info(
+                "Queuing privacy request '%s with '%s' status now that manual inputs are no longer required.",
+                pr.id,
+                pr.status.value,
+            )
+            pr.status = PrivacyRequestStatus.in_processing
+            pr.save(db=db)
+            queue_privacy_request(
+                privacy_request_id=pr.id,
+            )

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -3150,7 +3150,7 @@ class TestUploadManualWebhookInputs:
         assert response.json() is None
 
         assert (
-            privacy_request_requires_input.get_manual_webhook_input(
+            privacy_request_requires_input.get_manual_webhook_input_strict(
                 access_manual_webhook
             )
             == payload
@@ -3277,7 +3277,7 @@ class TestGetManualWebhookInputs:
             "fields": {"email": None, "last_name": None},
         }
 
-    def test_cached_data_differs_from_webhook_fields(
+    def test_cached_data_extra_saved_webhook_field(
         self,
         api_client: TestClient,
         db,
@@ -3295,11 +3295,40 @@ class TestGetManualWebhookInputs:
         ]
         access_manual_webhook.save(db)
         response = api_client.get(url, headers=auth_header)
-        assert response.status_code == 422
-        assert (
-            f"Saved fields differ from fields specified on webhook '{integration_manual_webhook_config.key}'."
-            in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json() == {
+            "checked": False,
+            "fields": {"id_number": None},
+        }, "Response has checked=False, so this data needs to be re-uploaded before we can run the privacy request."
+
+    def test_cached_data_missing_saved_webhook_field(
+        self,
+        api_client: TestClient,
+        db,
+        url,
+        generate_auth_header,
+        access_manual_webhook,
+        integration_manual_webhook_config,
+        privacy_request_requires_input,
+        cached_input,
+    ):
+        auth_header = generate_auth_header([PRIVACY_REQUEST_VIEW_DATA])
+
+        access_manual_webhook.fields.append(
+            {"pii_field": "id_no", "dsr_package_label": "id_number"}
         )
+        access_manual_webhook.save(db)
+        response = api_client.get(url, headers=auth_header)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "checked": False,
+            "fields": {
+                "id_number": None,
+                "email": "customer-1@example.com",
+                "last_name": "McCustomer",
+            },
+        }, "Response has checked=False. A new field has been defined on the webhook, so we should re-examine to see if that is more data we need to retrieve."
 
     def test_get_inputs_for_manual_webhook(
         self,

--- a/tests/ops/fixtures/manual_webhook_fixtures.py
+++ b/tests/ops/fixtures/manual_webhook_fixtures.py
@@ -42,7 +42,10 @@ def access_manual_webhook(db, integration_manual_webhook_config) -> ConnectionCo
         },
     )
     yield manual_webhook
-    manual_webhook.delete(db)
+    try:
+        manual_webhook.delete(db)
+    except ObjectDeletedError:
+        pass
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Purpose

Address some edge cases that surfaced in testing https://github.com/ethyca/fidesops/pull/1377

1. Deleting or disabling a webhook can leave Privacy Requests stuck in a `requires_input` state with no way to move them forward 
2. If data has already been saved for a webhook, but then the webhook definition itself changes, we can run into issues trying to retrieve the data for the webhook because of the mismatch.  The user needs to be alerted that data needs to be resubmitted for the altered webhook.  We currently throw a 429 if the webhook definition had a field removed, but we should also handle if the webhook definition had a field added. Both should require a re-review. 

# Changes
- If a manual webhook is deleted or disabled, check if there are any remaining active manual webhooks configured. If not, meaning we just disabled/deleted the last one, queue any Privacy Requests stuck in "requires_input" for processing.
- In the `view_uploaded_manual_webhook_data` endpoint, load cached webhook data for a privacy request in strict mode. If it fails (no data saved, extra field saved, field missing), return `checked=False`, so the user knows they need to re-upload data for this webhook before it can be submitted.
  - Previously, we would return a 429 if there were extra fields saved for the webhook. Now we return a 200 but surface that the data needs to be re-uploaded.
  - Return the data in non-strict mode, so we just show the overlap between the data saved and the fields defined.
  - Any webhooks that have `checked=True` will prevent the privacy request from being submitted


# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1388
Fixes #1389 
 
