### PR TITLE
Square Erasure APIs added 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ The types of changes are:
 
 ### Changed
 * Refactor privacy center to be more modular [#1363](https://github.com/ethyca/fidesops/pull/1363)
-* Access support for Square [#1378](https://github.com/ethyca/fidesops/pull/1378)
-* Erasure support for Square [#1398](https://github.com/ethyca/fidesops/pull/1398)
+
 
 ### Fixed
 * Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)
@@ -36,6 +35,7 @@ The types of changes are:
 * Access support for Rollbar [#1361](https://github.com/ethyca/fidesops/pull/1361)
 * Adds a new Timescale connector [#1327](https://github.com/ethyca/fidesops/pull/1327)
 * Allow querying the non-default schema with the Postgres Connector [#1375](https://github.com/ethyca/fidesops/pull/1375)
+* Access and Erasure support for Square [#1378](https://github.com/ethyca/fidesops/pull/1378)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ The types of changes are:
 
 ### Changed
 * Refactor privacy center to be more modular [#1363](https://github.com/ethyca/fidesops/pull/1363)
- * Access support for Square [#1378](https://github.com/ethyca/fidesops/pull/1378)
+* Access support for Square [#1378](https://github.com/ethyca/fidesops/pull/1378)
+* Erasure support for Square [#1398](https://github.com/ethyca/fidesops/pull/1398)
 
 ### Fixed
 * Distinguish whether webhook has been visited and no fields were found, versus never visited [#1339](https://github.com/ethyca/fidesops/pull/1339)

--- a/data/saas/config/square_config.yml
+++ b/data/saas/config/square_config.yml
@@ -22,7 +22,6 @@ saas_config:
     path: /v2/customers
 
   endpoints:
-#
     - name: customer
       requests:
         read:
@@ -42,7 +41,19 @@ saas_config:
               }
             }
           data_path: customers
-
+        update:
+          method: PUT
+          path: /v2/customers/<customer_id>
+          body: |
+            {
+              <masked_object_fields>
+            }
+          param_values:
+            - name: customer_id
+              references:
+                - dataset: <instance_fides_key>
+                  field: customer.id
+                  direction: from
     - name: locations
       requests:
         read:
@@ -56,7 +67,6 @@ saas_config:
             - name: email
               identity: email
           data_path: locations
-          
     - name: orders
       requests:
         read:

--- a/data/saas/dataset/square_dataset.yml
+++ b/data/saas/dataset/square_dataset.yml
@@ -75,7 +75,7 @@ dataset:
       fidesops_meta:
         data_type: string
     - name: birthday
-      data_categories:  [system.operations]
+      data_categories:  [user.date_of_birth]
       fidesops_meta:
         data_type: string
     - name: segment_ids

--- a/data/saas/dataset/square_dataset.yml
+++ b/data/saas/dataset/square_dataset.yml
@@ -6,9 +6,10 @@ dataset:
   - name: customer
     fields:
     - name: id
-      data_categories: [system.operations]
+      data_categories: [user.unique_id]
       fidesops_meta:
-        data_type: string
+        primary_key: True
+        data_type: integer
     - name: created_at
       data_categories: [system.operations]
       fidesops_meta:
@@ -18,19 +19,19 @@ dataset:
       fidesops_meta:
         data_type: string
     - name: given_name
-      data_categories: [system.operations]
+      data_categories: [user.name]
       fidesops_meta:
         data_type: string
     - name: family_name
-      data_categories: [system.operations]
+      data_categories: [user.name]
       fidesops_meta:
         data_type: string
     - name: nickname
-      data_categories: [system.operations]
+      data_categories: [user.name]
       fidesops_meta:
         data_type: string
     - name: email_address
-      data_categories: [system.operations]
+      data_categories: [user.contact.email]
       fidesops_meta:
         data_type: string
     - name: address
@@ -38,23 +39,23 @@ dataset:
         data_type: object
       fields:
       - name: address_line_1
-        data_categories: [system.operations]
+        data_categories: [user.contact.address.street]
         fidesops_meta:
           data_type: string
       - name: address_line_2
-        data_categories: [system.operations]
+        data_categories: [user.contact.address.street]
         fidesops_meta:
           data_type: string
       - name: locality
-        data_categories: [system.operations]
+        data_categories: [user.contact.address.city]
         fidesops_meta:
           data_type: string
       - name: postal_code
-        data_categories: [system.operations]
+        data_categories: [user.contact.address.postal_code]
         fidesops_meta:
           data_type: string
     - name: phone_number
-      data_categories: [system.operations]
+      data_categories: [user.contact.phone_number]
       fidesops_meta:
         data_type: string
     - name: company_name
@@ -74,7 +75,7 @@ dataset:
       fidesops_meta:
         data_type: string
     - name: birthday
-      data_categories: [system.operations]
+      data_categories:  [system.operations]
       fidesops_meta:
         data_type: string
     - name: segment_ids

--- a/tests/ops/fixtures/saas/square_fixtures.py
+++ b/tests/ops/fixtures/saas/square_fixtures.py
@@ -1,7 +1,13 @@
+import random
+import time
+import uuid
 from typing import Any, Dict, Generator
 
 import pydash
 import pytest
+import requests
+from faker import Faker
+from fideslib.cryptography import cryptographic_util
 from fideslib.db import session
 from sqlalchemy.orm import Session
 
@@ -15,9 +21,11 @@ from fidesops.ops.util.saas_util import (
     load_config_with_replacement,
     load_dataset_with_replacement,
 )
+from tests.ops.test_helpers.saas_test_utils import poll_for_existence
 from tests.ops.test_helpers.vault_client import get_secrets
 
 secrets = get_secrets("square")
+faker = Faker()
 
 
 @pytest.fixture(scope="session")
@@ -32,6 +40,11 @@ def square_secrets(saas_config):
 @pytest.fixture(scope="session")
 def square_identity_email(saas_config):
     return pydash.get(saas_config, "square.identity_email") or secrets["identity_email"]
+
+
+@pytest.fixture(scope="function")
+def square_erasure_identity_email() -> str:
+    return f"{cryptographic_util.generate_secure_random_string(13)}@email.com"
 
 
 @pytest.fixture
@@ -91,3 +104,197 @@ def square_dataset_config(
     )
     yield dataset
     dataset.delete(db=db)
+
+
+def square_idempotency_key():
+    """
+    Square supports idempotency by allowing API operations to provide an idempotency key (a unique string)
+    to protect against accidental duplicate calls that can have negative consequences.
+    https://developer.squareup.com/docs/build-basics/common-api-patterns/idempotency
+    """
+    # "idempotency_key": "4a1b1a54-a1e5-4691-88ca-2548ce09ee71",
+    return str(uuid.uuid4())
+
+
+class SquareTestClient:
+    headers: object = {}
+    base_url: str = ""
+    square_secrets: object = {}
+
+    def __init__(self, square_connection_config: ConnectionConfig):
+        self.square_secrets = square_connection_config.secrets
+
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.square_secrets['access_token']}",
+        }
+        self.base_url = f"https://{self.square_secrets['domain']}/v2"
+
+    def create_customer(
+        self, email_address: str, idempotency_key: str
+    ) -> requests.Response:
+        # create a new customer in square
+        random_num = random.randint(0, 999)
+        body = {
+            "idempotency_key": idempotency_key,
+            "email_address": email_address,
+            "company_name": f"test_connector_ethyca_{random_num}",
+            "nickname": f"ethcya_{random_num}",
+            "address": {
+                "address_line_1": faker.street_address(),
+                "address_line_2": faker.street_address(),
+                "postal_code": faker.postcode(),
+                "locality": faker.city(),
+            },
+            "birthday": str(faker.date_of_birth()),
+            "family_name": faker.first_name(),
+            "given_name": faker.last_name(),
+            "phone_number": faker.phone_number(),
+        }
+        customer_response: requests.Response = requests.post(
+            url=f"{self.base_url}/customers", json=body, headers=self.headers
+        )
+        return customer_response
+
+    def get_customer(self, email: str) -> requests.Response:
+        # get a customer
+        body = {"query": {"filter": {"email_address": {"exact": f"{email}"}}}}
+        customer_response: requests.Response = requests.post(
+            url=f"{self.base_url}/customers/search",
+            json=body,
+            headers=self.headers,
+        )
+        return customer_response
+
+    def delete_customer(self, customer_id) -> requests.Response:
+        # delete customer created for erasure purposes
+        url = f"{self.base_url}/customers/{customer_id}"
+        customer_response: requests.Response = requests.delete(
+            url=url, headers=self.headers
+        )
+        return customer_response
+
+    def get_location(self) -> requests.Response:
+        # Provides details about all the seller's locations, including those with an inactive status.
+
+        customer_response: requests.Response = requests.get(
+            url=f"{self.base_url}/locations",
+            headers=self.headers,
+        )
+        return customer_response
+
+    def create_order(
+        self, location_id: str, customer_id: str, idempotency_key: str
+    ) -> requests.Response:
+        # creates a new order
+        body = {
+            "idempotency_key": idempotency_key,
+            "order": {"location_id": location_id, "customer_id": customer_id},
+        }
+        order_response: requests.Response = requests.post(
+            url=f"{self.base_url}/orders", json=body, headers=self.headers
+        )
+        return order_response
+
+    def get_order(self, location_id: str, order_id) -> requests.Response:
+        # Retrieves a set of orders by their IDs
+        body = {"location_id": location_id, "order_ids": [order_id]}
+        url = f"{self.base_url}/orders/batch-retrieve"
+        customer_response: requests.Response = requests.post(
+            url=url,
+            json=body,
+            headers=self.headers,
+        )
+        return customer_response
+
+
+@pytest.fixture(scope="function")
+def square_test_client(
+    square_connection_config: SquareTestClient,
+) -> Generator:
+    test_client = SquareTestClient(square_connection_config=square_connection_config)
+    yield test_client
+
+
+def _customer_exists(customer_email: str, square_test_client: SquareTestClient) -> Any:
+    """check if the customer exists in the square"""
+    customer_response = square_test_client.get_customer(customer_email)
+    customers = customer_response.json()
+    # it always return status 200 and {} if no customer otherwise {"customers": []}
+    if customer_response.ok and customers:
+        return customers
+
+
+def _order_exists(
+    location_id: str, order_id: str, square_test_client: SquareTestClient
+) -> Any:
+    """check if the order exists in the square"""
+    order_response = square_test_client.get_order(location_id, order_id)
+    orders = order_response.json()
+    # it always return status 200 and {} if no order otherwise {"orders": []}
+    if order_response.ok and orders:
+        return order_response.json()
+
+
+@pytest.fixture(scope="function")
+def square_erasure_data(
+    square_test_client: SquareTestClient,
+    square_erasure_identity_email: str,
+) -> Generator:
+    """
+    Creates a dynamic test data record for erasure tests.
+        there are 2 steps to create data for erasure api
+        1) create a new user
+        2) get the seller location
+    """
+    # 1) create a new user
+    customer_response = square_test_client.create_customer(
+        square_erasure_identity_email, square_idempotency_key()
+    )
+    customer = customer_response.json()
+    customer_id = customer["customer"]["id"]
+
+    error_message = (
+        f"customer with customer id [{customer_id}] could not be added to square"
+    )
+    poll_for_existence(
+        _customer_exists,
+        (square_erasure_identity_email, square_test_client),
+        error_message=error_message,
+    )
+    # 2) get the seller location
+    location_response = square_test_client.get_location()
+    locations = location_response.json()
+    # we deal with only first location
+    location_id = locations["locations"][0]["id"]
+
+    # 3) create an order for given customer on given location
+    order_response = square_test_client.create_order(
+        location_id, customer_id, square_idempotency_key()
+    )
+
+    order = order_response.json()["order"]
+    order_id = order["id"]
+    error_message = f"Order with customer id [{customer_id}] for location [{location_id}] could not be added to square"
+    time.sleep(5)
+    poll_for_existence(
+        _order_exists,
+        (location_id, order_id, square_test_client),
+        error_message=error_message,
+    )
+
+    yield order, customer
+    # delete customer
+    customer_response = square_test_client.delete_customer(customer_id)
+    assert customer_response.ok
+
+    # verify customer is deleted
+    error_message = (
+        f"customer with customer id {customer_id} could not be deleted from square"
+    )
+    poll_for_existence(
+        _customer_exists,
+        (square_erasure_identity_email, square_test_client),
+        error_message=error_message,
+        existence_desired=False,
+    )

--- a/tests/ops/integration_tests/saas/test_square_task.py
+++ b/tests/ops/integration_tests/saas/test_square_task.py
@@ -116,6 +116,7 @@ async def test_square_erasure_request_task(
     square_dataset_config,
     square_erasure_identity_email,
     square_erasure_data,
+    square_test_client,
 ) -> None:
     """Full erasure request based on the Square SaaS config"""
 
@@ -202,8 +203,15 @@ async def test_square_erasure_request_task(
         db,
     )
     assert x == {
-        f"{dataset_name}:customer": 0,
+        f"{dataset_name}:customer": 1,
         f"{dataset_name}:orders": 0,
         f"{dataset_name}:locations": 0,
     }
+    customer_response = square_test_client.get_customer(square_erasure_identity_email)
+    customer = customer_response.json()
+    customer = customer["customers"][0]
+    assert customer["given_name"] == "MASKED"
+    assert customer["family_name"] == "MASKED"
+    assert customer["nickname"] == "MASKED"
+
     config.execution.masking_strict = temp_masking

--- a/tests/ops/integration_tests/saas/test_square_task.py
+++ b/tests/ops/integration_tests/saas/test_square_task.py
@@ -3,11 +3,13 @@ import random
 
 import pytest
 
+from fidesops.ops.core.config import config
 from fidesops.ops.graph.graph import DatasetGraph
 from fidesops.ops.models.privacy_request import PrivacyRequest
 from fidesops.ops.schemas.redis_cache import Identity
 from fidesops.ops.service.connectors import get_connector
 from fidesops.ops.task import graph_task
+from fidesops.ops.task.graph_task import get_cached_data_for_erasures
 from tests.ops.graph.graph_test_util import assert_rows_match
 
 logger = logging.getLogger(__name__)
@@ -29,7 +31,7 @@ async def test_square_access_request_task(
     square_dataset_config,
     square_identity_email,
 ) -> None:
-    """Full access request based on the square SaaS config"""
+    """Full access request based on the Square SaaS config"""
 
     privacy_request = PrivacyRequest(
         id=f"test_square_access_request_task_{random.randint(0, 1000)}"
@@ -101,3 +103,107 @@ async def test_square_access_request_task(
         min_size=1,
         keys=["id", "location_id", "customer_id", "state"],
     )
+
+
+@pytest.mark.integration_saas
+@pytest.mark.integration_square
+@pytest.mark.asyncio
+async def test_square_erasure_request_task(
+    db,
+    policy,
+    erasure_policy_string_rewrite,
+    square_connection_config,
+    square_dataset_config,
+    square_erasure_identity_email,
+    square_erasure_data,
+) -> None:
+    """Full erasure request based on the Square SaaS config"""
+
+    privacy_request = PrivacyRequest(
+        id=f"test_square_erasure_request_task_{random.randint(0, 1000)}"
+    )
+    identity_kwargs = {"email": square_erasure_identity_email}
+    identity = Identity(**identity_kwargs)
+    privacy_request.cache_identity(identity)
+
+    dataset_name = square_connection_config.get_saas_config().fides_key
+    merged_graph = square_dataset_config.get_graph()
+    graph = DatasetGraph(merged_graph)
+    v = await graph_task.run_access_request(
+        privacy_request,
+        policy,
+        graph,
+        [square_connection_config],
+        identity_kwargs,
+        db,
+    )
+
+    assert_rows_match(
+        v[f"{dataset_name}:customer"],
+        min_size=1,
+        keys=[
+            "id",
+            "created_at",
+            "updated_at",
+            "given_name",
+            "family_name",
+            "nickname",
+            "email_address",
+            "address",
+            "phone_number",
+            "company_name",
+            "preferences",
+            "creation_source",
+            "birthday",
+            "segment_ids",
+            "version",
+        ],
+    )
+    # verify we only returned data for our identity email
+    for customer in v[f"{dataset_name}:customer"]:
+        assert customer["email_address"] == square_erasure_identity_email
+
+    assert_rows_match(
+        v[f"{dataset_name}:locations"],
+        min_size=1,
+        keys=[
+            "id",
+            "name",
+            "address",
+            "timezone",
+            "capabilities",
+            "status",
+            "created_at",
+            "merchant_id",
+            "country",
+            "language_code",
+            "currency",
+            "business_name",
+            "type",
+            "business_hours",
+            "mcc",
+        ],
+    )
+    assert_rows_match(
+        v[f"{dataset_name}:orders"],
+        min_size=1,
+        keys=["id", "location_id", "customer_id", "state"],
+    )
+    temp_masking = config.execution.masking_strict
+    config.execution.masking_strict = True
+
+    x = await graph_task.run_erasure(
+        privacy_request,
+        erasure_policy_string_rewrite,
+        graph,
+        [square_connection_config],
+        identity_kwargs,
+        get_cached_data_for_erasures(privacy_request.id),
+        db,
+    )
+    assert x == {
+        f"{dataset_name}:customer": 0,
+        f"{dataset_name}:orders": 0,
+        f"{dataset_name}:locations": 0,
+    }
+    config.execution.masking_strict = temp_masking


### PR DESCRIPTION
# Purpose

- This PR aims to add a Square connector Customer, Order access endpoints.

# Changes
- Added config for Square Customer erasure Endpoints
- Added related dataset and configuration
- Added associated tests and fixtures to validate the above functionality


# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add a description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [x] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes https://github.com/ethyca/fidesops/issues/1184
 
