### PR TITLE
Add new template for consent requets emails

### DIFF
--- a/fidesops.toml
+++ b/fidesops.toml
@@ -42,6 +42,7 @@ worker_enabled = false
 
 [root_user]
 analytics_opt_out = false
+analytics_id = "3578e0a5b78e5af07d91d634cc67d067"
 
 [admin_ui]
 enabled = true

--- a/fidesops.toml
+++ b/fidesops.toml
@@ -42,7 +42,6 @@ worker_enabled = false
 
 [root_user]
 analytics_opt_out = false
-analytics_id = "3578e0a5b78e5af07d91d634cc67d067"
 
 [admin_ui]
 enabled = true

--- a/src/fidesops/ops/email_templates/get_email_template.py
+++ b/src/fidesops/ops/email_templates/get_email_template.py
@@ -5,6 +5,7 @@ from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
 
 from fidesops.ops.common_exceptions import EmailTemplateUnhandledActionType
 from fidesops.ops.email_templates.template_names import (
+    CONSENT_REQUEST_VERIFICATION_TEMPLATE,
     EMAIL_ERASURE_REQUEST_FULFILLMENT,
     PRIVACY_REQUEST_COMPLETE_ACCESS_TEMPLATE,
     PRIVACY_REQUEST_COMPLETE_DELETION_TEMPLATE,
@@ -28,6 +29,8 @@ template_env = Environment(
 def get_email_template(  # pylint: disable=too-many-return-statements
     action_type: EmailActionType,
 ) -> Template:
+    if action_type == EmailActionType.CONSENT_REQUEST:
+        return template_env.get_template(CONSENT_REQUEST_VERIFICATION_TEMPLATE)
     if action_type == EmailActionType.SUBJECT_IDENTITY_VERIFICATION:
         return template_env.get_template(SUBJECT_IDENTITY_VERIFICATION_TEMPLATE)
     if action_type == EmailActionType.EMAIL_ERASURE_REQUEST_FULFILLMENT:

--- a/src/fidesops/ops/email_templates/template_names.py
+++ b/src/fidesops/ops/email_templates/template_names.py
@@ -1,3 +1,4 @@
+CONSENT_REQUEST_VERIFICATION_TEMPLATE = "consent_request_verification.html"
 SUBJECT_IDENTITY_VERIFICATION_TEMPLATE = "subject_identity_verification.html"
 EMAIL_ERASURE_REQUEST_FULFILLMENT = "erasure_request_email_fulfillment.html"
 PRIVACY_REQUEST_RECEIPT_TEMPLATE = "privacy_request_receipt.html"

--- a/src/fidesops/ops/email_templates/templates/consent_request_verification.html
+++ b/src/fidesops/ops/email_templates/templates/consent_request_verification.html
@@ -1,0 +1,15 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ID Code</title>
+</head>
+<body>
+<main>
+    <p>
+        Your consent request verification code is {{code}}.
+        Please return to the consent request page and enter the code to
+        continue. This code will expire in {{minutes}} minutes
+    </p>
+</main>
+</body>
+</html>

--- a/src/fidesops/ops/schemas/email/email.py
+++ b/src/fidesops/ops/schemas/email/email.py
@@ -19,6 +19,7 @@ class EmailActionType(str, Enum):
     """Enum for email action type"""
 
     # verify email upon acct creation
+    CONSENT_REQUEST = "consent_request"
     SUBJECT_IDENTITY_VERIFICATION = "subject_identity_verification"
     EMAIL_ERASURE_REQUEST_FULFILLMENT = "email_erasure_fulfillment"
     PRIVACY_REQUEST_RECEIPT = "privacy_request_receipt"

--- a/src/fidesops/ops/service/_verification.py
+++ b/src/fidesops/ops/service/_verification.py
@@ -24,9 +24,14 @@ def send_verification_code_to_user(
     )  # Validates Fidesops is currently configured to send emails
     verification_code = generate_id_verification_code()
     request.cache_identity_verification_code(verification_code)
+    email_action_type = (
+        EmailActionType.CONSENT_REQUEST
+        if isinstance(request, ConsentRequest)
+        else EmailActionType.SUBJECT_IDENTITY_VERIFICATION
+    )
     dispatch_email(
         db,
-        action_type=EmailActionType.SUBJECT_IDENTITY_VERIFICATION,
+        action_type=email_action_type,
         to_email=email,
         email_body_params=SubjectIdentityVerificationBodyParams(
             verification_code=verification_code,

--- a/src/fidesops/ops/service/email/email_dispatch_service.py
+++ b/src/fidesops/ops/service/email/email_dispatch_service.py
@@ -97,7 +97,7 @@ def _build_email(  # pylint: disable=too-many-return-statements
     if action_type == EmailActionType.CONSENT_REQUEST:
         template = get_email_template(action_type)
         return EmailForActionType(
-            subject="your one-time code",
+            subject="Your one-time code",
             body=template.render(
                 {
                     "code": body_params.verification_code,

--- a/src/fidesops/ops/service/email/email_dispatch_service.py
+++ b/src/fidesops/ops/service/email/email_dispatch_service.py
@@ -94,6 +94,17 @@ def _build_email(  # pylint: disable=too-many-return-statements
     action_type: EmailActionType,
     body_params: Any,
 ) -> EmailForActionType:
+    if action_type == EmailActionType.CONSENT_REQUEST:
+        template = get_email_template(action_type)
+        return EmailForActionType(
+            subject="your one-time code",
+            body=template.render(
+                {
+                    "code": body_params.verification_code,
+                    "minutes": body_params.get_verification_code_ttl_minutes(),
+                }
+            ),
+        )
     if action_type == EmailActionType.SUBJECT_IDENTITY_VERIFICATION:
         template = get_email_template(action_type)
         return EmailForActionType(


### PR DESCRIPTION
# Purpose

Adds a new email template for consent request verification codes.

# Changes
- Add CONSENT_REQUEST as an email type
- Adds a template for consent request emails
- Uses separate email templates for consent requests and privacy requests.

# Checklist
- [ ] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [ ] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [ ] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [ ] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1400
 
