### PR TITLE
DX Improvements from `v1.8.1` release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ src_paths = ["src", "tests"]
 disable=[
     "bad-option-value",
     "broad-except",
+    "consider-using-f-string",
     "dangerous-default-value",
     "duplicate-code",
     "fixme",

--- a/src/fidesops/ops/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/dataset_endpoints.py
@@ -253,7 +253,6 @@ def create_or_update_dataset(
         dataset_config = DatasetConfig.create_or_update(db, data=data)
         created_or_updated.append(dataset_config.dataset)
     except (
-        IntegrityError,
         SaaSConfigNotFoundException,
         ValidationError,
     ) as exception:
@@ -264,11 +263,12 @@ def create_or_update_dataset(
                 data=data,
             )
         )
-    except IntegrityError as exception:
-        logger.warning(exception.message)
+    except IntegrityError:
+        message = "Dataset with key '%s' already exists." % data["fides_key"]
+        logger.warning(message)
         failed.append(
             BulkUpdateFailed(
-                message=exception.message,
+                message=message,
                 data=data,
             )
         )


### PR DESCRIPTION
# Purpose

This PR improves the DX in the following ways:
- better reporting of errors when `DatasetConfig` `get_or_create_dataset` is attempted, to log the `IntegrityError` that's thrown by SQLAlchemy when a `DatasetConfig` already exists, and it belongs to a different `ConnectionConfig` to the one specified in the data.
- don't attach the analytics middleware if the user has opted out via the config — this saves a lot of unnecessary logging output during development