### PR TITLE
Specify Multiple Masking Strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.8.1...main)
 
+### Changed
+
+* Allow multiple masking strategies to be specified when using fides as a masking engine [#1428](https://github.com/ethyca/fidesops/pull/1428)
+
 
 ## [1.8.0](https://github.com/ethyca/fidesops/compare/1.8.0...1.8.1)
 

--- a/docs/fidesops/docs/guides/masking_strategies.md
+++ b/docs/fidesops/docs/guides/masking_strategies.md
@@ -64,6 +64,39 @@ The email has been replaced with a random string of 20 characters, while still p
 
 See the [masking values](/fidesops/api#operations-tag-Masking) API on how to use fidesops to as a masking service.
 
+### Specifying Multiple Strategies
+
+If you would like multiple strategies to be applied in sequence when using fides as a masking service, 
+supply a list of strategies under "strategy". Each strategy will be applied across all values in order.
+In this example, the `random_string_rewrite` strategy will be run on both values first, and then the `hash` masking strategy 
+will be run on both values output from `random_string_rewrite`. 
+
+```json title="<code>PUT /masking/mask</code>"
+{
+   "values":[
+      "111-111-1111",
+      "customer-1@example.com"
+   ],
+   "masking_strategy":[
+      {
+         "strategy":"random_string_rewrite",
+         "configuration":{
+            "length":20,
+            "format_preservation":{
+               "suffix":"@masked.com"
+            }
+         }
+      },
+      {
+         "strategy":"hash",
+         "configuration":{
+            
+         }
+      }
+   ]
+}
+```
+
 ## Configuration
 
 Erasure requests will mask data with the chosen masking strategy.

--- a/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
@@ -31,9 +31,9 @@ def mask_value(request: MaskingAPIRequest) -> MaskingAPIResponse:
 
     """
     try:
-        values = request.values or []
-        masked_values: Optional[List[Any]] = request.values.copy()
-        masking_strategies: List[PolicyMaskingSpec] = request.masking_strategies or []
+        values: List[Any] = request.values
+        masked_values: List[Any] = request.values.copy()
+        masking_strategies: List[PolicyMaskingSpec] = request.masking_strategies
 
         num_strat: int = len(masking_strategies)
 
@@ -52,7 +52,7 @@ def mask_value(request: MaskingAPIRequest) -> MaskingAPIResponse:
                 len(values),
                 strategy.strategy,
             )
-            masked_values = masking_strategy.mask(
+            masked_values = masking_strategy.mask(  # type: ignore
                 masked_values, None
             )  # passing in masked values from previous strategy
 

--- a/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import Any, List, Optional
 
 from fastapi import HTTPException
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
@@ -13,6 +13,7 @@ from fidesops.ops.schemas.masking.masking_api import (
 from fidesops.ops.schemas.masking.masking_strategy_description import (
     MaskingStrategyDescription,
 )
+from fidesops.ops.schemas.policy import PolicyMaskingSpec
 from fidesops.ops.service.masking.strategy.masking_strategy import MaskingStrategy
 from fidesops.ops.util.api_router import APIRouter
 
@@ -23,19 +24,38 @@ logger = logging.getLogger(__name__)
 
 @router.put(MASKING, response_model=MaskingAPIResponse)
 def mask_value(request: MaskingAPIRequest) -> MaskingAPIResponse:
-    """Masks the value(s) provided using the provided masking strategy"""
+    """Masks the value(s) provided using the provided masking strategies
+
+    Each masking strategy supplied will be run on all the values in sequence.  The masked values
+    from one masking strategy will be passed into the next masking strategy.
+
+    """
     try:
-        values = request.values
-        masking_strategy = request.masking_strategy
-        strategy = MaskingStrategy.get_strategy(
-            masking_strategy.strategy, masking_strategy.configuration
-        )
-        logger.info(
-            "Starting masking of %s value(s) with strategy %s",
-            len(values),
-            masking_strategy.strategy,
-        )
-        masked_values = strategy.mask(values, None)
+        values = request.values or []
+        masked_values: Optional[List[Any]] = request.values.copy()
+        masking_strategies: List[PolicyMaskingSpec] = request.masking_strategies or []
+
+        num_strat: int = len(masking_strategies)
+
+        if num_strat > 1:
+            logger.info(
+                "%s masking strategies requested; running in order.",
+                num_strat,
+            )
+
+        for strategy in masking_strategies:
+            masking_strategy = MaskingStrategy.get_strategy(
+                strategy.strategy, strategy.configuration
+            )
+            logger.info(
+                "Starting masking of %s value(s) with strategy %s",
+                len(values),
+                strategy.strategy,
+            )
+            masked_values = masking_strategy.mask(
+                masked_values, None
+            )  # passing in masked values from previous strategy
+
         return MaskingAPIResponse(plain=values, masked_values=masked_values)
     except NoSuchStrategyException as e:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(e))

--- a/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
+++ b/src/fidesops/ops/api/v1/endpoints/masking_endpoints.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, Optional
+from typing import Any, List
 
 from fastapi import HTTPException
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND

--- a/src/fidesops/ops/schemas/masking/masking_api.py
+++ b/src/fidesops/ops/schemas/masking/masking_api.py
@@ -25,11 +25,10 @@ class MaskingAPIRequest(BaseModel):
         Masking_strategies should not be supplied directly.
         """
         strategy = values.get("masking_strategy")
-        if not strategy:
-            return values
         values["masking_strategies"] = (
             strategy if isinstance(strategy, list) else [strategy]
         )
+
         return values
 
 

--- a/src/fidesops/ops/schemas/masking/masking_api.py
+++ b/src/fidesops/ops/schemas/masking/masking_api.py
@@ -1,6 +1,6 @@
-from typing import Any, List
+from typing import Any, Dict, List, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 from fidesops.ops.schemas.policy import PolicyMaskingSpec
 
@@ -9,7 +9,28 @@ class MaskingAPIRequest(BaseModel):
     """The API Request for masking operations"""
 
     values: List[str]
-    masking_strategy: PolicyMaskingSpec
+    masking_strategy: Union[PolicyMaskingSpec, List[PolicyMaskingSpec]]
+    masking_strategies: List[PolicyMaskingSpec] = []
+
+    @root_validator(pre=False)
+    def build_masking_strategies(cls, values: Dict) -> Dict:
+        """
+        Update "masking_strategies" field by inspecting "masking_strategy".
+
+        The ability to specify one or more masking strategies was added in a
+        backwards-compatible way.  Pass in a single masking strategy, or a list
+        of masking_strategy objects under "masking_strategy", and we
+        set the "masking_strategies" value from there.
+
+        Masking_strategies should not be supplied directly.
+        """
+        strategy = values.get("masking_strategy")
+        if not strategy:
+            return values
+        values["masking_strategies"] = (
+            strategy if isinstance(strategy, list) else [strategy]
+        )
+        return values
 
 
 class MaskingAPIResponse(BaseModel):

--- a/src/fidesops/ops/schemas/policy.py
+++ b/src/fidesops/ops/schemas/policy.py
@@ -1,19 +1,18 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from fidesops.ops.models.policy import ActionType, DrpAction
 from fidesops.ops.schemas.api import BulkResponse, BulkUpdateFailed
 from fidesops.ops.schemas.base_class import BaseSchema
-from fidesops.ops.schemas.masking.masking_configuration import FormatPreservationConfig
 from fidesops.ops.schemas.shared_schemas import FidesOpsKey
 from fidesops.ops.schemas.storage.storage import StorageDestinationResponse
 from fidesops.ops.util.data_category import DataCategory
 
 
 class PolicyMaskingSpec(BaseSchema):
-    """Models the masking strategy definition int the policy document"""
+    """Models the masking strategy definition"""
 
     strategy: str
-    configuration: Dict[str, Union[str, FormatPreservationConfig]]
+    configuration: Dict[str, Any]
 
 
 class PolicyMaskingSpecResponse(BaseSchema):

--- a/tests/ops/api/v1/endpoints/test_masking_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_masking_endpoints.py
@@ -43,6 +43,27 @@ class TestGetMaskingStrategies:
 
 
 class TestMaskValues:
+    def test_no_strategies_specified(self, api_client: TestClient):
+        value = "my_email"
+        request = {
+            "values": [value],
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 422 == response.status_code
+
+    def test_mask_nothing(self, api_client: TestClient):
+        request = {
+            "values": None,
+            "masking_strategy": {
+                "strategy": StringRewriteMaskingStrategy.name,
+                "configuration": {"rewrite_value": "MASKED"},
+            },
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 422 == response.status_code
+
     def test_mask_value_string_rewrite(self, api_client: TestClient):
         value = "check"
         rewrite_val = "mate"

--- a/tests/ops/api/v1/endpoints/test_masking_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_masking_endpoints.py
@@ -254,3 +254,18 @@ class TestMaskValues:
         assert response.json()["masked_values"] == [
             rewrite_val
         ], "Final value is rewrite value, because that was the last strategy specified"
+
+    def test_flexible_config(self, api_client: TestClient):
+        """Test that this request is allowed.  Allow the configuration to be
+        very flexible so different configuration requirements by many masking strategies are supported"""
+        value = "my_email"
+        request = {
+            "values": [value],
+            "masking_strategy": {
+                "strategy": NullMaskingStrategy.name,
+                "configuration": {"test_val": {"test": [["test"]]}},
+            },
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 200 == response.status_code


### PR DESCRIPTION
# Purpose

Allow multiple masking strategies to be specified when using fides as a masking engine.  

# Changes
- We could already specify a single masking strategy.  Add in a backwards compatible way so you can specify a single strategy or a list of strategies to the same field.  If multiple strategies are supplied, they are executed in order.
- Allow specifying the config for the masking strategy to be much more flexible to accommodate the needs of new masking strategies

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [x] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [x] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes https://github.com/ethyca/fidesops-plus/issues/74
 
