### PR TITLE
Add deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The types of changes are:
 * `Security` in case of vulnerabilities.
 
 ## [Unreleased](https://github.com/ethyca/fidesops/compare/1.8.1...main)
+### Added
+- Add deprecation warning [#1429](https://github.com/ethyca/fidesops/pull/1429)
 ### Changed
 * Fix redis `db_index` config issue [#1427](https://github.com/ethyca/fidesops/pull/1427)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Meet Fidesops: Privacy as Code for DSAR Orchestration
+# Deprecation Notice
+Fidesops is deprecated now. The codebase has been merged in into [Fides](https://github.com/ethyca/fides). 
+Visit the Fides [Documentation](https://ethyca.github.io/fides) to learn more.
+
+## Meet Fidesops: Privacy as Code for DSAR Orchestration
 
 _A part of the [greater Fides ecosystem](https://github.com/ethyca/fides)._
 

--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -236,8 +236,8 @@ if config.admin_ui.enabled:
 def start_webserver() -> None:
     """Run any pending DB migrations and start the webserver."""
     logger.warning(
-        "Fidesops has been deprecated. The codebase has merged into the Fides repo. Located at "
-        "https://github.com/ethyca/fides"
+        "Fidesops has been deprecated. The codebase has merged into the Fides repo. Fides is located at "
+        "https://github.com/ethyca/fides. The documentation is located at https://ethyca.github.io/fides."
     )
     logger.info("****************fidesops****************")
 

--- a/src/fidesops/main.py
+++ b/src/fidesops/main.py
@@ -235,6 +235,10 @@ if config.admin_ui.enabled:
 
 def start_webserver() -> None:
     """Run any pending DB migrations and start the webserver."""
+    logger.warning(
+        "Fidesops has been deprecated. The codebase has merged into the Fides repo. Located at "
+        "https://github.com/ethyca/fides"
+    )
     logger.info("****************fidesops****************")
 
     if logger.getEffectiveLevel() == logging.DEBUG:


### PR DESCRIPTION
# Purpose
Add a deprecation warning to let users know that the Fidesops repo is no longer being developed and lets them know where to go instead. Currently it only logs the warning on startup but the warning could logged more frequent if desired.


![Screen Shot 2022-10-17 at 12 31 15](https://user-images.githubusercontent.com/17103888/196234237-88b5863f-5af9-4215-8b25-0dc25434e795.png)

# Changes
- Add deprecation warning

# Checklist
- [x] Update [`CHANGELOG.md`](https://github.com/ethyca/fidesops/blob/main/CHANGELOG.md) file
  - [x] Merge in main so the most recent `CHANGELOG.md` file is being appended to
  - [x] Add description within the `Unreleased` section in an appropriate category. Add a new category from the list at the top of the file if the needed one isn't already there.
  - [x] Add a link to this PR at the end of the description with the PR number as the text. example: [#1](https://github.com/ethyca/fidesops/pull/1)
- [ ] Applicable documentation updated (guides, quickstart, postman collections, tutorial, fidesdemo, [database diagram](https://github.com/ethyca/fidesops/blob/main/docs/fidesops/docs/development/update_erd_diagram.md).
- If docs updated (select one):
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
- [ ] Good unit test/integration test coverage
- [ ] This PR contains a DB migration. If checked, the reviewer should confirm with the author that the [down_revision correctly references the previous migration](https://ethyca.github.io/fidesops/development/contributing_details/#alembic-migrations) before merging
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1422 
 
