### PR TITLE
[#1393] Update Fidesops config with sane defaults where necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ The types of changes are:
 
 * Removed `query_param` auth strategy as `api_key` auth strategy now supersedes it [#1331](https://github.com/ethyca/fidesops/pull/1331)
 
+### Developer Experience
+
+* Update Fidesops config with sane defaults where necessary [#1393](https://github.com/ethyca/fidesops/pull/1395)
+
+
 ## [1.8.0](https://github.com/ethyca/fidesops/compare/1.8.0...main)
 
 ### Developer Experience

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ celery[pytest]==5.2.7
 click==8.1.3
 cryptography~=3.4.8
 dask==2022.8.0
-emails
 fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.10.0
 fastapi[all]==0.82.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.10.0
 fastapi[all]==0.82.0
 fideslang==1.2.0
-fideslib==3.1.3
+fideslib==3.1.4
 fideslog==1.2.3
 hvac==0.11.2
 Jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi-caching[redis]
 fastapi-pagination[sqlalchemy]~= 0.10.0
 fastapi[all]==0.82.0
 fideslang==1.2.0
-fideslib==3.1.2
+fideslib==3.1.3
 fideslog==1.2.3
 hvac==0.11.2
 Jinja2==3.1.2

--- a/src/fidesops/ops/api/v1/endpoints/drp_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/drp_endpoints.py
@@ -66,7 +66,7 @@ async def create_drp_privacy_request(
     a corresponding Fidesops PrivacyRequest
     """
 
-    jwt_key: str = config.security.drp_jwt_secret
+    jwt_key: Optional[str] = config.security.drp_jwt_secret
     if jwt_key is None:
         raise HTTPException(
             status_code=HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -174,10 +174,10 @@ class FidesopsConfig(FidesSettings):
     database: FidesopsDatabaseSettings
     redis: RedisSettings
     security: FidesopsSecuritySettings
-    execution: ExecutionSettings
-    root_user: RootUserSettings
-    admin_ui: AdminUiSettings
-    notifications: FidesopsNotificationSettings
+    execution: Optional[ExecutionSettings]
+    root_user: Optional[RootUserSettings]
+    admin_ui: Optional[AdminUiSettings]
+    notifications: Optional[FidesopsNotificationSettings]
 
     port: int = 8080  # Run the webserver on port 8080 by default
     is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class FidesopsDatabaseSettings(DatabaseSettings):
     """Configuration settings for Postgres."""
 
-    ENABLED: bool = True
+    enabled: bool = True
 
     class Config:
         env_prefix = "FIDESOPS__DATABASE__"
@@ -174,10 +174,12 @@ class FidesopsConfig(FidesSettings):
     database: FidesopsDatabaseSettings
     redis: RedisSettings
     security: FidesopsSecuritySettings
-    execution: Optional[ExecutionSettings]
-    root_user: Optional[RootUserSettings]
-    admin_ui: Optional[AdminUiSettings]
-    notifications: Optional[FidesopsNotificationSettings]
+    execution: Optional[ExecutionSettings] = ExecutionSettings()
+    root_user: Optional[RootUserSettings] = RootUserSettings()
+    admin_ui: Optional[AdminUiSettings] = AdminUiSettings()
+    notifications: Optional[
+        FidesopsNotificationSettings
+    ] = FidesopsNotificationSettings()
 
     port: int = 8080  # Run the webserver on port 8080 by default
     is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -181,9 +181,11 @@ class FidesopsConfig(FidesSettings):
         FidesopsNotificationSettings
     ] = FidesopsNotificationSettings()
 
-    port: int = os.getenv(
-        "FIDESOPS__PORT",
-        8080,  # Run the webserver on port 8080 by default
+    port: int = int(
+        os.getenv(
+            "FIDESOPS__PORT",
+            "8080",  # Run the webserver on port 8080 by default
+        )
     )
     is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"
     hot_reloading: bool = os.getenv("FIDESOPS__HOT_RELOAD", "").lower() == "true"

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -78,7 +78,7 @@ class RedisSettings(FidesSettings):
             # If the whole URL is provided via the config, preference that
             return v
 
-        return f"redis://{quote_plus(values.get('user', ''))}:{quote_plus(values['password'])}@{values['host']}:{values['port']}/{values.get('db_index', '')}"
+        return f"redis://{quote_plus(values.get('user', ''))}:{quote_plus(values.get('password', ''))}@{values.get('host', '')}:{values.get('port', '')}/{values.get('db_index', '')}"
 
     class Config:
         env_prefix = "FIDESOPS__REDIS__"
@@ -173,7 +173,7 @@ class FidesopsConfig(FidesSettings):
 
     # Pydantic doesn't initialise subsections automatically if
     # only environment variables are provided at runtime. If the
-    # subsection class is instantiated with no args, Pydantic runs
+    # config subclass is instantiated with no args, Pydantic runs
     # validation before loading in environment variables, which
     # always fails if any config vars in the subsection are non-optional.
     # Using the empty dict allows Python to load in the environment

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -171,9 +171,16 @@ class FidesopsNotificationSettings(FidesSettings):
 class FidesopsConfig(FidesSettings):
     """Configuration variables for the FastAPI project"""
 
-    database: FidesopsDatabaseSettings = FidesopsDatabaseSettings()
-    redis: RedisSettings = RedisSettings()
-    security: FidesopsSecuritySettings = FidesopsSecuritySettings()
+    # Pydantic doesn't initialise subsections automatically if
+    # only environment variables are provided at runtime. If the
+    # subsection class is instantiated with no args, Pydantic runs
+    # validation before loading in environment variables, which
+    # always fails if any config vars in the subsection are non-optional.
+    # Using the empty dict allows Python to load in the environment
+    # variables _before_ validating them against the Pydantic schema.
+    database: FidesopsDatabaseSettings = {}  # type: ignore
+    redis: RedisSettings = {}  # type: ignore
+    security: FidesopsSecuritySettings = {}  # type: ignore
     execution: Optional[ExecutionSettings] = ExecutionSettings()
     root_user: Optional[RootUserSettings] = RootUserSettings()
     admin_ui: Optional[AdminUiSettings] = AdminUiSettings()

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -127,7 +127,7 @@ class RootUserSettings(FidesSettings):
         cls,
         v: Optional[str],
         values: Dict[str, str],
-    ) -> str:
+    ) -> Optional[str]:
         """
         Populates the appropriate value for analytics id based on config
         """

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -171,9 +171,9 @@ class FidesopsNotificationSettings(FidesSettings):
 class FidesopsConfig(FidesSettings):
     """Configuration variables for the FastAPI project"""
 
-    database: FidesopsDatabaseSettings
-    redis: RedisSettings
-    security: FidesopsSecuritySettings
+    database: FidesopsDatabaseSettings = FidesopsDatabaseSettings()
+    redis: RedisSettings = RedisSettings()
+    security: FidesopsSecuritySettings = FidesopsSecuritySettings()
     execution: Optional[ExecutionSettings] = ExecutionSettings()
     root_user: Optional[RootUserSettings] = RootUserSettings()
     admin_ui: Optional[AdminUiSettings] = AdminUiSettings()

--- a/src/fidesops/ops/core/config.py
+++ b/src/fidesops/ops/core/config.py
@@ -181,7 +181,10 @@ class FidesopsConfig(FidesSettings):
         FidesopsNotificationSettings
     ] = FidesopsNotificationSettings()
 
-    port: int = 8080  # Run the webserver on port 8080 by default
+    port: int = os.getenv(
+        "FIDESOPS__PORT",
+        8080,  # Run the webserver on port 8080 by default
+    )
     is_test_mode: bool = os.getenv("TESTING", "").lower() == "true"
     hot_reloading: bool = os.getenv("FIDESOPS__HOT_RELOAD", "").lower() == "true"
     dev_mode: bool = os.getenv("FIDESOPS__DEV_MODE", "").lower() == "true"


### PR DESCRIPTION
# Purpose

This PR addresses some shortcomings in the Fidesops config highlighted by the recent removal of the `fidesops.toml` from the Docker build. I've not tried to set defaults for any config vars within the `[database]`, `[redis]`, or `[security]` subsections, since they're either handled separately, or setting a default is an anti-pattern.

This [Fideslib PR](https://github.com/ethyca/fideslib/pull/73/) also aims to clarify which part of config. loading any error has occurred in.

# Changes
- Only populate `analytics_id` if `analytics_opt_out` is either `None` or `False` — this still preserves the behaviour of an explicit opt-out.
- Sets `port` to `8080`
- Sets `task_retry_` vars to `0` — this means by default nodes in the Fidesops identity graph traversal will not attempt to retry if they fail.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket
Fixes #1393 